### PR TITLE
refactor(shared-log): unify the sync module (stage 4)

### DIFF
--- a/packages/programs/data/shared-log/src/sync/dispatch-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/sync/dispatch-lifecycle.ts
@@ -1,0 +1,230 @@
+// Shared dispatch-lifecycle registry for the sync module (stage-4 sync
+// unification). The simple and rateless synchronizers used to carry
+// near-verbatim copies of the capture/abort/finish/dispose/isActive
+// lifecycle machinery; this registry hosts the shared mechanics and keeps
+// the two deliberate behavioral deltas as injected strategies:
+//
+// - target activity: the simple synchronizer compares the target's dispatch
+//   EPOCH identity, the rateless synchronizer checks SET MEMBERSHIP of the
+//   target lifecycle in the active-target registry. The strategy is always
+//   injected (`isTargetCurrent`), never defaulted.
+// - retention: disposal is deferred while `hasRetainedWork` is true — a
+//   retained-work counter for the simple synchronizer, a per-target
+//   retainedByProcess/responseLeases scan for the rateless one.
+//
+// Lifecycle objects are constructed by the callers (they carry
+// caller-specific fields such as epochs, batches and retained-work
+// counters); the registry owns the per-target active sets, the listener
+// add/remove pairing and the dispose gating.
+
+export interface DispatchTargetLifecycleBase<LC> {
+	lifecycle: LC;
+	target: string;
+	controller: AbortController;
+}
+
+export interface DispatchLifecycleBase<TL> {
+	ownershipLifecycleController: AbortController;
+	callerSignal?: AbortSignal;
+	controller: AbortController;
+	targets: Map<string, TL>;
+	onOwnerOrCallerAbort: () => void;
+	dispatchFinished: boolean;
+	disposed: boolean;
+}
+
+export type DispatchLifecycleRegistryDeps<
+	LC extends DispatchLifecycleBase<TL>,
+	TL extends DispatchTargetLifecycleBase<LC>,
+> = {
+	isClosed: () => boolean;
+	currentOwnershipLifecycleController: () => AbortController;
+	// Retention hook: disposal is deferred while this is true.
+	hasRetainedWork: (lifecycle: LC) => boolean;
+	// Target-activity strategy (epoch identity vs set membership).
+	isTargetCurrent: (targetLifecycle: TL) => boolean;
+	// Side effects on target abort (the simple synchronizer removes the
+	// target's pending response batches here).
+	onTargetAborted?: (targetLifecycle: TL) => void;
+};
+
+export class DispatchLifecycleRegistry<
+	LC extends DispatchLifecycleBase<TL>,
+	TL extends DispatchTargetLifecycleBase<LC>,
+> {
+	readonly activeTargets: Map<string, Set<TL>> = new Map();
+
+	constructor(private readonly deps: DispatchLifecycleRegistryDeps<LC, TL>) {}
+
+	// Registers the caller-constructed lifecycle: creates the per-target
+	// lifecycles (the factory may skip a target or abort it right after
+	// registration via `onTargetRegistered`), pairs the owner/caller abort
+	// listeners and performs the initial staleness abort exactly like both
+	// former capture implementations.
+	register(
+		lifecycle: LC,
+		targets: string[],
+		createTargetLifecycle: (lifecycle: LC, target: string) => TL | undefined,
+		onTargetRegistered?: (targetLifecycle: TL) => void,
+	): void {
+		for (const target of [...new Set(targets)]) {
+			const targetLifecycle = createTargetLifecycle(lifecycle, target);
+			if (!targetLifecycle) {
+				continue;
+			}
+			lifecycle.targets.set(target, targetLifecycle);
+			let activeForTarget = this.activeTargets.get(target);
+			if (!activeForTarget) {
+				activeForTarget = new Set();
+				this.activeTargets.set(target, activeForTarget);
+			}
+			activeForTarget.add(targetLifecycle);
+			onTargetRegistered?.(targetLifecycle);
+		}
+
+		lifecycle.ownershipLifecycleController.signal.addEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+			{ once: true },
+		);
+		if (
+			lifecycle.callerSignal &&
+			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
+		) {
+			lifecycle.callerSignal.addEventListener(
+				"abort",
+				lifecycle.onOwnerOrCallerAbort,
+				{ once: true },
+			);
+		}
+		if (
+			this.deps.isClosed() ||
+			lifecycle.ownershipLifecycleController !==
+				this.deps.currentOwnershipLifecycleController() ||
+			lifecycle.ownershipLifecycleController.signal.aborted ||
+			lifecycle.callerSignal?.aborted
+		) {
+			lifecycle.onOwnerOrCallerAbort();
+		}
+	}
+
+	abortTarget(targetLifecycle: TL, reason?: unknown): void {
+		if (!targetLifecycle.controller.signal.aborted) {
+			targetLifecycle.controller.abort(reason);
+		}
+		this.deps.onTargetAborted?.(targetLifecycle);
+		this.maybeDispose(targetLifecycle.lifecycle);
+	}
+
+	abortLifecycle(lifecycle: LC, reason?: unknown): void {
+		if (!lifecycle.controller.signal.aborted) {
+			lifecycle.controller.abort(reason);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			this.abortTarget(targetLifecycle, reason);
+		}
+		this.maybeDispose(lifecycle);
+	}
+
+	finish(lifecycle: LC): void {
+		lifecycle.dispatchFinished = true;
+		this.maybeDispose(lifecycle);
+	}
+
+	maybeDispose(lifecycle: LC): void {
+		if (
+			lifecycle.disposed ||
+			!lifecycle.dispatchFinished ||
+			this.deps.hasRetainedWork(lifecycle)
+		) {
+			return;
+		}
+		lifecycle.disposed = true;
+		lifecycle.ownershipLifecycleController.signal.removeEventListener(
+			"abort",
+			lifecycle.onOwnerOrCallerAbort,
+		);
+		if (
+			lifecycle.callerSignal &&
+			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
+		) {
+			lifecycle.callerSignal.removeEventListener(
+				"abort",
+				lifecycle.onOwnerOrCallerAbort,
+			);
+		}
+		for (const targetLifecycle of lifecycle.targets.values()) {
+			const activeForTarget = this.activeTargets.get(targetLifecycle.target);
+			activeForTarget?.delete(targetLifecycle);
+			if (activeForTarget?.size === 0) {
+				this.activeTargets.delete(targetLifecycle.target);
+			}
+		}
+	}
+
+	isLifecycleActive(lifecycle: LC, target?: string): boolean {
+		if (
+			this.deps.isClosed() ||
+			lifecycle.disposed ||
+			lifecycle.ownershipLifecycleController !==
+				this.deps.currentOwnershipLifecycleController() ||
+			lifecycle.ownershipLifecycleController.signal.aborted ||
+			lifecycle.callerSignal?.aborted ||
+			lifecycle.controller.signal.aborted
+		) {
+			return false;
+		}
+		if (target === undefined) {
+			return true;
+		}
+		const targetLifecycle = lifecycle.targets.get(target);
+		return (
+			targetLifecycle !== undefined &&
+			!targetLifecycle.controller.signal.aborted &&
+			this.deps.isTargetCurrent(targetLifecycle)
+		);
+	}
+
+	getSignal(lifecycle: LC, target: string): AbortSignal {
+		return (
+			lifecycle.targets.get(target)?.controller.signal ??
+			lifecycle.controller.signal
+		);
+	}
+}
+
+// The shared ownership-generation identity check: a captured ownership
+// controller is current while the synchronizer is open, the controller is
+// still THE controller (identity, not just non-aborted) and it has not been
+// aborted.
+export const isOwnershipGenerationActive = (properties: {
+	closed: boolean;
+	ownershipLifecycleController: AbortController;
+	currentOwnershipLifecycleController: AbortController;
+}): boolean =>
+	!properties.closed &&
+	properties.ownershipLifecycleController ===
+		properties.currentOwnershipLifecycleController &&
+	!properties.ownershipLifecycleController.signal.aborted;
+
+// The shared tracked-session identity check (the pattern the host-side
+// instance lifecycle drained the index.ts fences into): a session is active
+// while nothing cancelled or aborted it, its ownership generation is still
+// current, and the session registry still maps its id to THIS session
+// object.
+export const isTrackedSessionActive = <TSession>(properties: {
+	closed: boolean;
+	cancelled: boolean;
+	sessionController: AbortController;
+	ownershipLifecycleController: AbortController;
+	currentOwnershipLifecycleController: AbortController;
+	session: TSession;
+	registered: TSession | undefined;
+}): boolean =>
+	!properties.closed &&
+	!properties.cancelled &&
+	!properties.sessionController.signal.aborted &&
+	!properties.ownershipLifecycleController.signal.aborted &&
+	properties.ownershipLifecycleController ===
+		properties.currentOwnershipLifecycleController &&
+	properties.registered === properties.session;

--- a/packages/programs/data/shared-log/src/sync/pending-sync-store.ts
+++ b/packages/programs/data/shared-log/src/sync/pending-sync-store.ts
@@ -1,0 +1,1096 @@
+import type { Cache } from "@peerbit/cache";
+import type { PublicSignKey } from "@peerbit/crypto";
+import type { SyncableKey } from "./index.js";
+
+// The keyed record store for pending simple-sync claims (stage-4 sync
+// unification). One record per retained key replaces the former lockstep
+// map family (claimants, claimant indexes, round-robin cursors and key
+// expiry nodes); the expiry heap holds the records themselves, unioned with
+// admission-reservation expiry nodes. The public queue maps survive as the
+// store's physical indexes — the SAME Map instances tests and integrations
+// have always seeded and observed — and directly seeded keys hydrate into
+// records on first access, exactly like the former defensive branches.
+//
+// Lifetimes: a record exists while its key is retained (one add path:
+// addPendingSyncClaim; unified removal: clearSyncProcessKey /
+// removePendingSyncClaim / TTL expiry / close). Admission reservations keep
+// their quota charged until their originating lookup settles — invalidation
+// (expiry/disconnect/close) deliberately does not return the quota early.
+
+// Late coordinate-to-hash cache fills are discovered incrementally. Keep this
+// independent of retained queue size so an empty or repeated request cannot
+// force an O(global pending keys) reverse-alias rebuild.
+const MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE = 128;
+export const QUEUED_SYNC_ALIAS_REFRESH_PENDING = Symbol(
+	"queued-sync-alias-refresh-pending",
+);
+// This is an absolute first-seen lifetime. Repeated claims and additional peers
+// deliberately do not slide the deadline.
+export const PENDING_SIMPLE_SYNC_KEY_TTL_MS = 60_000;
+
+export type PendingSyncAdmissionReservation = {
+	peer: string;
+	remaining: number;
+	active: boolean;
+	released: boolean;
+	expiresAt: number;
+	identities: Set<SyncableKey>;
+	retainedSettled: number;
+};
+
+export type PendingSyncRecord = {
+	kind: "key";
+	key: SyncableKey;
+	peers: PublicSignKey[];
+	claimants: Set<string>;
+	claimantIndexes: Map<string, number>;
+	rrCursor: number;
+	expiresAt: number;
+	heapIndex: number;
+};
+
+type PendingSyncAdmissionExpiryNode = {
+	kind: "admission";
+	reservation: PendingSyncAdmissionReservation;
+	expiresAt: number;
+	heapIndex: number;
+};
+
+type PendingSyncExpiryNode = PendingSyncRecord | PendingSyncAdmissionExpiryNode;
+
+export type PendingSyncStoreDeps = {
+	coordinateToHash: Cache<string>;
+	isDispatchEpochCurrent: (peer: string, epoch: unknown) => boolean;
+};
+
+export class PendingSyncStore {
+	// map of hash to public keys that we can ask for entries. The public
+	// legacy view instances: the same Maps the synchronizer has always
+	// exposed, kept as the store's physical indexes.
+	syncInFlightQueue: Map<SyncableKey, PublicSignKey[]>;
+	syncInFlightQueueInverted: Map<string, Set<SyncableKey>>;
+	syncInFlightQueueExpiresAt: Map<SyncableKey, number>;
+	records: Map<SyncableKey, PendingSyncRecord>;
+	pendingSyncExpiryHeap: PendingSyncExpiryNode[];
+	syncInFlightQueueExpiryTimer?: ReturnType<typeof setTimeout>;
+	pendingSyncAdmissionExpiryNodes: Map<
+		PendingSyncAdmissionReservation,
+		PendingSyncAdmissionExpiryNode
+	>;
+	syncInFlightQueuedCoordinates: Set<bigint>;
+	syncInFlightQueuedHashByCoordinate: Map<bigint, string>;
+	syncInFlightQueuedCoordinatesByHash: Map<string, Set<bigint>>;
+	syncInFlightQueuedCoordinateRefreshIterator?: IterableIterator<bigint>;
+	pendingSyncClaimCount: number;
+	pendingSyncAdmissionCount: number;
+	pendingSyncActiveAdmissionReservations: number;
+	pendingSyncAdmissionCountByPeer: Map<string, number>;
+	pendingSyncAdmissionIdentitiesByPeer: Map<string, Set<SyncableKey>>;
+	pendingSyncAdmissionReservations: Set<PendingSyncAdmissionReservation>;
+	pendingSyncAdmissionReservationsByPeer: Map<
+		string,
+		Set<PendingSyncAdmissionReservation>
+	>;
+	pendingSyncAdmissionReservationsByIdentity: Map<
+		SyncableKey,
+		Set<PendingSyncAdmissionReservation>
+	>;
+
+	// map of hash to public keys that we have asked for entries
+	syncInFlight: Map<string, Map<SyncableKey, { timestamp: number }>>;
+	syncInFlightTargetsByKey: Map<SyncableKey, Set<string>>;
+
+	constructor(private readonly deps: PendingSyncStoreDeps) {
+		this.syncInFlightQueue = new Map();
+		this.syncInFlightQueueInverted = new Map();
+		this.syncInFlightQueueExpiresAt = new Map();
+		this.records = new Map();
+		this.pendingSyncExpiryHeap = [];
+		this.pendingSyncAdmissionExpiryNodes = new Map();
+		this.syncInFlightQueuedCoordinates = new Set();
+		this.syncInFlightQueuedHashByCoordinate = new Map();
+		this.syncInFlightQueuedCoordinatesByHash = new Map();
+		this.pendingSyncClaimCount = 0;
+		this.pendingSyncAdmissionCount = 0;
+		this.pendingSyncActiveAdmissionReservations = 0;
+		this.pendingSyncAdmissionCountByPeer = new Map();
+		this.pendingSyncAdmissionIdentitiesByPeer = new Map();
+		this.pendingSyncAdmissionReservations = new Set();
+		this.pendingSyncAdmissionReservationsByPeer = new Map();
+		this.pendingSyncAdmissionReservationsByIdentity = new Map();
+		this.syncInFlight = new Map();
+		this.syncInFlightTargetsByKey = new Map();
+	}
+
+	// Defensive compatibility for callers/tests that seed the public queue
+	// maps directly. Internally every retained key gets its record at
+	// creation; a seeded key hydrates here (counting its claimants) and never
+	// enters the expiry heap, exactly like the former hydration branches.
+	private hydrateRecordFromQueue(
+		key: SyncableKey,
+		peers: PublicSignKey[],
+	): PendingSyncRecord {
+		const claimants = new Set(peers.map((peer) => peer.hashcode()));
+		const claimantIndexes = new Map<string, number>();
+		for (let index = 0; index < peers.length; index += 1) {
+			claimantIndexes.set(peers[index]!.hashcode(), index);
+		}
+		const record: PendingSyncRecord = {
+			kind: "key",
+			key,
+			peers,
+			claimants,
+			claimantIndexes,
+			rrCursor: 0,
+			expiresAt:
+				this.syncInFlightQueueExpiresAt.get(key) ?? Number.POSITIVE_INFINITY,
+			heapIndex: -1,
+		};
+		this.records.set(key, record);
+		this.pendingSyncClaimCount += claimants.size;
+		return record;
+	}
+
+	getPendingSyncKeyIdentity(key: SyncableKey): SyncableKey {
+		if (typeof key === "string") {
+			return key;
+		}
+		const hash = this.deps.coordinateToHash.get(key);
+		return hash ?? key;
+	}
+
+	private removeQueuedSyncCoordinateAlias(key: bigint): void {
+		this.syncInFlightQueuedCoordinates.delete(key);
+		if (this.syncInFlightQueuedCoordinates.size === 0) {
+			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+		}
+		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
+		this.syncInFlightQueuedHashByCoordinate.delete(key);
+		if (previousHash != null) {
+			const coordinates =
+				this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
+			coordinates?.delete(key);
+			if (coordinates?.size === 0) {
+				this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
+			}
+		}
+	}
+
+	private refreshQueuedSyncCoordinateAlias(key: bigint): void {
+		if (!this.syncInFlightQueue.has(key)) {
+			this.removeQueuedSyncCoordinateAlias(key);
+			return;
+		}
+		this.syncInFlightQueuedCoordinates.add(key);
+		const hash = this.deps.coordinateToHash.get(key) ?? undefined;
+		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
+		if (previousHash !== hash) {
+			if (previousHash != null) {
+				const coordinates =
+					this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
+				coordinates?.delete(key);
+				if (coordinates?.size === 0) {
+					this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
+				}
+			}
+			if (hash == null) {
+				this.syncInFlightQueuedHashByCoordinate.delete(key);
+			} else {
+				this.syncInFlightQueuedHashByCoordinate.set(key, hash);
+			}
+		}
+		if (hash != null) {
+			let coordinates = this.syncInFlightQueuedCoordinatesByHash.get(hash);
+			if (!coordinates) {
+				coordinates = new Set();
+				this.syncInFlightQueuedCoordinatesByHash.set(hash, coordinates);
+			}
+			coordinates.add(key);
+			this.reconcileQueuedSyncCoordinateAlias(key, hash);
+		}
+	}
+
+	private reconcileQueuedSyncCoordinateAlias(
+		coordinate: bigint,
+		hash: string,
+	): void {
+		const now = Date.now();
+		const coordinateExpiresAt = this.syncInFlightQueueExpiresAt.get(coordinate);
+		if (coordinateExpiresAt != null && coordinateExpiresAt <= now) {
+			this.clearSyncProcessKey(coordinate);
+			return;
+		}
+		const hashExpiresAt = this.syncInFlightQueueExpiresAt.get(hash);
+		if (hashExpiresAt != null && hashExpiresAt <= now) {
+			this.clearSyncProcessKey(hash);
+			return;
+		}
+		const hashClaimants = this.syncInFlightQueue.get(hash);
+		if (!hashClaimants || !this.syncInFlightQueue.has(coordinate)) {
+			return;
+		}
+		const expiresAt = Math.min(
+			this.syncInFlightQueueExpiresAt.get(coordinate) ?? Infinity,
+			this.syncInFlightQueueExpiresAt.get(hash) ?? Infinity,
+		);
+		for (const claimant of [...hashClaimants]) {
+			this.addPendingSyncClaim(coordinate, claimant, expiresAt);
+		}
+		if (Number.isFinite(expiresAt)) {
+			this.movePendingSyncKeyExpiryEarlier(coordinate, expiresAt);
+		}
+		for (const target of [...(this.syncInFlightTargetsByKey.get(hash) ?? [])]) {
+			const state = this.syncInFlight.get(target)?.get(hash);
+			if (state) {
+				this.setSyncInFlightTargetKey(target, coordinate, state.timestamp);
+			}
+		}
+		this.clearSyncProcessKey(hash);
+	}
+
+	refreshQueuedSyncCoordinateAliases(): void {
+		if (
+			this.syncInFlightQueuedCoordinates.size === 0 &&
+			this.records.size < this.syncInFlightQueue.size
+		) {
+			// Defensive compatibility for callers/tests that seed the public queue
+			// directly. Keep hydration bounded; internal writes register coordinates
+			// when the key is first admitted.
+			let inspected = 0;
+			for (const key of this.syncInFlightQueue.keys()) {
+				if (typeof key === "bigint") {
+					this.syncInFlightQueuedCoordinates.add(key);
+				}
+				inspected += 1;
+				if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
+					break;
+				}
+			}
+		}
+		if (this.syncInFlightQueuedCoordinates.size === 0) {
+			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+			return;
+		}
+		this.syncInFlightQueuedCoordinateRefreshIterator ??=
+			this.syncInFlightQueuedCoordinates.values();
+		for (
+			let refreshed = 0;
+			refreshed < MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE;
+			refreshed += 1
+		) {
+			const next = this.syncInFlightQueuedCoordinateRefreshIterator.next();
+			if (next.done) {
+				this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+				break;
+			}
+			this.refreshQueuedSyncCoordinateAlias(next.value);
+		}
+	}
+
+	getQueuedSyncKeyForAdmission(
+		key: SyncableKey,
+	): SyncableKey | typeof QUEUED_SYNC_ALIAS_REFRESH_PENDING | undefined {
+		const getValidQueuedKey = (
+			candidate: SyncableKey,
+		): SyncableKey | undefined => {
+			if (!this.syncInFlightQueue.has(candidate)) {
+				return undefined;
+			}
+			const expiresAt = this.syncInFlightQueueExpiresAt.get(candidate);
+			if (expiresAt != null && expiresAt <= Date.now()) {
+				this.clearSyncProcessKey(candidate);
+				return undefined;
+			}
+			return candidate;
+		};
+		if (getValidQueuedKey(key) != null) {
+			if (typeof key === "bigint") {
+				this.refreshQueuedSyncCoordinateAlias(key);
+				return getValidQueuedKey(key);
+			}
+			return key;
+		}
+		if (typeof key === "string") {
+			const aliases = this.syncInFlightQueuedCoordinatesByHash.get(key);
+			if (aliases) {
+				let inspected = 0;
+				for (const alias of aliases) {
+					if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
+						return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
+					}
+					inspected += 1;
+					this.refreshQueuedSyncCoordinateAlias(alias);
+					if (
+						this.syncInFlightQueuedCoordinatesByHash.get(key)?.has(alias) ===
+						true
+					) {
+						const validAlias = getValidQueuedKey(alias);
+						if (validAlias != null) {
+							return validAlias;
+						}
+					}
+				}
+				if (
+					(this.syncInFlightQueuedCoordinatesByHash.get(key)?.size ?? 0) > 0
+				) {
+					return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
+				}
+			}
+			return undefined;
+		}
+		const hash = this.deps.coordinateToHash.get(key);
+		return hash != null ? getValidQueuedKey(hash) : undefined;
+	}
+
+	addPendingSyncClaim(
+		key: SyncableKey,
+		from: PublicSignKey,
+		expiresAt?: number,
+	): boolean {
+		const fromHash = from.hashcode();
+		let peers = this.syncInFlightQueue.get(key);
+		let record = this.records.get(key);
+		if (!peers) {
+			peers = [];
+			this.syncInFlightQueue.set(key, peers);
+			const deadline = expiresAt ?? Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS;
+			this.syncInFlightQueueExpiresAt.set(key, deadline);
+			record = {
+				kind: "key",
+				key,
+				peers,
+				claimants: new Set(),
+				claimantIndexes: new Map(),
+				rrCursor: 0,
+				expiresAt: deadline,
+				heapIndex: -1,
+			};
+			this.records.set(key, record);
+			this.pushPendingSyncExpiry(record);
+			if (typeof key === "bigint") {
+				this.refreshQueuedSyncCoordinateAlias(key);
+			}
+		} else if (!record) {
+			record = this.hydrateRecordFromQueue(key, peers);
+		}
+		if (record.claimants.has(fromHash)) {
+			return false;
+		}
+
+		record.claimantIndexes.set(fromHash, peers.length);
+		peers.push(from);
+		record.claimants.add(fromHash);
+		let inverted = this.syncInFlightQueueInverted.get(fromHash);
+		if (!inverted) {
+			inverted = new Set();
+			this.syncInFlightQueueInverted.set(fromHash, inverted);
+		}
+		inverted.add(key);
+		this.pendingSyncClaimCount += 1;
+		this.schedulePendingSyncKeyExpiry();
+		return true;
+	}
+
+	hasPendingSyncClaim(key: SyncableKey, peer: string): boolean {
+		const record = this.records.get(key);
+		if (record) {
+			return record.claimants.has(peer);
+		}
+		const peers = this.syncInFlightQueue.get(key);
+		if (!peers) {
+			return false;
+		}
+		return this.hydrateRecordFromQueue(key, peers).claimants.has(peer);
+	}
+
+	filterDispatchablePendingSyncClaims(
+		keys: SyncableKey[],
+		peer: string,
+		epoch: unknown,
+	): SyncableKey[] {
+		if (!this.deps.isDispatchEpochCurrent(peer, epoch)) {
+			return [];
+		}
+		const now = Date.now();
+		const dispatchable: SyncableKey[] = [];
+		for (const key of keys) {
+			const expiresAt = this.syncInFlightQueueExpiresAt.get(key);
+			if (expiresAt != null && expiresAt <= now) {
+				this.clearSyncProcessKey(key);
+				continue;
+			}
+			if (
+				this.syncInFlightQueue.has(key) &&
+				this.hasPendingSyncClaim(key, peer)
+			) {
+				dispatchable.push(key);
+			}
+		}
+		return dispatchable;
+	}
+
+	getRoundRobinCursor(key: SyncableKey): number {
+		return this.records.get(key)?.rrCursor ?? 0;
+	}
+
+	setRoundRobinCursor(key: SyncableKey, cursor: number): void {
+		const peers = this.syncInFlightQueue.get(key);
+		if (!peers) {
+			return;
+		}
+		const record =
+			this.records.get(key) ?? this.hydrateRecordFromQueue(key, peers);
+		record.rrCursor = cursor;
+	}
+
+	reservePendingSyncAdmission(
+		peer: string,
+		identities: SyncableKey[],
+	): PendingSyncAdmissionReservation | undefined {
+		const count = identities.length;
+		if (count <= 0) {
+			return undefined;
+		}
+		const reservation: PendingSyncAdmissionReservation = {
+			peer,
+			remaining: count,
+			active: true,
+			released: false,
+			expiresAt: Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+			identities: new Set(identities),
+			retainedSettled: 0,
+		};
+		this.pendingSyncAdmissionReservations.add(reservation);
+		let peerReservations =
+			this.pendingSyncAdmissionReservationsByPeer.get(peer);
+		if (!peerReservations) {
+			peerReservations = new Set();
+			this.pendingSyncAdmissionReservationsByPeer.set(peer, peerReservations);
+		}
+		peerReservations.add(reservation);
+		this.pendingSyncActiveAdmissionReservations += 1;
+		this.pendingSyncAdmissionCount += count;
+		this.pendingSyncAdmissionCountByPeer.set(
+			peer,
+			(this.pendingSyncAdmissionCountByPeer.get(peer) ?? 0) + count,
+		);
+		let reservedIdentities =
+			this.pendingSyncAdmissionIdentitiesByPeer.get(peer);
+		if (!reservedIdentities) {
+			reservedIdentities = new Set();
+			this.pendingSyncAdmissionIdentitiesByPeer.set(peer, reservedIdentities);
+		}
+		for (const identity of identities) {
+			reservedIdentities.add(identity);
+			let reservationsForIdentity =
+				this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+			if (!reservationsForIdentity) {
+				reservationsForIdentity = new Set();
+				this.pendingSyncAdmissionReservationsByIdentity.set(
+					identity,
+					reservationsForIdentity,
+				);
+			}
+			reservationsForIdentity.add(reservation);
+		}
+		const expiryNode: PendingSyncAdmissionExpiryNode = {
+			kind: "admission",
+			reservation,
+			expiresAt: reservation.expiresAt,
+			heapIndex: -1,
+		};
+		this.pendingSyncAdmissionExpiryNodes.set(reservation, expiryNode);
+		this.pushPendingSyncExpiry(expiryNode);
+		this.schedulePendingSyncKeyExpiry();
+		return reservation;
+	}
+
+	private removePendingSyncAdmissionIdentity(
+		reservation: PendingSyncAdmissionReservation,
+		identity: SyncableKey,
+		options?: { retainQuota?: boolean },
+	): boolean {
+		if (!reservation.identities.delete(identity)) {
+			return false;
+		}
+		if (options?.retainQuota === true) {
+			reservation.retainedSettled += 1;
+		} else {
+			reservation.remaining -= 1;
+			this.pendingSyncAdmissionCount -= 1;
+			const peerCount =
+				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) - 1;
+			if (peerCount === 0) {
+				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
+			} else {
+				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
+			}
+		}
+		const reservedIdentities = this.pendingSyncAdmissionIdentitiesByPeer.get(
+			reservation.peer,
+		);
+		reservedIdentities?.delete(identity);
+		if (reservedIdentities?.size === 0) {
+			this.pendingSyncAdmissionIdentitiesByPeer.delete(reservation.peer);
+		}
+		const reservationsForIdentity =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		reservationsForIdentity?.delete(reservation);
+		if (reservationsForIdentity?.size === 0) {
+			this.pendingSyncAdmissionReservationsByIdentity.delete(identity);
+		}
+		return true;
+	}
+
+	clearPendingSyncAdmissionIdentity(identity: SyncableKey): void {
+		const reservations =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		if (!reservations) {
+			return;
+		}
+		for (const reservation of [...reservations]) {
+			this.removePendingSyncAdmissionIdentity(reservation, identity, {
+				retainQuota: true,
+			});
+		}
+	}
+
+	consumePendingSyncAdmission(
+		reservation: PendingSyncAdmissionReservation,
+		identity: SyncableKey,
+	): "consumed" | "settled" | "invalid" {
+		if (!reservation.active || reservation.expiresAt <= Date.now()) {
+			if (reservation.expiresAt <= Date.now()) {
+				this.invalidatePendingSyncAdmission(reservation);
+			}
+			return "invalid";
+		}
+		if (!reservation.identities.has(identity)) {
+			return "settled";
+		}
+		this.removePendingSyncAdmissionIdentity(reservation, identity);
+		if (reservation.remaining === 0) {
+			this.removePendingSyncAdmissionExpiry(reservation);
+			reservation.active = false;
+			reservation.released = true;
+			this.pendingSyncActiveAdmissionReservations -= 1;
+			this.pendingSyncAdmissionReservations.delete(reservation);
+			const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
+				reservation.peer,
+			);
+			peerReservations?.delete(reservation);
+			if (peerReservations?.size === 0) {
+				this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
+			}
+			this.clearPendingSyncExpiryTimerIfIdle();
+		}
+		return "consumed";
+	}
+
+	transferPendingSyncAdmissionIdentity(
+		peer: string,
+		identity: SyncableKey,
+	): number | undefined {
+		const reservations =
+			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
+		if (!reservations) {
+			return undefined;
+		}
+		for (const reservation of reservations) {
+			if (
+				reservation.peer !== peer ||
+				reservation.released ||
+				reservation.expiresAt <= Date.now() ||
+				!this.removePendingSyncAdmissionIdentity(reservation, identity, {
+					retainQuota: true,
+				})
+			) {
+				continue;
+			}
+			// The original resolver may be non-abortable and still retains its input
+			// arrays. Keep that reservation charged until its queueSync finally
+			// settles; the queued claim is counted separately and can disappear
+			// without returning the resolver's quota early.
+			return reservation.expiresAt;
+		}
+		return undefined;
+	}
+
+	invalidatePendingSyncAdmission(
+		reservation?: PendingSyncAdmissionReservation,
+	): void {
+		if (!reservation || reservation.released || !reservation.active) {
+			return;
+		}
+		// Expiry/disconnect invalidates late lookup results, but it must not return
+		// the quota slot while the underlying storage/index work is still alive.
+		// Those lookups are not generally abortable; only queueSync's finally block
+		// may release their active-work accounting.
+		this.removePendingSyncAdmissionExpiry(reservation);
+		reservation.active = false;
+		this.pendingSyncActiveAdmissionReservations -= 1;
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	releasePendingSyncAdmission(
+		reservation?: PendingSyncAdmissionReservation,
+	): void {
+		if (!reservation || reservation.released) {
+			return;
+		}
+		this.removePendingSyncAdmissionExpiry(reservation);
+		for (const identity of [...reservation.identities]) {
+			this.removePendingSyncAdmissionIdentity(reservation, identity);
+		}
+		if (reservation.retainedSettled > 0) {
+			const retainedSettled = reservation.retainedSettled;
+			reservation.retainedSettled = 0;
+			reservation.remaining -= retainedSettled;
+			this.pendingSyncAdmissionCount -= retainedSettled;
+			const peerCount =
+				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) -
+				retainedSettled;
+			if (peerCount === 0) {
+				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
+			} else {
+				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
+			}
+		}
+		if (reservation.active) {
+			this.pendingSyncActiveAdmissionReservations -= 1;
+		}
+		reservation.active = false;
+		reservation.released = true;
+		this.pendingSyncAdmissionReservations.delete(reservation);
+		const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
+			reservation.peer,
+		);
+		peerReservations?.delete(reservation);
+		if (peerReservations?.size === 0) {
+			this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
+		}
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	clearPendingSyncAdmissions(peer?: string): void {
+		const reservations =
+			peer == null
+				? this.pendingSyncAdmissionReservations
+				: this.pendingSyncAdmissionReservationsByPeer.get(peer);
+		if (!reservations) {
+			return;
+		}
+		for (const reservation of [...reservations]) {
+			this.invalidatePendingSyncAdmission(reservation);
+		}
+	}
+
+	private swapPendingSyncExpiry(left: number, right: number): void {
+		const leftNode = this.pendingSyncExpiryHeap[left]!;
+		const rightNode = this.pendingSyncExpiryHeap[right]!;
+		this.pendingSyncExpiryHeap[left] = rightNode;
+		this.pendingSyncExpiryHeap[right] = leftNode;
+		rightNode.heapIndex = left;
+		leftNode.heapIndex = right;
+	}
+
+	private pushPendingSyncExpiry(node: PendingSyncExpiryNode): void {
+		node.heapIndex = this.pendingSyncExpiryHeap.length;
+		this.pendingSyncExpiryHeap.push(node);
+		let index = node.heapIndex;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (
+				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
+				this.pendingSyncExpiryHeap[index]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingSyncExpiry(parent, index);
+			index = parent;
+		}
+	}
+
+	private removePendingSyncExpiry(node: PendingSyncExpiryNode): void {
+		const index = node.heapIndex;
+		if (
+			index < 0 ||
+			index >= this.pendingSyncExpiryHeap.length ||
+			this.pendingSyncExpiryHeap[index] !== node
+		) {
+			return;
+		}
+		const last = this.pendingSyncExpiryHeap.pop()!;
+		node.heapIndex = -1;
+		if (index >= this.pendingSyncExpiryHeap.length) {
+			return;
+		}
+		this.pendingSyncExpiryHeap[index] = last;
+		last.heapIndex = index;
+
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (
+				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
+				this.pendingSyncExpiryHeap[current]!.expiresAt
+			) {
+				break;
+			}
+			this.swapPendingSyncExpiry(parent, current);
+			current = parent;
+		}
+		for (;;) {
+			const left = current * 2 + 1;
+			const right = left + 1;
+			let smallest = current;
+			if (
+				left < this.pendingSyncExpiryHeap.length &&
+				this.pendingSyncExpiryHeap[left]!.expiresAt <
+					this.pendingSyncExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = left;
+			}
+			if (
+				right < this.pendingSyncExpiryHeap.length &&
+				this.pendingSyncExpiryHeap[right]!.expiresAt <
+					this.pendingSyncExpiryHeap[smallest]!.expiresAt
+			) {
+				smallest = right;
+			}
+			if (smallest === current) {
+				break;
+			}
+			this.swapPendingSyncExpiry(current, smallest);
+			current = smallest;
+		}
+	}
+
+	movePendingSyncKeyExpiryEarlier(key: SyncableKey, expiresAt: number): void {
+		const current = this.syncInFlightQueueExpiresAt.get(key);
+		if (current == null || current <= expiresAt) {
+			return;
+		}
+		this.syncInFlightQueueExpiresAt.set(key, expiresAt);
+		const record = this.records.get(key);
+		if (!record) {
+			return;
+		}
+		this.removePendingSyncExpiry(record);
+		record.expiresAt = expiresAt;
+		this.pushPendingSyncExpiry(record);
+		this.schedulePendingSyncKeyExpiry();
+	}
+
+	private removePendingSyncAdmissionExpiry(
+		reservation: PendingSyncAdmissionReservation,
+	): void {
+		const node = this.pendingSyncAdmissionExpiryNodes.get(reservation);
+		if (!node) {
+			return;
+		}
+		this.pendingSyncAdmissionExpiryNodes.delete(reservation);
+		this.removePendingSyncExpiry(node);
+	}
+
+	expirePendingSyncKeys(now = Date.now()): void {
+		for (;;) {
+			const node = this.pendingSyncExpiryHeap[0];
+			if (!node || node.expiresAt > now) {
+				break;
+			}
+			this.removePendingSyncExpiry(node);
+			if (node.kind === "key") {
+				if (this.records.get(node.key) !== node) {
+					continue;
+				}
+				this.clearSyncProcessKey(node.key);
+			} else {
+				if (
+					this.pendingSyncAdmissionExpiryNodes.get(node.reservation) !== node
+				) {
+					continue;
+				}
+				this.pendingSyncAdmissionExpiryNodes.delete(node.reservation);
+				this.invalidatePendingSyncAdmission(node.reservation);
+			}
+		}
+	}
+
+	clearPendingSyncExpiryTimerIfIdle(): void {
+		if (
+			this.pendingSyncExpiryHeap.length === 0 &&
+			this.syncInFlightQueueExpiryTimer != null
+		) {
+			clearTimeout(this.syncInFlightQueueExpiryTimer);
+			this.syncInFlightQueueExpiryTimer = undefined;
+		}
+	}
+
+	private schedulePendingSyncKeyExpiry(): void {
+		if (
+			this.syncInFlightQueueExpiryTimer != null ||
+			this.pendingSyncExpiryHeap.length === 0
+		) {
+			return;
+		}
+		const expiresAt = this.pendingSyncExpiryHeap[0]!.expiresAt;
+		this.syncInFlightQueueExpiryTimer = setTimeout(
+			() => {
+				this.syncInFlightQueueExpiryTimer = undefined;
+				this.expirePendingSyncKeys();
+				this.schedulePendingSyncKeyExpiry();
+			},
+			Math.max(0, expiresAt - Date.now()),
+		);
+		this.syncInFlightQueueExpiryTimer.unref?.();
+	}
+
+	hasSyncProcessState(): boolean {
+		return (
+			this.syncInFlightQueue.size > 0 ||
+			this.syncInFlightQueueInverted.size > 0 ||
+			this.pendingSyncAdmissionCount > 0 ||
+			this.syncInFlight.size > 0
+		);
+	}
+
+	clearSyncProcessKey(key: SyncableKey): void {
+		const inflight = this.syncInFlightQueue.get(key);
+		const record = this.records.get(key);
+		if (inflight) {
+			for (const peer of inflight) {
+				const map = this.syncInFlightQueueInverted.get(peer.hashcode());
+				if (map) {
+					map.delete(key);
+					if (map.size === 0) {
+						this.syncInFlightQueueInverted.delete(peer.hashcode());
+					}
+				}
+			}
+
+			this.pendingSyncClaimCount = Math.max(
+				0,
+				this.pendingSyncClaimCount -
+					(record?.claimants.size ?? inflight.length),
+			);
+			this.syncInFlightQueue.delete(key);
+		}
+		if (record) {
+			this.records.delete(key);
+			this.removePendingSyncExpiry(record);
+		}
+		if (typeof key === "bigint") {
+			this.removeQueuedSyncCoordinateAlias(key);
+		}
+		this.syncInFlightQueueExpiresAt.delete(key);
+		this.clearPendingSyncExpiryTimerIfIdle();
+
+		this.clearSyncInFlightKey(key);
+	}
+
+	removePendingSyncClaim(key: SyncableKey, peer: string): void {
+		const inflight = this.syncInFlightQueue.get(key);
+		if (!inflight) {
+			return;
+		}
+		const record =
+			this.records.get(key) ?? this.hydrateRecordFromQueue(key, inflight);
+		const index = record.claimantIndexes.get(peer);
+		if (index == null) {
+			return;
+		}
+
+		const lastIndex = inflight.length - 1;
+		if (index !== lastIndex) {
+			const lastClaimant = inflight[lastIndex]!;
+			const lastClaimantHash = lastClaimant.hashcode();
+			inflight[index] = lastClaimant;
+			record.claimantIndexes.set(lastClaimantHash, index);
+		}
+		inflight.pop();
+		record.claimantIndexes.delete(peer);
+		record.claimants.delete(peer);
+		this.pendingSyncClaimCount = Math.max(0, this.pendingSyncClaimCount - 1);
+		const inverted = this.syncInFlightQueueInverted.get(peer);
+		inverted?.delete(key);
+		if (inverted?.size === 0) {
+			this.syncInFlightQueueInverted.delete(peer);
+		}
+		if (inflight.length > 0) {
+			const cursor = record.rrCursor;
+			record.rrCursor =
+				cursor === lastIndex
+					? index % inflight.length
+					: cursor % inflight.length;
+			return;
+		}
+
+		this.syncInFlightQueue.delete(key);
+		this.records.delete(key);
+		if (typeof key === "bigint") {
+			this.removeQueuedSyncCoordinateAlias(key);
+		}
+		this.removePendingSyncExpiry(record);
+		this.syncInFlightQueueExpiresAt.delete(key);
+		this.clearSyncInFlightKey(key);
+		this.clearPendingSyncExpiryTimerIfIdle();
+	}
+
+	removeClaimsForPeer(publicKeyHash: string): void {
+		const map = this.syncInFlightQueueInverted.get(publicKeyHash);
+		if (map) {
+			for (const hash of [...map]) {
+				this.removePendingSyncClaim(hash, publicKeyHash);
+			}
+			this.syncInFlightQueueInverted.delete(publicKeyHash);
+		}
+	}
+
+	removeSyncInFlightTargetKey(peer: string, key: SyncableKey): void {
+		const map = this.syncInFlight.get(peer);
+		if (!map?.delete(key)) {
+			return;
+		}
+		if (map.size === 0) {
+			this.syncInFlight.delete(peer);
+		}
+		const targets = this.syncInFlightTargetsByKey.get(key);
+		targets?.delete(peer);
+		if (targets?.size === 0) {
+			this.syncInFlightTargetsByKey.delete(key);
+		}
+	}
+
+	setSyncInFlightTargetKey(
+		peer: string,
+		key: SyncableKey,
+		timestamp: number,
+	): void {
+		let map = this.syncInFlight.get(peer);
+		if (!map) {
+			map = new Map();
+			this.syncInFlight.set(peer, map);
+		}
+		const existing = map.get(key);
+		if (!existing || existing.timestamp < timestamp) {
+			map.set(key, { timestamp });
+		}
+		let targets = this.syncInFlightTargetsByKey.get(key);
+		if (!targets) {
+			targets = new Set();
+			this.syncInFlightTargetsByKey.set(key, targets);
+		}
+		targets.add(peer);
+	}
+
+	clearSyncInFlightTarget(peer: string): void {
+		const map = this.syncInFlight.get(peer);
+		if (!map) {
+			return;
+		}
+		for (const key of map.keys()) {
+			const targets = this.syncInFlightTargetsByKey.get(key);
+			targets?.delete(peer);
+			if (targets?.size === 0) {
+				this.syncInFlightTargetsByKey.delete(key);
+			}
+		}
+		this.syncInFlight.delete(peer);
+	}
+
+	private clearSyncInFlightKey(key: SyncableKey): void {
+		const targets = this.syncInFlightTargetsByKey.get(key);
+		if (!targets) {
+			// Defensive compatibility for tests or integrations that seed the public
+			// syncInFlight map directly. Internal writes always populate the index.
+			for (const [peer, map] of this.syncInFlight) {
+				if (map.has(key)) {
+					this.removeSyncInFlightTargetKey(peer, key);
+				}
+			}
+			return;
+		}
+		for (const peer of [...targets]) {
+			this.removeSyncInFlightTargetKey(peer, key);
+		}
+	}
+
+	private forEachKnownAlias(
+		hash: string,
+		callback: (key: SyncableKey) => void,
+	): void {
+		callback(hash);
+		for (const coordinate of [
+			...(this.syncInFlightQueuedCoordinatesByHash.get(hash) ?? []),
+		]) {
+			callback(coordinate);
+		}
+	}
+
+	clearSyncInFlightForPeer(publicKeyHash: string, hash: string): void {
+		const map = this.syncInFlight.get(publicKeyHash);
+		if (!map) {
+			return;
+		}
+		this.refreshQueuedSyncCoordinateAliases();
+		this.forEachKnownAlias(hash, (key) =>
+			this.removeSyncInFlightTargetKey(publicKeyHash, key),
+		);
+	}
+
+	clearSyncInFlightForPeerHashes(
+		publicKeyHash: string,
+		hashes: string[],
+	): void {
+		const map = this.syncInFlight.get(publicKeyHash);
+		if (!map || hashes.length === 0) {
+			return;
+		}
+		this.refreshQueuedSyncCoordinateAliases();
+		for (const hash of hashes) {
+			this.forEachKnownAlias(hash, (key) =>
+				this.removeSyncInFlightTargetKey(publicKeyHash, key),
+			);
+		}
+	}
+
+	clearSyncProcess(hash: string): void {
+		this.refreshQueuedSyncCoordinateAliases();
+		this.forEachKnownAlias(hash, (key) => this.clearSyncProcessKey(key));
+	}
+
+	clearSyncProcesses(hashes: string[]): void {
+		if (hashes.length === 0) {
+			return;
+		}
+		this.refreshQueuedSyncCoordinateAliases();
+		const keys = new Set<SyncableKey>();
+		for (const hash of hashes) {
+			this.forEachKnownAlias(hash, (key) => keys.add(key));
+		}
+		for (const key of keys) {
+			this.clearSyncProcessKey(key);
+		}
+	}
+
+	clearForClose(): void {
+		this.syncInFlightQueue.clear();
+		this.syncInFlightQueueInverted.clear();
+		this.syncInFlightQueueExpiresAt.clear();
+		this.pendingSyncExpiryHeap.length = 0;
+		this.records.clear();
+		this.pendingSyncAdmissionExpiryNodes.clear();
+		this.syncInFlightQueuedCoordinates.clear();
+		this.syncInFlightQueuedHashByCoordinate.clear();
+		this.syncInFlightQueuedCoordinatesByHash.clear();
+		this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
+		this.pendingSyncClaimCount = 0;
+		if (this.syncInFlightQueueExpiryTimer != null) {
+			clearTimeout(this.syncInFlightQueueExpiryTimer);
+			this.syncInFlightQueueExpiryTimer = undefined;
+		}
+		this.syncInFlight.clear();
+		this.syncInFlightTargetsByKey.clear();
+	}
+}

--- a/packages/programs/data/shared-log/src/sync/pending-sync-store.ts
+++ b/packages/programs/data/shared-log/src/sync/pending-sync-store.ts
@@ -1028,17 +1028,6 @@ export class PendingSyncStore {
 		}
 	}
 
-	clearSyncInFlightForPeer(publicKeyHash: string, hash: string): void {
-		const map = this.syncInFlight.get(publicKeyHash);
-		if (!map) {
-			return;
-		}
-		this.refreshQueuedSyncCoordinateAliases();
-		this.forEachKnownAlias(hash, (key) =>
-			this.removeSyncInFlightTargetKey(publicKeyHash, key),
-		);
-	}
-
 	clearSyncInFlightForPeerHashes(
 		publicKeyHash: string,
 		hashes: string[],

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -25,6 +25,11 @@ import { SilentDelivery } from "@peerbit/stream-interface";
 import { type EntryWithRefs } from "../exchange-heads.js";
 import { TransportMessage } from "../message.js";
 import { type EntryReplicated } from "../ranges.js";
+import {
+	DispatchLifecycleRegistry,
+	isOwnershipGenerationActive,
+	isTrackedSessionActive,
+} from "./dispatch-lifecycle.js";
 import type {
 	HashSymbolRangeResolver,
 	RepairSession,
@@ -851,10 +856,17 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	outgoingSyncProcesses: Map<string, OutgoingRatelessSyncProcess>;
 	private outgoingSyncProcessByTarget: Map<string, OutgoingRatelessSyncProcess>;
 	private ratelessDispatchLifecycleController: AbortController;
-	private ratelessDispatchTargets: Map<
+	private readonly ratelessDispatchRegistry: DispatchLifecycleRegistry<
+		RatelessDispatchLifecycle,
+		RatelessDispatchTargetLifecycle
+	>;
+
+	private get ratelessDispatchTargets(): Map<
 		string,
 		Set<RatelessDispatchTargetLifecycle>
-	>;
+	> {
+		return this.ratelessDispatchRegistry.activeTargets;
+	}
 	private activeRatelessResponseCount: number;
 	private activeRatelessResponseCountByPeer: Map<string, number>;
 	// Per-peer slot rows for active rateless responses (shared registry; see
@@ -875,7 +887,24 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		this.outgoingSyncProcesses = new Map();
 		this.outgoingSyncProcessByTarget = new Map();
 		this.ratelessDispatchLifecycleController = new AbortController();
-		this.ratelessDispatchTargets = new Map();
+		this.ratelessDispatchRegistry = new DispatchLifecycleRegistry<
+			RatelessDispatchLifecycle,
+			RatelessDispatchTargetLifecycle
+		>({
+			isClosed: () => this.ratelessClosed,
+			currentOwnershipLifecycleController: () =>
+				this.ratelessDispatchLifecycleController,
+			hasRetainedWork: (lifecycle) =>
+				[...lifecycle.targets.values()].some(
+					(target) => target.retainedByProcess || target.responseLeases > 0,
+				),
+			// Target-activity strategy: set membership in the active-target
+			// registry (rateless target lifecycles carry no epochs).
+			isTargetCurrent: (targetLifecycle) =>
+				this.ratelessDispatchRegistry.activeTargets
+					.get(targetLifecycle.target)
+					?.has(targetLifecycle) === true,
+		});
 		this.activeRatelessResponseCount = 0;
 		this.activeRatelessResponseCountByPeer = new Map();
 		this.ratelessPeerSlotRows = new SyncPeerSlotRegistry();
@@ -931,15 +960,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	private isRatelessRepairSessionActive(
 		session: RatelessRepairSessionLifecycle,
 	): boolean {
-		return (
-			!this.ratelessClosed &&
-			!session.cancelled &&
-			!session.controller.signal.aborted &&
-			!session.ownershipLifecycleController.signal.aborted &&
-			session.ownershipLifecycleController ===
-				this.ratelessDispatchLifecycleController &&
-			this.ratelessRepairSessions.get(session.id) === session
-		);
+		return isTrackedSessionActive({
+			closed: this.ratelessClosed,
+			cancelled: session.cancelled,
+			sessionController: session.controller,
+			ownershipLifecycleController: session.ownershipLifecycleController,
+			currentOwnershipLifecycleController:
+				this.ratelessDispatchLifecycleController,
+			session,
+			registered: this.ratelessRepairSessions.get(session.id),
+		});
 	}
 
 	private cancelRatelessRepairSession(
@@ -1423,42 +1453,17 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			disposed: false,
 		} satisfies RatelessDispatchLifecycle;
 
-		for (const target of [...new Set(targets)]) {
-			const targetLifecycle: RatelessDispatchTargetLifecycle = {
-				lifecycle,
+		this.ratelessDispatchRegistry.register(
+			lifecycle,
+			targets,
+			(forLifecycle, target) => ({
+				lifecycle: forLifecycle,
 				target,
 				controller: new AbortController(),
 				retainedByProcess: false,
 				responseLeases: 0,
-			};
-			lifecycle.targets.set(target, targetLifecycle);
-			let activeForTarget = this.ratelessDispatchTargets.get(target);
-			if (!activeForTarget) {
-				activeForTarget = new Set();
-				this.ratelessDispatchTargets.set(target, activeForTarget);
-			}
-			activeForTarget.add(targetLifecycle);
-		}
-
-		ownershipLifecycleController.signal.addEventListener(
-			"abort",
-			lifecycle.onOwnerOrCallerAbort,
-			{ once: true },
+			}),
 		);
-		if (callerSignal && callerSignal !== ownershipLifecycleController.signal) {
-			callerSignal.addEventListener("abort", lifecycle.onOwnerOrCallerAbort, {
-				once: true,
-			});
-		}
-		if (
-			this.ratelessClosed ||
-			ownershipLifecycleController !==
-				this.ratelessDispatchLifecycleController ||
-			ownershipLifecycleController.signal.aborted ||
-			callerSignal?.aborted
-		) {
-			lifecycle.onOwnerOrCallerAbort();
-		}
 		return lifecycle;
 	}
 
@@ -1466,93 +1471,33 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		targetLifecycle: RatelessDispatchTargetLifecycle,
 		reason?: unknown,
 	): void {
-		if (!targetLifecycle.controller.signal.aborted) {
-			targetLifecycle.controller.abort(reason);
-		}
-		this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
+		this.ratelessDispatchRegistry.abortTarget(targetLifecycle, reason);
 	}
 
 	private abortRatelessDispatchLifecycle(
 		lifecycle: RatelessDispatchLifecycle,
 		reason?: unknown,
 	): void {
-		if (!lifecycle.controller.signal.aborted) {
-			lifecycle.controller.abort(reason);
-		}
-		for (const targetLifecycle of lifecycle.targets.values()) {
-			this.abortRatelessDispatchTarget(targetLifecycle, reason);
-		}
-		this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
+		this.ratelessDispatchRegistry.abortLifecycle(lifecycle, reason);
 	}
 
 	private finishRatelessDispatchLifecycle(
 		lifecycle: RatelessDispatchLifecycle,
 	): void {
-		lifecycle.dispatchFinished = true;
-		this.maybeDisposeRatelessDispatchLifecycle(lifecycle);
+		this.ratelessDispatchRegistry.finish(lifecycle);
 	}
 
 	private maybeDisposeRatelessDispatchLifecycle(
 		lifecycle: RatelessDispatchLifecycle,
 	): void {
-		if (
-			lifecycle.disposed ||
-			!lifecycle.dispatchFinished ||
-			[...lifecycle.targets.values()].some(
-				(target) => target.retainedByProcess || target.responseLeases > 0,
-			)
-		) {
-			return;
-		}
-		lifecycle.disposed = true;
-		lifecycle.ownershipLifecycleController.signal.removeEventListener(
-			"abort",
-			lifecycle.onOwnerOrCallerAbort,
-		);
-		if (
-			lifecycle.callerSignal &&
-			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
-		) {
-			lifecycle.callerSignal.removeEventListener(
-				"abort",
-				lifecycle.onOwnerOrCallerAbort,
-			);
-		}
-		for (const targetLifecycle of lifecycle.targets.values()) {
-			const activeForTarget = this.ratelessDispatchTargets.get(
-				targetLifecycle.target,
-			);
-			activeForTarget?.delete(targetLifecycle);
-			if (activeForTarget?.size === 0) {
-				this.ratelessDispatchTargets.delete(targetLifecycle.target);
-			}
-		}
+		this.ratelessDispatchRegistry.maybeDispose(lifecycle);
 	}
 
 	private isRatelessDispatchLifecycleActive(
 		lifecycle: RatelessDispatchLifecycle,
 		target?: string,
 	): boolean {
-		if (
-			this.ratelessClosed ||
-			lifecycle.disposed ||
-			lifecycle.ownershipLifecycleController !==
-				this.ratelessDispatchLifecycleController ||
-			lifecycle.ownershipLifecycleController.signal.aborted ||
-			lifecycle.callerSignal?.aborted ||
-			lifecycle.controller.signal.aborted
-		) {
-			return false;
-		}
-		if (target === undefined) {
-			return true;
-		}
-		const targetLifecycle = lifecycle.targets.get(target);
-		return (
-			targetLifecycle !== undefined &&
-			!targetLifecycle.controller.signal.aborted &&
-			this.ratelessDispatchTargets.get(target)?.has(targetLifecycle) === true
-		);
+		return this.ratelessDispatchRegistry.isLifecycleActive(lifecycle, target);
 	}
 
 	private getIncomingSyncProcessKey(sender: string, syncId: string): string {
@@ -1562,12 +1507,12 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	private isIncomingSyncGenerationActive(
 		ownershipLifecycleController: AbortController,
 	): boolean {
-		return (
-			!this.ratelessClosed &&
-			ownershipLifecycleController ===
-				this.ratelessDispatchLifecycleController &&
-			!ownershipLifecycleController.signal.aborted
-		);
+		return isOwnershipGenerationActive({
+			closed: this.ratelessClosed,
+			ownershipLifecycleController,
+			currentOwnershipLifecycleController:
+				this.ratelessDispatchLifecycleController,
+		});
 	}
 
 	private isIncomingSyncProcessActive(

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -47,6 +47,10 @@ import {
 	SYNC_MESSAGE_PRIORITY,
 	SimpleSyncronizer,
 } from "./simple.js";
+import {
+	SyncPeerSlotRegistry,
+	type SyncPeerSlotRow,
+} from "./sync-peer-state.js";
 
 export const logger = loggerFn("peerbit:shared-log:rateless");
 
@@ -815,16 +819,6 @@ type IncomingRatelessProcessAdmission = {
 	sender: string;
 };
 
-// Per-peer slot accounting for active rateless responses. Release closures
-// capture the row: after a disconnect detaches it, the peer's quota returns
-// immediately and a late release only settles the detached row — it never
-// touches a reconnected successor's quota or the global aggregate.
-type RatelessResponseSlotRow = {
-	peer: string;
-	attached: boolean;
-	active: number;
-};
-
 type RatelessRepairSessionLifecycle = {
 	id: string;
 	ownershipLifecycleController: AbortController;
@@ -863,8 +857,16 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	>;
 	private activeRatelessResponseCount: number;
 	private activeRatelessResponseCountByPeer: Map<string, number>;
-	private ratelessResponseSlotRows: Map<string, RatelessResponseSlotRow>;
+	// Per-peer slot rows for active rateless responses (shared registry; see
+	// sync-peer-state.ts for the lifetime policy). Release closures capture
+	// the row: after a disconnect detaches it, the peer's quota returns
+	// immediately and a late release only settles the detached row.
+	private readonly ratelessPeerSlotRows: SyncPeerSlotRegistry;
 	private ratelessClosed: boolean;
+
+	private get ratelessResponseSlotRows(): Map<string, SyncPeerSlotRow> {
+		return this.ratelessPeerSlotRows.rows;
+	}
 
 	constructor(readonly properties: SynchronizerComponents<D>) {
 		this.simple = new SimpleSyncronizer(properties);
@@ -876,7 +878,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		this.ratelessDispatchTargets = new Map();
 		this.activeRatelessResponseCount = 0;
 		this.activeRatelessResponseCountByPeer = new Map();
-		this.ratelessResponseSlotRows = new Map();
+		this.ratelessPeerSlotRows = new SyncPeerSlotRegistry();
 		this.ratelessClosed = false;
 		this.ingoingSyncProcesses = new Map();
 		this.incomingRatelessProcessAdmissions = new Set();
@@ -2355,33 +2357,22 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					} else {
 						this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
 					}
-					if (slotRow.active === 0) {
-						this.ratelessResponseSlotRows.delete(target);
-					}
+					this.ratelessPeerSlotRows.maybeDropIdle(slotRow);
 				}
 				this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
 			},
 		};
 	}
 
-	private getOrCreateRatelessResponseSlotRow(
-		peer: string,
-	): RatelessResponseSlotRow {
-		let row = this.ratelessResponseSlotRows.get(peer);
-		if (!row) {
-			row = { peer, attached: true, active: 0 };
-			this.ratelessResponseSlotRows.set(peer, row);
-		}
-		return row;
+	private getOrCreateRatelessResponseSlotRow(peer: string): SyncPeerSlotRow {
+		return this.ratelessPeerSlotRows.ensure(peer);
 	}
 
 	private detachRatelessResponseSlotRow(peer: string): void {
-		const row = this.ratelessResponseSlotRows.get(peer);
+		const row = this.ratelessPeerSlotRows.detach(peer);
 		if (!row) {
 			return;
 		}
-		row.attached = false;
-		this.ratelessResponseSlotRows.delete(peer);
 		if (row.active > 0) {
 			this.activeRatelessResponseCount -= row.active;
 			this.activeRatelessResponseCountByPeer.delete(peer);

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -815,6 +815,16 @@ type IncomingRatelessProcessAdmission = {
 	sender: string;
 };
 
+// Per-peer slot accounting for active rateless responses. Release closures
+// capture the row: after a disconnect detaches it, the peer's quota returns
+// immediately and a late release only settles the detached row — it never
+// touches a reconnected successor's quota or the global aggregate.
+type RatelessResponseSlotRow = {
+	peer: string;
+	attached: boolean;
+	active: number;
+};
+
 type RatelessRepairSessionLifecycle = {
 	id: string;
 	ownershipLifecycleController: AbortController;
@@ -853,6 +863,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	>;
 	private activeRatelessResponseCount: number;
 	private activeRatelessResponseCountByPeer: Map<string, number>;
+	private ratelessResponseSlotRows: Map<string, RatelessResponseSlotRow>;
 	private ratelessClosed: boolean;
 
 	constructor(readonly properties: SynchronizerComponents<D>) {
@@ -865,6 +876,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		this.ratelessDispatchTargets = new Map();
 		this.activeRatelessResponseCount = 0;
 		this.activeRatelessResponseCountByPeer = new Map();
+		this.ratelessResponseSlotRows = new Map();
 		this.ratelessClosed = false;
 		this.ingoingSyncProcesses = new Map();
 		this.incomingRatelessProcessAdmissions = new Set();
@@ -2309,6 +2321,8 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 
 		const targetLifecycle = process.targetLifecycle;
 		targetLifecycle.responseLeases += 1;
+		const slotRow = this.getOrCreateRatelessResponseSlotRow(target);
+		slotRow.active += 1;
 		this.activeRatelessResponseCount += 1;
 		this.activeRatelessResponseCountByPeer.set(
 			target,
@@ -2331,17 +2345,47 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 					}
 				}
 				targetLifecycle.responseLeases -= 1;
-				this.activeRatelessResponseCount -= 1;
-				const activeForPeer =
-					(this.activeRatelessResponseCountByPeer.get(target) ?? 1) - 1;
-				if (activeForPeer === 0) {
-					this.activeRatelessResponseCountByPeer.delete(target);
-				} else {
-					this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
+				slotRow.active -= 1;
+				if (slotRow.attached) {
+					this.activeRatelessResponseCount -= 1;
+					const activeForPeer =
+						(this.activeRatelessResponseCountByPeer.get(target) ?? 1) - 1;
+					if (activeForPeer === 0) {
+						this.activeRatelessResponseCountByPeer.delete(target);
+					} else {
+						this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
+					}
+					if (slotRow.active === 0) {
+						this.ratelessResponseSlotRows.delete(target);
+					}
 				}
 				this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
 			},
 		};
+	}
+
+	private getOrCreateRatelessResponseSlotRow(
+		peer: string,
+	): RatelessResponseSlotRow {
+		let row = this.ratelessResponseSlotRows.get(peer);
+		if (!row) {
+			row = { peer, attached: true, active: 0 };
+			this.ratelessResponseSlotRows.set(peer, row);
+		}
+		return row;
+	}
+
+	private detachRatelessResponseSlotRow(peer: string): void {
+		const row = this.ratelessResponseSlotRows.get(peer);
+		if (!row) {
+			return;
+		}
+		row.attached = false;
+		this.ratelessResponseSlotRows.delete(peer);
+		if (row.active > 0) {
+			this.activeRatelessResponseCount -= row.active;
+			this.activeRatelessResponseCountByPeer.delete(peer);
+		}
 	}
 
 	async onMessage(
@@ -3247,6 +3291,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				new Error("rateless sync target disconnected"),
 			);
 		}
+		// A response ship for this peer may never settle. Detach the slot row so
+		// the quota returns immediately; late releases settle against the
+		// detached row. Note: open() deliberately does NOT clear this
+		// accounting — cross-generation work is still charged until it settles.
+		this.detachRatelessResponseSlotRow(target);
 		return this.simple.onPeerDisconnected(target);
 	}
 

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -32,6 +32,11 @@ import type {
 	SyncableKey,
 	Syncronizer,
 } from "./index.js";
+import {
+	type PendingSyncAdmissionReservation,
+	PendingSyncStore,
+	QUEUED_SYNC_ALIAS_REFRESH_PENDING,
+} from "./pending-sync-store.js";
 import { emitSyncProfileDuration, syncProfileStart } from "./profile.js";
 
 @variant([0, 1])
@@ -332,16 +337,10 @@ export const MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL = 32;
 // Retry scanning can touch persistent indexes. Bound each pass so a full
 // adversarial queue cannot force 40,000 lookups in one event-loop turn.
 export const MAX_SIMPLE_SYNC_RETRY_KEYS_PER_TICK = 4_096;
-// Late coordinate-to-hash cache fills are discovered incrementally. Keep this
-// independent of retained queue size so an empty or repeated request cannot
-// force an O(global pending keys) reverse-alias rebuild.
-const MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE = 128;
-const QUEUED_SYNC_ALIAS_REFRESH_PENDING = Symbol(
-	"queued-sync-alias-refresh-pending",
-);
-// This is an absolute first-seen lifetime. Repeated claims and additional peers
-// deliberately do not slide the deadline.
-export const PENDING_SIMPLE_SYNC_KEY_TTL_MS = 60_000;
+// The pending-claim TTL, alias-refresh bound and pending-refresh sentinel
+// moved into ./pending-sync-store.ts with the record store (stage-4 sync
+// unification). Re-exported here for compatibility.
+export { PENDING_SIMPLE_SYNC_KEY_TTL_MS } from "./pending-sync-store.js";
 // Bound retained request/response associations globally. Ten thousand hashes
 // covers several full default-size request batches while keeping adversarial or
 // abandoned requests to a small, predictable amount of heap.
@@ -350,30 +349,6 @@ export const MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_PER_PEER = 4;
 export const MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL = 32;
 const MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITER_BYPASSES = 32;
 const MAX_PENDING_MAYBE_SYNC_RESPONSE_WAITERS = 10_000;
-
-type PendingSyncAdmissionReservation = {
-	peer: string;
-	remaining: number;
-	active: boolean;
-	released: boolean;
-	expiresAt: number;
-	identities: Set<SyncableKey>;
-	retainedSettled: number;
-};
-
-type PendingSyncExpiryNode =
-	| {
-			kind: "key";
-			key: SyncableKey;
-			expiresAt: number;
-			heapIndex: number;
-	  }
-	| {
-			kind: "admission";
-			reservation: PendingSyncAdmissionReservation;
-			expiresAt: number;
-			heapIndex: number;
-	  };
 
 type PendingMaybeSyncResponse = {
 	hashes: Set<string>;
@@ -513,54 +488,99 @@ type RepairSessionState = {
 export class SimpleSyncronizer<R extends "u32" | "u64">
 	implements Syncronizer<R>
 {
-	// map of hash to public keys that we can ask for entries
-	syncInFlightQueue: Map<SyncableKey, PublicSignKey[]>;
-	syncInFlightQueueInverted: Map<string, Set<SyncableKey>>;
-	private syncInFlightQueueExpiresAt: Map<SyncableKey, number>;
-	private syncInFlightQueueExpiryTimer?: ReturnType<typeof setTimeout>;
-	private pendingSyncExpiryHeap: PendingSyncExpiryNode[];
-	private pendingSyncKeyExpiryNodes: Map<SyncableKey, PendingSyncExpiryNode>;
-	private pendingSyncAdmissionExpiryNodes: Map<
-		PendingSyncAdmissionReservation,
-		PendingSyncExpiryNode
-	>;
+	// The pending-sync record store owns the claim/admission state. The
+	// legacy public map instances (syncInFlightQueue, syncInFlightQueueInverted,
+	// syncInFlight, ...) live inside it and are exposed through the accessors
+	// below under their historical names.
+	private readonly pendingSync: PendingSyncStore;
 	private syncInFlightRetryIterator?: IterableIterator<
 		[SyncableKey, PublicSignKey[]]
 	>;
 	private syncInFlightRetryRemaining = 0;
-	private syncInFlightQueueClaimants: Map<SyncableKey, Set<string>>;
-	private syncInFlightQueueClaimantIndexes: Map<
-		SyncableKey,
-		Map<string, number>
-	>;
-	private syncInFlightQueueRoundRobinCursor: Map<SyncableKey, number>;
-	private syncInFlightQueuedCoordinates: Set<bigint>;
-	private syncInFlightQueuedHashByCoordinate: Map<bigint, string>;
-	private syncInFlightQueuedCoordinatesByHash: Map<string, Set<bigint>>;
-	private syncInFlightQueuedCoordinateRefreshIterator?: IterableIterator<bigint>;
-	private pendingSyncClaimCount: number;
-	private pendingSyncAdmissionCount: number;
-	private pendingSyncActiveAdmissionReservations: number;
-	private pendingSyncAdmissionCountByPeer: Map<string, number>;
-	private pendingSyncAdmissionIdentitiesByPeer: Map<string, Set<SyncableKey>>;
-	private pendingSyncAdmissionReservations: Set<PendingSyncAdmissionReservation>;
-	private pendingSyncAdmissionReservationsByPeer: Map<
-		string,
-		Set<PendingSyncAdmissionReservation>
-	>;
-	private pendingSyncAdmissionReservationsByIdentity: Map<
-		SyncableKey,
-		Set<PendingSyncAdmissionReservation>
-	>;
 	private pendingCoordinateLookupCount: number;
 	private pendingCoordinateLookupCountByPeer: Map<string, number>;
 	private pendingCoordinateResponseCount: number;
 	private pendingCoordinateResponseCountByPeer: Map<string, number>;
 	private syncResponseSlotRows: Map<string, SyncResponseSlotRow>;
 
+	// map of hash to public keys that we can ask for entries
+	get syncInFlightQueue(): Map<SyncableKey, PublicSignKey[]> {
+		return this.pendingSync.syncInFlightQueue;
+	}
+
+	get syncInFlightQueueInverted(): Map<string, Set<SyncableKey>> {
+		return this.pendingSync.syncInFlightQueueInverted;
+	}
+
 	// map of hash to public keys that we have asked for entries
-	syncInFlight!: Map<string, Map<SyncableKey, { timestamp: number }>>;
-	private syncInFlightTargetsByKey: Map<SyncableKey, Set<string>>;
+	get syncInFlight(): Map<string, Map<SyncableKey, { timestamp: number }>> {
+		return this.pendingSync.syncInFlight;
+	}
+
+	private get syncInFlightTargetsByKey(): Map<SyncableKey, Set<string>> {
+		return this.pendingSync.syncInFlightTargetsByKey;
+	}
+
+	private get syncInFlightQueueExpiresAt(): Map<SyncableKey, number> {
+		return this.pendingSync.syncInFlightQueueExpiresAt;
+	}
+
+	private get syncInFlightQueueExpiryTimer():
+		| ReturnType<typeof setTimeout>
+		| undefined {
+		return this.pendingSync.syncInFlightQueueExpiryTimer;
+	}
+
+	private get pendingSyncExpiryHeap() {
+		return this.pendingSync.pendingSyncExpiryHeap;
+	}
+
+	private get pendingSyncAdmissionExpiryNodes() {
+		return this.pendingSync.pendingSyncAdmissionExpiryNodes;
+	}
+
+	private get syncInFlightQueuedCoordinates(): Set<bigint> {
+		return this.pendingSync.syncInFlightQueuedCoordinates;
+	}
+
+	private get syncInFlightQueuedHashByCoordinate(): Map<bigint, string> {
+		return this.pendingSync.syncInFlightQueuedHashByCoordinate;
+	}
+
+	private get syncInFlightQueuedCoordinatesByHash(): Map<string, Set<bigint>> {
+		return this.pendingSync.syncInFlightQueuedCoordinatesByHash;
+	}
+
+	private get pendingSyncClaimCount(): number {
+		return this.pendingSync.pendingSyncClaimCount;
+	}
+
+	private get pendingSyncAdmissionCount(): number {
+		return this.pendingSync.pendingSyncAdmissionCount;
+	}
+
+	private get pendingSyncAdmissionCountByPeer(): Map<string, number> {
+		return this.pendingSync.pendingSyncAdmissionCountByPeer;
+	}
+
+	private get pendingSyncAdmissionIdentitiesByPeer(): Map<
+		string,
+		Set<SyncableKey>
+	> {
+		return this.pendingSync.pendingSyncAdmissionIdentitiesByPeer;
+	}
+
+	private get pendingSyncAdmissionReservations() {
+		return this.pendingSync.pendingSyncAdmissionReservations;
+	}
+
+	private get pendingSyncAdmissionReservationsByPeer() {
+		return this.pendingSync.pendingSyncAdmissionReservationsByPeer;
+	}
+
+	private get pendingSyncAdmissionReservationsByIdentity() {
+		return this.pendingSync.pendingSyncAdmissionReservationsByIdentity;
+	}
 
 	rpc: RPC<TransportMessage, TransportMessage>;
 	log: Log<any>;
@@ -622,33 +642,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		peerSupportsRawExchangeHeads?: (peer: string) => boolean;
 		sendRawExchangeHeads?: RawExchangeHeadsSender;
 	}) {
-		this.syncInFlightQueue = new Map();
-		this.syncInFlightQueueInverted = new Map();
-		this.syncInFlightQueueExpiresAt = new Map();
-		this.pendingSyncExpiryHeap = [];
-		this.pendingSyncKeyExpiryNodes = new Map();
-		this.pendingSyncAdmissionExpiryNodes = new Map();
-		this.syncInFlightQueueClaimants = new Map();
-		this.syncInFlightQueueClaimantIndexes = new Map();
-		this.syncInFlightQueueRoundRobinCursor = new Map();
-		this.syncInFlightQueuedCoordinates = new Set();
-		this.syncInFlightQueuedHashByCoordinate = new Map();
-		this.syncInFlightQueuedCoordinatesByHash = new Map();
-		this.pendingSyncClaimCount = 0;
-		this.pendingSyncAdmissionCount = 0;
-		this.pendingSyncActiveAdmissionReservations = 0;
-		this.pendingSyncAdmissionCountByPeer = new Map();
-		this.pendingSyncAdmissionIdentitiesByPeer = new Map();
-		this.pendingSyncAdmissionReservations = new Set();
-		this.pendingSyncAdmissionReservationsByPeer = new Map();
-		this.pendingSyncAdmissionReservationsByIdentity = new Map();
+		this.pendingSync = new PendingSyncStore({
+			coordinateToHash: properties.coordinateToHash,
+			isDispatchEpochCurrent: (peer, epoch) =>
+				this.syncDispatchTargetEpochs.get(peer) === epoch,
+		});
 		this.pendingCoordinateLookupCount = 0;
 		this.pendingCoordinateLookupCountByPeer = new Map();
 		this.pendingCoordinateResponseCount = 0;
 		this.pendingCoordinateResponseCountByPeer = new Map();
 		this.syncResponseSlotRows = new Map();
-		this.syncInFlight = new Map();
-		this.syncInFlightTargetsByKey = new Map();
 		this.rpc = properties.rpc;
 		this.log = properties.log;
 		this.entryIndex = properties.entryIndex;
@@ -2867,194 +2870,17 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	}
 
 	private getPendingSyncKeyIdentity(key: SyncableKey): SyncableKey {
-		if (typeof key === "string") {
-			return key;
-		}
-		const hash = this.coordinateToHash.get(key);
-		return hash ?? key;
-	}
-
-	private removeQueuedSyncCoordinateAlias(key: bigint): void {
-		this.syncInFlightQueuedCoordinates.delete(key);
-		if (this.syncInFlightQueuedCoordinates.size === 0) {
-			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
-		}
-		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
-		this.syncInFlightQueuedHashByCoordinate.delete(key);
-		if (previousHash != null) {
-			const coordinates =
-				this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
-			coordinates?.delete(key);
-			if (coordinates?.size === 0) {
-				this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
-			}
-		}
-	}
-
-	private refreshQueuedSyncCoordinateAlias(key: bigint): void {
-		if (!this.syncInFlightQueue.has(key)) {
-			this.removeQueuedSyncCoordinateAlias(key);
-			return;
-		}
-		this.syncInFlightQueuedCoordinates.add(key);
-		const hash = this.coordinateToHash.get(key) ?? undefined;
-		const previousHash = this.syncInFlightQueuedHashByCoordinate.get(key);
-		if (previousHash !== hash) {
-			if (previousHash != null) {
-				const coordinates =
-					this.syncInFlightQueuedCoordinatesByHash.get(previousHash);
-				coordinates?.delete(key);
-				if (coordinates?.size === 0) {
-					this.syncInFlightQueuedCoordinatesByHash.delete(previousHash);
-				}
-			}
-			if (hash == null) {
-				this.syncInFlightQueuedHashByCoordinate.delete(key);
-			} else {
-				this.syncInFlightQueuedHashByCoordinate.set(key, hash);
-			}
-		}
-		if (hash != null) {
-			let coordinates = this.syncInFlightQueuedCoordinatesByHash.get(hash);
-			if (!coordinates) {
-				coordinates = new Set();
-				this.syncInFlightQueuedCoordinatesByHash.set(hash, coordinates);
-			}
-			coordinates.add(key);
-			this.reconcileQueuedSyncCoordinateAlias(key, hash);
-		}
-	}
-
-	private reconcileQueuedSyncCoordinateAlias(
-		coordinate: bigint,
-		hash: string,
-	): void {
-		const now = Date.now();
-		const coordinateExpiresAt = this.syncInFlightQueueExpiresAt.get(coordinate);
-		if (coordinateExpiresAt != null && coordinateExpiresAt <= now) {
-			this.clearSyncProcessKey(coordinate);
-			return;
-		}
-		const hashExpiresAt = this.syncInFlightQueueExpiresAt.get(hash);
-		if (hashExpiresAt != null && hashExpiresAt <= now) {
-			this.clearSyncProcessKey(hash);
-			return;
-		}
-		const hashClaimants = this.syncInFlightQueue.get(hash);
-		if (!hashClaimants || !this.syncInFlightQueue.has(coordinate)) {
-			return;
-		}
-		const expiresAt = Math.min(
-			this.syncInFlightQueueExpiresAt.get(coordinate) ?? Infinity,
-			this.syncInFlightQueueExpiresAt.get(hash) ?? Infinity,
-		);
-		for (const claimant of [...hashClaimants]) {
-			this.addPendingSyncClaim(coordinate, claimant, expiresAt);
-		}
-		if (Number.isFinite(expiresAt)) {
-			this.movePendingSyncKeyExpiryEarlier(coordinate, expiresAt);
-		}
-		for (const target of [...(this.syncInFlightTargetsByKey.get(hash) ?? [])]) {
-			const state = this.syncInFlight.get(target)?.get(hash);
-			if (state) {
-				this.setSyncInFlightTargetKey(target, coordinate, state.timestamp);
-			}
-		}
-		this.clearSyncProcessKey(hash);
+		return this.pendingSync.getPendingSyncKeyIdentity(key);
 	}
 
 	private refreshQueuedSyncCoordinateAliases(): void {
-		if (
-			this.syncInFlightQueuedCoordinates.size === 0 &&
-			this.syncInFlightQueueClaimants.size < this.syncInFlightQueue.size
-		) {
-			// Defensive compatibility for callers/tests that seed the public queue
-			// directly. Keep hydration bounded; internal writes register coordinates
-			// when the key is first admitted.
-			let inspected = 0;
-			for (const key of this.syncInFlightQueue.keys()) {
-				if (typeof key === "bigint") {
-					this.syncInFlightQueuedCoordinates.add(key);
-				}
-				inspected += 1;
-				if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
-					break;
-				}
-			}
-		}
-		if (this.syncInFlightQueuedCoordinates.size === 0) {
-			this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
-			return;
-		}
-		this.syncInFlightQueuedCoordinateRefreshIterator ??=
-			this.syncInFlightQueuedCoordinates.values();
-		for (
-			let refreshed = 0;
-			refreshed < MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE;
-			refreshed += 1
-		) {
-			const next = this.syncInFlightQueuedCoordinateRefreshIterator.next();
-			if (next.done) {
-				this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
-				break;
-			}
-			this.refreshQueuedSyncCoordinateAlias(next.value);
-		}
+		this.pendingSync.refreshQueuedSyncCoordinateAliases();
 	}
 
 	private getQueuedSyncKeyForAdmission(
 		key: SyncableKey,
 	): SyncableKey | typeof QUEUED_SYNC_ALIAS_REFRESH_PENDING | undefined {
-		const getValidQueuedKey = (
-			candidate: SyncableKey,
-		): SyncableKey | undefined => {
-			if (!this.syncInFlightQueue.has(candidate)) {
-				return undefined;
-			}
-			const expiresAt = this.syncInFlightQueueExpiresAt.get(candidate);
-			if (expiresAt != null && expiresAt <= Date.now()) {
-				this.clearSyncProcessKey(candidate);
-				return undefined;
-			}
-			return candidate;
-		};
-		if (getValidQueuedKey(key) != null) {
-			if (typeof key === "bigint") {
-				this.refreshQueuedSyncCoordinateAlias(key);
-				return getValidQueuedKey(key);
-			}
-			return key;
-		}
-		if (typeof key === "string") {
-			const aliases = this.syncInFlightQueuedCoordinatesByHash.get(key);
-			if (aliases) {
-				let inspected = 0;
-				for (const alias of aliases) {
-					if (inspected >= MAX_PENDING_SIMPLE_SYNC_ALIAS_REFRESH_PER_MESSAGE) {
-						return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
-					}
-					inspected += 1;
-					this.refreshQueuedSyncCoordinateAlias(alias);
-					if (
-						this.syncInFlightQueuedCoordinatesByHash.get(key)?.has(alias) ===
-						true
-					) {
-						const validAlias = getValidQueuedKey(alias);
-						if (validAlias != null) {
-							return validAlias;
-						}
-					}
-				}
-				if (
-					(this.syncInFlightQueuedCoordinatesByHash.get(key)?.size ?? 0) > 0
-				) {
-					return QUEUED_SYNC_ALIAS_REFRESH_PENDING;
-				}
-			}
-			return undefined;
-		}
-		const hash = this.coordinateToHash.get(key);
-		return hash != null ? getValidQueuedKey(hash) : undefined;
+		return this.pendingSync.getQueuedSyncKeyForAdmission(key);
 	}
 
 	private addPendingSyncClaim(
@@ -3062,80 +2888,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		from: PublicSignKey,
 		expiresAt?: number,
 	): boolean {
-		const fromHash = from.hashcode();
-		let peers = this.syncInFlightQueue.get(key);
-		let claimants = this.syncInFlightQueueClaimants.get(key);
-		let claimantIndexes = this.syncInFlightQueueClaimantIndexes.get(key);
-		if (!peers) {
-			peers = [];
-			this.syncInFlightQueue.set(key, peers);
-			claimants = new Set();
-			this.syncInFlightQueueClaimants.set(key, claimants);
-			claimantIndexes = new Map();
-			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
-			const deadline = expiresAt ?? Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS;
-			this.syncInFlightQueueExpiresAt.set(key, deadline);
-			const expiryNode: PendingSyncExpiryNode = {
-				kind: "key",
-				key,
-				expiresAt: deadline,
-				heapIndex: -1,
-			};
-			this.pendingSyncKeyExpiryNodes.set(key, expiryNode);
-			this.pushPendingSyncExpiry(expiryNode);
-			if (typeof key === "bigint") {
-				this.refreshQueuedSyncCoordinateAlias(key);
-			}
-		} else if (!claimants) {
-			// Defensive compatibility for callers/tests that seed the public queue
-			// maps directly. Internally every retained key gets this set at creation.
-			claimants = new Set(peers.map((peer) => peer.hashcode()));
-			this.syncInFlightQueueClaimants.set(key, claimants);
-			this.pendingSyncClaimCount += claimants.size;
-		}
-		if (!claimantIndexes) {
-			claimantIndexes = new Map();
-			for (let index = 0; index < peers.length; index += 1) {
-				claimantIndexes.set(peers[index]!.hashcode(), index);
-			}
-			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
-		}
-		if (claimants.has(fromHash)) {
-			return false;
-		}
-
-		claimantIndexes.set(fromHash, peers.length);
-		peers.push(from);
-		claimants.add(fromHash);
-		let inverted = this.syncInFlightQueueInverted.get(fromHash);
-		if (!inverted) {
-			inverted = new Set();
-			this.syncInFlightQueueInverted.set(fromHash, inverted);
-		}
-		inverted.add(key);
-		this.pendingSyncClaimCount += 1;
-		this.schedulePendingSyncKeyExpiry();
-		return true;
+		return this.pendingSync.addPendingSyncClaim(key, from, expiresAt);
 	}
 
 	private hasPendingSyncClaim(key: SyncableKey, peer: string): boolean {
-		const claimants = this.syncInFlightQueueClaimants.get(key);
-		if (claimants) {
-			return claimants.has(peer);
-		}
-		const peers = this.syncInFlightQueue.get(key);
-		if (!peers) {
-			return false;
-		}
-		const hydrated = new Set(peers.map((candidate) => candidate.hashcode()));
-		this.syncInFlightQueueClaimants.set(key, hydrated);
-		const indexes = new Map<string, number>();
-		for (let index = 0; index < peers.length; index += 1) {
-			indexes.set(peers[index]!.hashcode(), index);
-		}
-		this.syncInFlightQueueClaimantIndexes.set(key, indexes);
-		this.pendingSyncClaimCount += hydrated.size;
-		return hydrated.has(peer);
+		return this.pendingSync.hasPendingSyncClaim(key, peer);
 	}
 
 	private filterDispatchablePendingSyncClaims(
@@ -3143,25 +2900,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		peer: string,
 		epoch: SyncDispatchTargetEpoch,
 	): SyncableKey[] {
-		if (this.syncDispatchTargetEpochs.get(peer) !== epoch) {
-			return [];
-		}
-		const now = Date.now();
-		const dispatchable: SyncableKey[] = [];
-		for (const key of keys) {
-			const expiresAt = this.syncInFlightQueueExpiresAt.get(key);
-			if (expiresAt != null && expiresAt <= now) {
-				this.clearSyncProcessKey(key);
-				continue;
-			}
-			if (
-				this.syncInFlightQueue.has(key) &&
-				this.hasPendingSyncClaim(key, peer)
-			) {
-				dispatchable.push(key);
-			}
-		}
-		return dispatchable;
+		return this.pendingSync.filterDispatchablePendingSyncClaims(
+			keys,
+			peer,
+			epoch,
+		);
 	}
 
 	private canStartPendingSyncLookup(peer: string): boolean {
@@ -3293,418 +3036,53 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		peer: string,
 		identities: SyncableKey[],
 	): PendingSyncAdmissionReservation | undefined {
-		const count = identities.length;
-		if (count <= 0) {
-			return undefined;
-		}
-		const reservation: PendingSyncAdmissionReservation = {
-			peer,
-			remaining: count,
-			active: true,
-			released: false,
-			expiresAt: Date.now() + PENDING_SIMPLE_SYNC_KEY_TTL_MS,
-			identities: new Set(identities),
-			retainedSettled: 0,
-		};
-		this.pendingSyncAdmissionReservations.add(reservation);
-		let peerReservations =
-			this.pendingSyncAdmissionReservationsByPeer.get(peer);
-		if (!peerReservations) {
-			peerReservations = new Set();
-			this.pendingSyncAdmissionReservationsByPeer.set(peer, peerReservations);
-		}
-		peerReservations.add(reservation);
-		this.pendingSyncActiveAdmissionReservations += 1;
-		this.pendingSyncAdmissionCount += count;
-		this.pendingSyncAdmissionCountByPeer.set(
-			peer,
-			(this.pendingSyncAdmissionCountByPeer.get(peer) ?? 0) + count,
-		);
-		let reservedIdentities =
-			this.pendingSyncAdmissionIdentitiesByPeer.get(peer);
-		if (!reservedIdentities) {
-			reservedIdentities = new Set();
-			this.pendingSyncAdmissionIdentitiesByPeer.set(peer, reservedIdentities);
-		}
-		for (const identity of identities) {
-			reservedIdentities.add(identity);
-			let reservationsForIdentity =
-				this.pendingSyncAdmissionReservationsByIdentity.get(identity);
-			if (!reservationsForIdentity) {
-				reservationsForIdentity = new Set();
-				this.pendingSyncAdmissionReservationsByIdentity.set(
-					identity,
-					reservationsForIdentity,
-				);
-			}
-			reservationsForIdentity.add(reservation);
-		}
-		const expiryNode: PendingSyncExpiryNode = {
-			kind: "admission",
-			reservation,
-			expiresAt: reservation.expiresAt,
-			heapIndex: -1,
-		};
-		this.pendingSyncAdmissionExpiryNodes.set(reservation, expiryNode);
-		this.pushPendingSyncExpiry(expiryNode);
-		this.schedulePendingSyncKeyExpiry();
-		return reservation;
-	}
-
-	private removePendingSyncAdmissionIdentity(
-		reservation: PendingSyncAdmissionReservation,
-		identity: SyncableKey,
-		options?: { retainQuota?: boolean },
-	): boolean {
-		if (!reservation.identities.delete(identity)) {
-			return false;
-		}
-		if (options?.retainQuota === true) {
-			reservation.retainedSettled += 1;
-		} else {
-			reservation.remaining -= 1;
-			this.pendingSyncAdmissionCount -= 1;
-			const peerCount =
-				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) - 1;
-			if (peerCount === 0) {
-				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
-			} else {
-				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
-			}
-		}
-		const reservedIdentities = this.pendingSyncAdmissionIdentitiesByPeer.get(
-			reservation.peer,
-		);
-		reservedIdentities?.delete(identity);
-		if (reservedIdentities?.size === 0) {
-			this.pendingSyncAdmissionIdentitiesByPeer.delete(reservation.peer);
-		}
-		const reservationsForIdentity =
-			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
-		reservationsForIdentity?.delete(reservation);
-		if (reservationsForIdentity?.size === 0) {
-			this.pendingSyncAdmissionReservationsByIdentity.delete(identity);
-		}
-		return true;
+		return this.pendingSync.reservePendingSyncAdmission(peer, identities);
 	}
 
 	private clearPendingSyncAdmissionIdentity(identity: SyncableKey): void {
-		const reservations =
-			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
-		if (!reservations) {
-			return;
-		}
-		for (const reservation of [...reservations]) {
-			this.removePendingSyncAdmissionIdentity(reservation, identity, {
-				retainQuota: true,
-			});
-		}
+		this.pendingSync.clearPendingSyncAdmissionIdentity(identity);
 	}
 
 	private consumePendingSyncAdmission(
 		reservation: PendingSyncAdmissionReservation,
 		identity: SyncableKey,
 	): "consumed" | "settled" | "invalid" {
-		if (!reservation.active || reservation.expiresAt <= Date.now()) {
-			if (reservation.expiresAt <= Date.now()) {
-				this.invalidatePendingSyncAdmission(reservation);
-			}
-			return "invalid";
-		}
-		if (!reservation.identities.has(identity)) {
-			return "settled";
-		}
-		this.removePendingSyncAdmissionIdentity(reservation, identity);
-		if (reservation.remaining === 0) {
-			this.removePendingSyncAdmissionExpiry(reservation);
-			reservation.active = false;
-			reservation.released = true;
-			this.pendingSyncActiveAdmissionReservations -= 1;
-			this.pendingSyncAdmissionReservations.delete(reservation);
-			const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
-				reservation.peer,
-			);
-			peerReservations?.delete(reservation);
-			if (peerReservations?.size === 0) {
-				this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
-			}
-			this.clearPendingSyncExpiryTimerIfIdle();
-		}
-		return "consumed";
+		return this.pendingSync.consumePendingSyncAdmission(reservation, identity);
 	}
 
 	private transferPendingSyncAdmissionIdentity(
 		peer: string,
 		identity: SyncableKey,
 	): number | undefined {
-		const reservations =
-			this.pendingSyncAdmissionReservationsByIdentity.get(identity);
-		if (!reservations) {
-			return undefined;
-		}
-		for (const reservation of reservations) {
-			if (
-				reservation.peer !== peer ||
-				reservation.released ||
-				reservation.expiresAt <= Date.now() ||
-				!this.removePendingSyncAdmissionIdentity(reservation, identity, {
-					retainQuota: true,
-				})
-			) {
-				continue;
-			}
-			// The original resolver may be non-abortable and still retains its input
-			// arrays. Keep that reservation charged until its queueSync finally
-			// settles; the queued claim is counted separately and can disappear
-			// without returning the resolver's quota early.
-			return reservation.expiresAt;
-		}
-		return undefined;
-	}
-
-	private invalidatePendingSyncAdmission(
-		reservation?: PendingSyncAdmissionReservation,
-	): void {
-		if (!reservation || reservation.released || !reservation.active) {
-			return;
-		}
-		// Expiry/disconnect invalidates late lookup results, but it must not return
-		// the quota slot while the underlying storage/index work is still alive.
-		// Those lookups are not generally abortable; only queueSync's finally block
-		// may release their active-work accounting.
-		this.removePendingSyncAdmissionExpiry(reservation);
-		reservation.active = false;
-		this.pendingSyncActiveAdmissionReservations -= 1;
-		this.clearPendingSyncExpiryTimerIfIdle();
+		return this.pendingSync.transferPendingSyncAdmissionIdentity(
+			peer,
+			identity,
+		);
 	}
 
 	private releasePendingSyncAdmission(
 		reservation?: PendingSyncAdmissionReservation,
 	): void {
-		if (!reservation || reservation.released) {
-			return;
-		}
-		this.removePendingSyncAdmissionExpiry(reservation);
-		for (const identity of [...reservation.identities]) {
-			this.removePendingSyncAdmissionIdentity(reservation, identity);
-		}
-		if (reservation.retainedSettled > 0) {
-			const retainedSettled = reservation.retainedSettled;
-			reservation.retainedSettled = 0;
-			reservation.remaining -= retainedSettled;
-			this.pendingSyncAdmissionCount -= retainedSettled;
-			const peerCount =
-				(this.pendingSyncAdmissionCountByPeer.get(reservation.peer) ?? 0) -
-				retainedSettled;
-			if (peerCount === 0) {
-				this.pendingSyncAdmissionCountByPeer.delete(reservation.peer);
-			} else {
-				this.pendingSyncAdmissionCountByPeer.set(reservation.peer, peerCount);
-			}
-		}
-		if (reservation.active) {
-			this.pendingSyncActiveAdmissionReservations -= 1;
-		}
-		reservation.active = false;
-		reservation.released = true;
-		this.pendingSyncAdmissionReservations.delete(reservation);
-		const peerReservations = this.pendingSyncAdmissionReservationsByPeer.get(
-			reservation.peer,
-		);
-		peerReservations?.delete(reservation);
-		if (peerReservations?.size === 0) {
-			this.pendingSyncAdmissionReservationsByPeer.delete(reservation.peer);
-		}
-		this.clearPendingSyncExpiryTimerIfIdle();
+		this.pendingSync.releasePendingSyncAdmission(reservation);
 	}
 
 	private clearPendingSyncAdmissions(peer?: string): void {
-		const reservations =
-			peer == null
-				? this.pendingSyncAdmissionReservations
-				: this.pendingSyncAdmissionReservationsByPeer.get(peer);
-		if (!reservations) {
-			return;
-		}
-		for (const reservation of [...reservations]) {
-			this.invalidatePendingSyncAdmission(reservation);
-		}
-	}
-
-	private swapPendingSyncExpiry(left: number, right: number): void {
-		const leftNode = this.pendingSyncExpiryHeap[left]!;
-		const rightNode = this.pendingSyncExpiryHeap[right]!;
-		this.pendingSyncExpiryHeap[left] = rightNode;
-		this.pendingSyncExpiryHeap[right] = leftNode;
-		rightNode.heapIndex = left;
-		leftNode.heapIndex = right;
-	}
-
-	private pushPendingSyncExpiry(node: PendingSyncExpiryNode): void {
-		node.heapIndex = this.pendingSyncExpiryHeap.length;
-		this.pendingSyncExpiryHeap.push(node);
-		let index = node.heapIndex;
-		while (index > 0) {
-			const parent = Math.floor((index - 1) / 2);
-			if (
-				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
-				this.pendingSyncExpiryHeap[index]!.expiresAt
-			) {
-				break;
-			}
-			this.swapPendingSyncExpiry(parent, index);
-			index = parent;
-		}
-	}
-
-	private removePendingSyncExpiry(node: PendingSyncExpiryNode): void {
-		const index = node.heapIndex;
-		if (
-			index < 0 ||
-			index >= this.pendingSyncExpiryHeap.length ||
-			this.pendingSyncExpiryHeap[index] !== node
-		) {
-			return;
-		}
-		const last = this.pendingSyncExpiryHeap.pop()!;
-		node.heapIndex = -1;
-		if (index >= this.pendingSyncExpiryHeap.length) {
-			return;
-		}
-		this.pendingSyncExpiryHeap[index] = last;
-		last.heapIndex = index;
-
-		let current = index;
-		while (current > 0) {
-			const parent = Math.floor((current - 1) / 2);
-			if (
-				this.pendingSyncExpiryHeap[parent]!.expiresAt <=
-				this.pendingSyncExpiryHeap[current]!.expiresAt
-			) {
-				break;
-			}
-			this.swapPendingSyncExpiry(parent, current);
-			current = parent;
-		}
-		for (;;) {
-			const left = current * 2 + 1;
-			const right = left + 1;
-			let smallest = current;
-			if (
-				left < this.pendingSyncExpiryHeap.length &&
-				this.pendingSyncExpiryHeap[left]!.expiresAt <
-					this.pendingSyncExpiryHeap[smallest]!.expiresAt
-			) {
-				smallest = left;
-			}
-			if (
-				right < this.pendingSyncExpiryHeap.length &&
-				this.pendingSyncExpiryHeap[right]!.expiresAt <
-					this.pendingSyncExpiryHeap[smallest]!.expiresAt
-			) {
-				smallest = right;
-			}
-			if (smallest === current) {
-				break;
-			}
-			this.swapPendingSyncExpiry(current, smallest);
-			current = smallest;
-		}
-	}
-
-	private removePendingSyncKeyExpiry(key: SyncableKey): void {
-		const node = this.pendingSyncKeyExpiryNodes.get(key);
-		if (!node) {
-			return;
-		}
-		this.pendingSyncKeyExpiryNodes.delete(key);
-		this.removePendingSyncExpiry(node);
+		this.pendingSync.clearPendingSyncAdmissions(peer);
 	}
 
 	private movePendingSyncKeyExpiryEarlier(
 		key: SyncableKey,
 		expiresAt: number,
 	): void {
-		const current = this.syncInFlightQueueExpiresAt.get(key);
-		if (current == null || current <= expiresAt) {
-			return;
-		}
-		this.removePendingSyncKeyExpiry(key);
-		this.syncInFlightQueueExpiresAt.set(key, expiresAt);
-		const node: PendingSyncExpiryNode = {
-			kind: "key",
-			key,
-			expiresAt,
-			heapIndex: -1,
-		};
-		this.pendingSyncKeyExpiryNodes.set(key, node);
-		this.pushPendingSyncExpiry(node);
-		this.schedulePendingSyncKeyExpiry();
-	}
-
-	private removePendingSyncAdmissionExpiry(
-		reservation: PendingSyncAdmissionReservation,
-	): void {
-		const node = this.pendingSyncAdmissionExpiryNodes.get(reservation);
-		if (!node) {
-			return;
-		}
-		this.pendingSyncAdmissionExpiryNodes.delete(reservation);
-		this.removePendingSyncExpiry(node);
+		this.pendingSync.movePendingSyncKeyExpiryEarlier(key, expiresAt);
 	}
 
 	private expirePendingSyncKeys(now = Date.now()): void {
-		for (;;) {
-			const node = this.pendingSyncExpiryHeap[0];
-			if (!node || node.expiresAt > now) {
-				break;
-			}
-			this.removePendingSyncExpiry(node);
-			if (node.kind === "key") {
-				if (this.pendingSyncKeyExpiryNodes.get(node.key) !== node) {
-					continue;
-				}
-				this.pendingSyncKeyExpiryNodes.delete(node.key);
-				this.clearSyncProcessKey(node.key);
-			} else {
-				if (
-					this.pendingSyncAdmissionExpiryNodes.get(node.reservation) !== node
-				) {
-					continue;
-				}
-				this.pendingSyncAdmissionExpiryNodes.delete(node.reservation);
-				this.invalidatePendingSyncAdmission(node.reservation);
-			}
-		}
+		this.pendingSync.expirePendingSyncKeys(now);
 	}
 
 	private clearPendingSyncExpiryTimerIfIdle(): void {
-		if (
-			this.pendingSyncExpiryHeap.length === 0 &&
-			this.syncInFlightQueueExpiryTimer != null
-		) {
-			clearTimeout(this.syncInFlightQueueExpiryTimer);
-			this.syncInFlightQueueExpiryTimer = undefined;
-		}
-	}
-
-	private schedulePendingSyncKeyExpiry(): void {
-		if (
-			this.syncInFlightQueueExpiryTimer != null ||
-			this.pendingSyncExpiryHeap.length === 0
-		) {
-			return;
-		}
-		const expiresAt = this.pendingSyncExpiryHeap[0]!.expiresAt;
-		this.syncInFlightQueueExpiryTimer = setTimeout(
-			() => {
-				this.syncInFlightQueueExpiryTimer = undefined;
-				this.expirePendingSyncKeys();
-				this.schedulePendingSyncKeyExpiry();
-			},
-			Math.max(0, expiresAt - Date.now()),
-		);
-		this.syncInFlightQueueExpiryTimer.unref?.();
+		this.pendingSync.clearPendingSyncExpiryTimerIfIdle();
 	}
 
 	async queueSync(
@@ -4286,8 +3664,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						}
 
 						const cursor =
-							(this.syncInFlightQueueRoundRobinCursor.get(key) ?? 0) %
-							value.length;
+							this.pendingSync.getRoundRobinCursor(key) % value.length;
 						const candidate = value[cursor]!;
 						const publicKeyHash = candidate.hashcode();
 						const inflightTimestamp = this.syncInFlight
@@ -4308,7 +3685,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 							}
 							request.hashes.push(key);
 							if (value.length > 1) {
-								this.syncInFlightQueueRoundRobinCursor.set(
+								this.pendingSync.setRoundRobinCursor(
 									key,
 									(cursor + 1) % value.length,
 								);
@@ -4384,28 +3761,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.syncDispatchLifecycleController.abort();
 		this.syncDispatchTargetEpochs.clear();
 		this.clearPendingSyncAdmissions();
-		this.syncInFlightQueue.clear();
-		this.syncInFlightQueueInverted.clear();
 		this.syncInFlightRetryIterator = undefined;
 		this.syncInFlightRetryRemaining = 0;
-		this.syncInFlightQueueExpiresAt.clear();
-		this.pendingSyncExpiryHeap.length = 0;
-		this.pendingSyncKeyExpiryNodes.clear();
-		this.pendingSyncAdmissionExpiryNodes.clear();
-		this.syncInFlightQueueClaimants.clear();
-		this.syncInFlightQueueClaimantIndexes.clear();
-		this.syncInFlightQueueRoundRobinCursor.clear();
-		this.syncInFlightQueuedCoordinates.clear();
-		this.syncInFlightQueuedHashByCoordinate.clear();
-		this.syncInFlightQueuedCoordinatesByHash.clear();
-		this.syncInFlightQueuedCoordinateRefreshIterator = undefined;
-		this.pendingSyncClaimCount = 0;
-		if (this.syncInFlightQueueExpiryTimer != null) {
-			clearTimeout(this.syncInFlightQueueExpiryTimer);
-			this.syncInFlightQueueExpiryTimer = undefined;
-		}
-		this.syncInFlight.clear();
-		this.syncInFlightTargetsByKey.clear();
+		this.pendingSync.clearForClose();
 		this.recentlySentExchangeHeads.clear();
 		this.clearPendingMaybeSyncResponses();
 		for (const sessionId of [...this.repairSessions.keys()]) {
@@ -4456,127 +3814,19 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	}
 
 	private hasSyncProcessState(): boolean {
-		return (
-			this.syncInFlightQueue.size > 0 ||
-			this.syncInFlightQueueInverted.size > 0 ||
-			this.pendingSyncAdmissionCount > 0 ||
-			this.syncInFlight.size > 0
-		);
+		return this.pendingSync.hasSyncProcessState();
 	}
 
 	private clearSyncProcessKey(key: SyncableKey) {
-		const inflight = this.syncInFlightQueue.get(key);
-		if (inflight) {
-			for (const peer of inflight) {
-				const map = this.syncInFlightQueueInverted.get(peer.hashcode());
-				if (map) {
-					map.delete(key);
-					if (map.size === 0) {
-						this.syncInFlightQueueInverted.delete(peer.hashcode());
-					}
-				}
-			}
-
-			const trackedClaimants = this.syncInFlightQueueClaimants.get(key);
-			this.pendingSyncClaimCount = Math.max(
-				0,
-				this.pendingSyncClaimCount -
-					(trackedClaimants?.size ?? inflight.length),
-			);
-			this.syncInFlightQueue.delete(key);
-		}
-		this.syncInFlightQueueClaimants.delete(key);
-		this.syncInFlightQueueClaimantIndexes.delete(key);
-		this.syncInFlightQueueRoundRobinCursor.delete(key);
-		if (typeof key === "bigint") {
-			this.removeQueuedSyncCoordinateAlias(key);
-		}
-		this.removePendingSyncKeyExpiry(key);
-		this.syncInFlightQueueExpiresAt.delete(key);
-		this.clearPendingSyncExpiryTimerIfIdle();
-
-		this.clearSyncInFlightKey(key);
+		this.pendingSync.clearSyncProcessKey(key);
 	}
 
 	private removePendingSyncClaim(key: SyncableKey, peer: string): void {
-		const inflight = this.syncInFlightQueue.get(key);
-		if (!inflight) {
-			return;
-		}
-		let claimants = this.syncInFlightQueueClaimants.get(key);
-		let claimantIndexes = this.syncInFlightQueueClaimantIndexes.get(key);
-		if (!claimants || !claimantIndexes) {
-			claimants = new Set();
-			claimantIndexes = new Map();
-			for (let index = 0; index < inflight.length; index += 1) {
-				const claimant = inflight[index]!.hashcode();
-				claimants.add(claimant);
-				claimantIndexes.set(claimant, index);
-			}
-			if (!this.syncInFlightQueueClaimants.has(key)) {
-				this.pendingSyncClaimCount += claimants.size;
-			}
-			this.syncInFlightQueueClaimants.set(key, claimants);
-			this.syncInFlightQueueClaimantIndexes.set(key, claimantIndexes);
-		}
-		const index = claimantIndexes.get(peer);
-		if (index == null) {
-			return;
-		}
-
-		const lastIndex = inflight.length - 1;
-		if (index !== lastIndex) {
-			const lastClaimant = inflight[lastIndex]!;
-			const lastClaimantHash = lastClaimant.hashcode();
-			inflight[index] = lastClaimant;
-			claimantIndexes.set(lastClaimantHash, index);
-		}
-		inflight.pop();
-		claimantIndexes.delete(peer);
-		claimants.delete(peer);
-		this.pendingSyncClaimCount = Math.max(0, this.pendingSyncClaimCount - 1);
-		const inverted = this.syncInFlightQueueInverted.get(peer);
-		inverted?.delete(key);
-		if (inverted?.size === 0) {
-			this.syncInFlightQueueInverted.delete(peer);
-		}
-		if (inflight.length > 0) {
-			const cursor = this.syncInFlightQueueRoundRobinCursor.get(key) ?? 0;
-			this.syncInFlightQueueRoundRobinCursor.set(
-				key,
-				cursor === lastIndex
-					? index % inflight.length
-					: cursor % inflight.length,
-			);
-			return;
-		}
-
-		this.syncInFlightQueue.delete(key);
-		this.syncInFlightQueueClaimants.delete(key);
-		this.syncInFlightQueueClaimantIndexes.delete(key);
-		this.syncInFlightQueueRoundRobinCursor.delete(key);
-		if (typeof key === "bigint") {
-			this.removeQueuedSyncCoordinateAlias(key);
-		}
-		this.removePendingSyncKeyExpiry(key);
-		this.syncInFlightQueueExpiresAt.delete(key);
-		this.clearSyncInFlightKey(key);
-		this.clearPendingSyncExpiryTimerIfIdle();
+		this.pendingSync.removePendingSyncClaim(key, peer);
 	}
 
 	private removeSyncInFlightTargetKey(peer: string, key: SyncableKey): void {
-		const map = this.syncInFlight.get(peer);
-		if (!map?.delete(key)) {
-			return;
-		}
-		if (map.size === 0) {
-			this.syncInFlight.delete(peer);
-		}
-		const targets = this.syncInFlightTargetsByKey.get(key);
-		targets?.delete(peer);
-		if (targets?.size === 0) {
-			this.syncInFlightTargetsByKey.delete(key);
-		}
+		this.pendingSync.removeSyncInFlightTargetKey(peer, key);
 	}
 
 	private setSyncInFlightTargetKey(
@@ -4584,111 +3834,26 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		key: SyncableKey,
 		timestamp: number,
 	): void {
-		let map = this.syncInFlight.get(peer);
-		if (!map) {
-			map = new Map();
-			this.syncInFlight.set(peer, map);
-		}
-		const existing = map.get(key);
-		if (!existing || existing.timestamp < timestamp) {
-			map.set(key, { timestamp });
-		}
-		let targets = this.syncInFlightTargetsByKey.get(key);
-		if (!targets) {
-			targets = new Set();
-			this.syncInFlightTargetsByKey.set(key, targets);
-		}
-		targets.add(peer);
+		this.pendingSync.setSyncInFlightTargetKey(peer, key, timestamp);
 	}
 
 	private clearSyncInFlightTarget(peer: string): void {
-		const map = this.syncInFlight.get(peer);
-		if (!map) {
-			return;
-		}
-		for (const key of map.keys()) {
-			const targets = this.syncInFlightTargetsByKey.get(key);
-			targets?.delete(peer);
-			if (targets?.size === 0) {
-				this.syncInFlightTargetsByKey.delete(key);
-			}
-		}
-		this.syncInFlight.delete(peer);
-	}
-
-	private clearSyncInFlightKey(key: SyncableKey) {
-		const targets = this.syncInFlightTargetsByKey.get(key);
-		if (!targets) {
-			// Defensive compatibility for tests or integrations that seed the public
-			// syncInFlight map directly. Internal writes always populate the index.
-			for (const [peer, map] of this.syncInFlight) {
-				if (map.has(key)) {
-					this.removeSyncInFlightTargetKey(peer, key);
-				}
-			}
-			return;
-		}
-		for (const peer of [...targets]) {
-			this.removeSyncInFlightTargetKey(peer, key);
-		}
-	}
-
-	private forEachKnownAlias(
-		hash: string,
-		callback: (key: SyncableKey) => void,
-	): void {
-		callback(hash);
-		for (const coordinate of [
-			...(this.syncInFlightQueuedCoordinatesByHash.get(hash) ?? []),
-		]) {
-			callback(coordinate);
-		}
-	}
-
-	private clearSyncInFlightForPeer(publicKeyHash: string, hash: string) {
-		const map = this.syncInFlight.get(publicKeyHash);
-		if (!map) {
-			return;
-		}
-		this.refreshQueuedSyncCoordinateAliases();
-		this.forEachKnownAlias(hash, (key) =>
-			this.removeSyncInFlightTargetKey(publicKeyHash, key),
-		);
+		this.pendingSync.clearSyncInFlightTarget(peer);
 	}
 
 	private clearSyncInFlightForPeerHashes(
 		publicKeyHash: string,
 		hashes: string[],
 	) {
-		const map = this.syncInFlight.get(publicKeyHash);
-		if (!map || hashes.length === 0) {
-			return;
-		}
-		this.refreshQueuedSyncCoordinateAliases();
-		for (const hash of hashes) {
-			this.forEachKnownAlias(hash, (key) =>
-				this.removeSyncInFlightTargetKey(publicKeyHash, key),
-			);
-		}
+		this.pendingSync.clearSyncInFlightForPeerHashes(publicKeyHash, hashes);
 	}
 
 	private clearSyncProcess(hash: string) {
-		this.refreshQueuedSyncCoordinateAliases();
-		this.forEachKnownAlias(hash, (key) => this.clearSyncProcessKey(key));
+		this.pendingSync.clearSyncProcess(hash);
 	}
 
 	private clearSyncProcesses(hashes: string[]) {
-		if (hashes.length === 0) {
-			return;
-		}
-		this.refreshQueuedSyncCoordinateAliases();
-		const keys = new Set<SyncableKey>();
-		for (const hash of hashes) {
-			this.forEachKnownAlias(hash, (key) => keys.add(key));
-		}
-		for (const key of keys) {
-			this.clearSyncProcessKey(key);
-		}
+		this.pendingSync.clearSyncProcesses(hashes);
 	}
 
 	onPeerDisconnected(key: PublicSignKey | string): Promise<void> | void {
@@ -4716,13 +3881,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.clearSyncInFlightTarget(publicKeyHash);
 		this.recentlySentExchangeHeads.delete(publicKeyHash);
 		this.clearPendingMaybeSyncResponses(publicKeyHash);
-		const map = this.syncInFlightQueueInverted.get(publicKeyHash);
-		if (map) {
-			for (const hash of [...map]) {
-				this.removePendingSyncClaim(hash, publicKeyHash);
-			}
-			this.syncInFlightQueueInverted.delete(publicKeyHash);
-		}
+		this.pendingSync.removeClaimsForPeer(publicKeyHash);
 		// Storage lookups and response ships for this peer may never settle
 		// (the resolvers are not universally abortable). Detach the slot row so
 		// the peer's quota returns immediately; the captured closures settle

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -438,6 +438,21 @@ export type AuthorizedMaybeSyncResponseLease = {
 	release: (options?: { fulfilled?: boolean }) => void;
 };
 
+// Per-peer slot accounting for coordinate lookups, coordinate responses and
+// active maybe-sync responses. The underlying storage resolvers are not
+// universally abortable, so a release closure may settle long after the peer
+// disconnected (or never). Release closures capture the row object: once a
+// disconnect or close() detaches the row, the peer's slots return to the
+// aggregate quota immediately, and a late release only settles the detached
+// row — it never touches a reconnected successor's quota or the globals.
+type SyncResponseSlotRow = {
+	peer: string;
+	attached: boolean;
+	lookups: number;
+	responses: number;
+	active: number;
+};
+
 type SyncDispatchLifecycle = {
 	ownershipLifecycleController: AbortController;
 	callerSignal?: AbortSignal;
@@ -541,6 +556,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	private pendingCoordinateLookupCountByPeer: Map<string, number>;
 	private pendingCoordinateResponseCount: number;
 	private pendingCoordinateResponseCountByPeer: Map<string, number>;
+	private syncResponseSlotRows: Map<string, SyncResponseSlotRow>;
 
 	// map of hash to public keys that we have asked for entries
 	syncInFlight!: Map<string, Map<SyncableKey, { timestamp: number }>>;
@@ -630,6 +646,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.pendingCoordinateLookupCountByPeer = new Map();
 		this.pendingCoordinateResponseCount = 0;
 		this.pendingCoordinateResponseCountByPeer = new Map();
+		this.syncResponseSlotRows = new Map();
 		this.syncInFlight = new Map();
 		this.syncInFlightTargetsByKey = new Map();
 		this.rpc = properties.rpc;
@@ -2048,6 +2065,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (acceptedByLifecycle.size === 0) {
 			return [];
 		}
+		const slotRow = this.getOrCreateSyncResponseSlotRow(fromHash);
+		slotRow.active += 1;
 		this.activeMaybeSyncResponseCount += 1;
 		this.activeMaybeSyncResponseCountByPeer.set(
 			fromHash,
@@ -2086,17 +2105,21 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 						targetLifecycle.lifecycle.retainedWork -= 1;
 						remainingLeases -= 1;
 						if (remainingLeases === 0) {
-							this.activeMaybeSyncResponseCount -= 1;
-							const activeForPeer =
-								(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
-								1;
-							if (activeForPeer === 0) {
-								this.activeMaybeSyncResponseCountByPeer.delete(fromHash);
-							} else {
-								this.activeMaybeSyncResponseCountByPeer.set(
-									fromHash,
-									activeForPeer,
-								);
+							slotRow.active -= 1;
+							if (slotRow.attached) {
+								this.activeMaybeSyncResponseCount -= 1;
+								const activeForPeer =
+									(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
+									1;
+								if (activeForPeer === 0) {
+									this.activeMaybeSyncResponseCountByPeer.delete(fromHash);
+								} else {
+									this.activeMaybeSyncResponseCountByPeer.set(
+										fromHash,
+										activeForPeer,
+									);
+								}
+								this.maybeDropIdleSyncResponseSlotRow(slotRow);
 							}
 						}
 						this.schedulePendingMaybeSyncResponseWaiter();
@@ -3152,10 +3175,53 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		);
 	}
 
+	private getOrCreateSyncResponseSlotRow(peer: string): SyncResponseSlotRow {
+		let row = this.syncResponseSlotRows.get(peer);
+		if (!row) {
+			row = { peer, attached: true, lookups: 0, responses: 0, active: 0 };
+			this.syncResponseSlotRows.set(peer, row);
+		}
+		return row;
+	}
+
+	private detachSyncResponseSlotRow(peer: string): void {
+		const row = this.syncResponseSlotRows.get(peer);
+		if (!row) {
+			return;
+		}
+		row.attached = false;
+		this.syncResponseSlotRows.delete(peer);
+		if (row.lookups > 0) {
+			this.pendingCoordinateLookupCount -= row.lookups;
+			this.pendingCoordinateLookupCountByPeer.delete(peer);
+		}
+		if (row.responses > 0) {
+			this.pendingCoordinateResponseCount -= row.responses;
+			this.pendingCoordinateResponseCountByPeer.delete(peer);
+		}
+		if (row.active > 0) {
+			this.activeMaybeSyncResponseCount -= row.active;
+			this.activeMaybeSyncResponseCountByPeer.delete(peer);
+		}
+	}
+
+	private maybeDropIdleSyncResponseSlotRow(row: SyncResponseSlotRow): void {
+		if (
+			row.attached &&
+			row.lookups === 0 &&
+			row.responses === 0 &&
+			row.active === 0
+		) {
+			this.syncResponseSlotRows.delete(row.peer);
+		}
+	}
+
 	private tryAcquireCoordinateLookup(peer: string): (() => void) | undefined {
 		if (!this.canStartPendingSyncLookup(peer)) {
 			return undefined;
 		}
+		const row = this.getOrCreateSyncResponseSlotRow(peer);
+		row.lookups += 1;
 		this.pendingCoordinateLookupCount += 1;
 		this.pendingCoordinateLookupCountByPeer.set(
 			peer,
@@ -3167,6 +3233,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				return;
 			}
 			released = true;
+			row.lookups -= 1;
+			if (!row.attached) {
+				// The quota already returned in aggregate when the row detached.
+				return;
+			}
 			this.pendingCoordinateLookupCount -= 1;
 			const remaining =
 				(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 1) - 1;
@@ -3175,6 +3246,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			} else {
 				this.pendingCoordinateLookupCountByPeer.set(peer, remaining);
 			}
+			this.maybeDropIdleSyncResponseSlotRow(row);
 		};
 	}
 
@@ -3187,6 +3259,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		) {
 			return undefined;
 		}
+		const row = this.getOrCreateSyncResponseSlotRow(peer);
+		row.responses += 1;
 		this.pendingCoordinateResponseCount += 1;
 		this.pendingCoordinateResponseCountByPeer.set(
 			peer,
@@ -3198,6 +3272,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				return;
 			}
 			released = true;
+			row.responses -= 1;
+			if (!row.attached) {
+				// The quota already returned in aggregate when the row detached.
+				return;
+			}
 			this.pendingCoordinateResponseCount -= 1;
 			const remaining =
 				(this.pendingCoordinateResponseCountByPeer.get(peer) ?? 1) - 1;
@@ -3206,6 +3285,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			} else {
 				this.pendingCoordinateResponseCountByPeer.set(peer, remaining);
 			}
+			this.maybeDropIdleSyncResponseSlotRow(row);
 		};
 	}
 
@@ -4643,6 +4723,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			}
 			this.syncInFlightQueueInverted.delete(publicKeyHash);
 		}
+		// Storage lookups and response ships for this peer may never settle
+		// (the resolvers are not universally abortable). Detach the slot row so
+		// the peer's quota returns immediately; the captured closures settle
+		// against the detached row without touching a successor's quota.
+		this.detachSyncResponseSlotRow(publicKeyHash);
 	}
 
 	get pending() {

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -20,6 +20,7 @@ import {
 } from "../exchange-heads.js";
 import { TransportMessage } from "../message.js";
 import type { EntryReplicated } from "../ranges.js";
+import { DispatchLifecycleRegistry } from "./dispatch-lifecycle.js";
 import type {
 	HashSymbolHashListResolver,
 	HashSymbolResolver,
@@ -616,7 +617,17 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	private syncDispatchLifecycleController: AbortController;
 	private syncDispatchTargetEpochCounter: number;
 	private syncDispatchTargetEpochs: Map<string, SyncDispatchTargetEpoch>;
-	private syncDispatchTargets: Map<string, Set<SyncDispatchTargetLifecycle>>;
+	private readonly syncDispatchRegistry: DispatchLifecycleRegistry<
+		SyncDispatchLifecycle,
+		SyncDispatchTargetLifecycle
+	>;
+
+	private get syncDispatchTargets(): Map<
+		string,
+		Set<SyncDispatchTargetLifecycle>
+	> {
+		return this.syncDispatchRegistry.activeTargets;
+	}
 	private repairSessionCounter: number;
 	private repairSessions: Map<string, RepairSessionState>;
 
@@ -678,7 +689,24 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.syncDispatchLifecycleController = new AbortController();
 		this.syncDispatchTargetEpochCounter = 0;
 		this.syncDispatchTargetEpochs = new Map();
-		this.syncDispatchTargets = new Map();
+		this.syncDispatchRegistry = new DispatchLifecycleRegistry<
+			SyncDispatchLifecycle,
+			SyncDispatchTargetLifecycle
+		>({
+			isClosed: () => this.closed === true,
+			currentOwnershipLifecycleController: () =>
+				this.syncDispatchLifecycleController,
+			hasRetainedWork: (lifecycle) => lifecycle.retainedWork > 0,
+			// Target-activity strategy: dispatch-epoch identity.
+			isTargetCurrent: (targetLifecycle) =>
+				this.syncDispatchTargetEpochs.get(targetLifecycle.target) ===
+				targetLifecycle.epoch,
+			onTargetAborted: (targetLifecycle) => {
+				for (const batch of [...targetLifecycle.batches]) {
+					this.removePendingMaybeSyncResponseBatch(batch);
+				}
+			},
+		});
 		this.repairSessionCounter = 0;
 		this.repairSessions = new Map();
 	}
@@ -858,60 +886,43 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			abortAllOnTargetDisconnect: options?.abortAllOnTargetDisconnect === true,
 		} satisfies SyncDispatchLifecycle;
 
-		for (const target of [...new Set(targets)]) {
-			const expectedEpoch = options?.targetEpochs?.get(target);
-			const currentEpoch = this.syncDispatchTargetEpochs.get(target);
-			const epoch =
-				expectedEpoch ??
-				currentEpoch ??
-				(options?.createTargetEpochs === false
-					? undefined
-					: this.getOrCreateSyncDispatchTargetEpoch(target));
-			if (!epoch) {
-				continue;
-			}
-			const targetLifecycle: SyncDispatchTargetLifecycle = {
-				lifecycle,
-				target,
-				epoch,
-				controller: new AbortController(),
-				batches: new Set(),
-				responseLeases: 0,
-				activeWaiters: 0,
-			};
-			lifecycle.targets.set(target, targetLifecycle);
-			let activeForTarget = this.syncDispatchTargets.get(target);
-			if (!activeForTarget) {
-				activeForTarget = new Set();
-				this.syncDispatchTargets.set(target, activeForTarget);
-			}
-			activeForTarget.add(targetLifecycle);
-			if (this.syncDispatchTargetEpochs.get(target) !== epoch) {
-				this.abortSyncDispatchTarget(
-					targetLifecycle,
-					new Error("sync target lifecycle is stale"),
-				);
-			}
-		}
-
-		ownershipLifecycleController.signal.addEventListener(
-			"abort",
-			lifecycle.onOwnerOrCallerAbort,
-			{ once: true },
+		this.syncDispatchRegistry.register(
+			lifecycle,
+			targets,
+			(forLifecycle, target) => {
+				const expectedEpoch = options?.targetEpochs?.get(target);
+				const currentEpoch = this.syncDispatchTargetEpochs.get(target);
+				const epoch =
+					expectedEpoch ??
+					currentEpoch ??
+					(options?.createTargetEpochs === false
+						? undefined
+						: this.getOrCreateSyncDispatchTargetEpoch(target));
+				if (!epoch) {
+					return undefined;
+				}
+				return {
+					lifecycle: forLifecycle,
+					target,
+					epoch,
+					controller: new AbortController(),
+					batches: new Set(),
+					responseLeases: 0,
+					activeWaiters: 0,
+				};
+			},
+			(targetLifecycle) => {
+				if (
+					this.syncDispatchTargetEpochs.get(targetLifecycle.target) !==
+					targetLifecycle.epoch
+				) {
+					this.abortSyncDispatchTarget(
+						targetLifecycle,
+						new Error("sync target lifecycle is stale"),
+					);
+				}
+			},
 		);
-		if (callerSignal && callerSignal !== ownershipLifecycleController.signal) {
-			callerSignal.addEventListener("abort", lifecycle.onOwnerOrCallerAbort, {
-				once: true,
-			});
-		}
-		if (
-			this.closed === true ||
-			ownershipLifecycleController !== this.syncDispatchLifecycleController ||
-			ownershipLifecycleController.signal.aborted ||
-			callerSignal?.aborted
-		) {
-			lifecycle.onOwnerOrCallerAbort();
-		}
 		return lifecycle;
 	}
 
@@ -919,102 +930,38 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		targetLifecycle: SyncDispatchTargetLifecycle,
 		reason?: unknown,
 	): void {
-		if (!targetLifecycle.controller.signal.aborted) {
-			targetLifecycle.controller.abort(reason);
-		}
-		for (const batch of [...targetLifecycle.batches]) {
-			this.removePendingMaybeSyncResponseBatch(batch);
-		}
-		this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+		this.syncDispatchRegistry.abortTarget(targetLifecycle, reason);
 	}
 
 	private abortSyncDispatchLifecycle(
 		lifecycle: SyncDispatchLifecycle,
 		reason?: unknown,
 	): void {
-		if (!lifecycle.controller.signal.aborted) {
-			lifecycle.controller.abort(reason);
-		}
-		for (const targetLifecycle of lifecycle.targets.values()) {
-			this.abortSyncDispatchTarget(targetLifecycle, reason);
-		}
-		this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+		this.syncDispatchRegistry.abortLifecycle(lifecycle, reason);
 	}
 
 	private finishSyncDispatchLifecycle(lifecycle: SyncDispatchLifecycle): void {
-		lifecycle.dispatchFinished = true;
-		this.maybeDisposeSyncDispatchLifecycle(lifecycle);
+		this.syncDispatchRegistry.finish(lifecycle);
 	}
 
 	private maybeDisposeSyncDispatchLifecycle(
 		lifecycle: SyncDispatchLifecycle,
 	): void {
-		if (
-			lifecycle.disposed ||
-			!lifecycle.dispatchFinished ||
-			lifecycle.retainedWork > 0
-		) {
-			return;
-		}
-		lifecycle.disposed = true;
-		lifecycle.ownershipLifecycleController.signal.removeEventListener(
-			"abort",
-			lifecycle.onOwnerOrCallerAbort,
-		);
-		if (
-			lifecycle.callerSignal &&
-			lifecycle.callerSignal !== lifecycle.ownershipLifecycleController.signal
-		) {
-			lifecycle.callerSignal.removeEventListener(
-				"abort",
-				lifecycle.onOwnerOrCallerAbort,
-			);
-		}
-		for (const targetLifecycle of lifecycle.targets.values()) {
-			const activeForTarget = this.syncDispatchTargets.get(
-				targetLifecycle.target,
-			);
-			activeForTarget?.delete(targetLifecycle);
-			if (activeForTarget?.size === 0) {
-				this.syncDispatchTargets.delete(targetLifecycle.target);
-			}
-		}
+		this.syncDispatchRegistry.maybeDispose(lifecycle);
 	}
 
 	private isSyncDispatchLifecycleActive(
 		lifecycle: SyncDispatchLifecycle,
 		target?: string,
 	): boolean {
-		if (
-			this.closed === true ||
-			lifecycle.disposed ||
-			lifecycle.ownershipLifecycleController !==
-				this.syncDispatchLifecycleController ||
-			lifecycle.ownershipLifecycleController.signal.aborted ||
-			lifecycle.callerSignal?.aborted ||
-			lifecycle.controller.signal.aborted
-		) {
-			return false;
-		}
-		if (target === undefined) {
-			return true;
-		}
-		const targetLifecycle = lifecycle.targets.get(target);
-		return (
-			targetLifecycle !== undefined &&
-			!targetLifecycle.controller.signal.aborted &&
-			this.syncDispatchTargetEpochs.get(target) === targetLifecycle.epoch
-		);
+		return this.syncDispatchRegistry.isLifecycleActive(lifecycle, target);
 	}
 
 	private getSyncDispatchSignal(
 		lifecycle: SyncDispatchLifecycle,
 		target: string,
 	): AbortSignal {
-		return (
-			lifecycle.targets.get(target)?.controller.signal ??
-			lifecycle.controller.signal
-		);
+		return this.syncDispatchRegistry.getSignal(lifecycle, target);
 	}
 
 	private pendingMaybeSyncResponseWaiterBefore(

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -376,6 +376,12 @@ type PendingMaybeSyncResponseAuthorization = {
 	deliveryInFlight?: boolean;
 	settled?: "fulfilled" | "released";
 	active?: boolean;
+	// Set when consume accepts the authorization: the peer slot row that holds
+	// this authorization's pending-response hash-budget unit whenever
+	// deliveryInFlight !== true (deliveryInFlight custody belongs to
+	// finishDelivery). Row identity, not peer hash: a late settle never
+	// touches a reconnected successor's row.
+	slotRow?: SyncPeerSlotRow;
 };
 
 type PendingMaybeSyncResponseReservation = {
@@ -1663,6 +1669,16 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				beginDelivery: () => {
 					for (const authorization of addedAuthorizations) {
 						if (!authorization.settled) {
+							if (
+								authorization.deliveryInFlight !== true &&
+								authorization.active === true &&
+								authorization.slotRow?.attached === true
+							) {
+								// The response was accepted before the request send began:
+								// custody of the hash-budget unit moves from the slot row to
+								// finishDelivery for the duration of the send.
+								authorization.slotRow.pendingResponseHashes -= 1;
+							}
 							authorization.deliveryInFlight = true;
 						}
 					}
@@ -1681,6 +1697,14 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 								?.get(authorization.hash) !== authorization
 						) {
 							releasedCount += 1;
+						} else if (
+							authorization.active === true &&
+							authorization.slotRow?.attached === true
+						) {
+							// The response was accepted while the request send was in
+							// flight; custody of the hash-budget unit returns to the
+							// active lease's slot row.
+							authorization.slotRow.pendingResponseHashes += 1;
 						}
 					}
 					if (releasedCount > 0) {
@@ -2021,59 +2045,80 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			fromHash,
 			(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 0) + 1,
 		);
+		// Accepted authorizations leave their batch (above) but stay charged
+		// against the global hash budget. Move that charge into row custody so a
+		// disconnect can return it even when the response ship never settles;
+		// units currently owned by finishDelivery (deliveryInFlight) stay out.
+		for (const { authorizations } of acceptedByLifecycle.values()) {
+			for (const authorization of authorizations) {
+				authorization.slotRow = slotRow;
+				if (authorization.deliveryInFlight !== true) {
+					slotRow.pendingResponseHashes += 1;
+				}
+			}
+		}
 		let remainingLeases = acceptedByLifecycle.size;
 		return [...acceptedByLifecycle].map(
 			([targetLifecycle, { hashes: acceptedHashes, authorizations }]) => {
 				let released = false;
+				const release = (options?: { fulfilled?: boolean }) => {
+					if (released) {
+						return;
+					}
+					released = true;
+					slotRow.activeReleases.delete(release);
+					const pendingForTarget = this.pendingMaybeSyncResponses.get(fromHash);
+					for (const authorization of authorizations) {
+						this.settlePendingMaybeSyncResponseAuthorization(
+							authorization,
+							options?.fulfilled === true,
+						);
+						if (pendingForTarget?.get(authorization.hash) === authorization) {
+							pendingForTarget.delete(authorization.hash);
+						}
+					}
+					if (pendingForTarget?.size === 0) {
+						this.pendingMaybeSyncResponses.delete(fromHash);
+					}
+					const chargedToRow = authorizations.filter(
+						(authorization) => authorization.deliveryInFlight !== true,
+					).length;
+					if (slotRow.attached) {
+						this.pendingMaybeSyncResponseCount -= chargedToRow;
+						slotRow.pendingResponseHashes -= chargedToRow;
+					}
+					// else: the hash budget already returned in aggregate when the row
+					// detached; only the deliveryInFlight units (owned by
+					// finishDelivery) remain charged.
+					targetLifecycle.responseLeases -= 1;
+					targetLifecycle.lifecycle.retainedWork -= 1;
+					remainingLeases -= 1;
+					if (remainingLeases === 0) {
+						slotRow.active -= 1;
+						if (slotRow.attached) {
+							this.activeMaybeSyncResponseCount -= 1;
+							const activeForPeer =
+								(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
+								1;
+							if (activeForPeer === 0) {
+								this.activeMaybeSyncResponseCountByPeer.delete(fromHash);
+							} else {
+								this.activeMaybeSyncResponseCountByPeer.set(
+									fromHash,
+									activeForPeer,
+								);
+							}
+							this.maybeDropIdleSyncResponseSlotRow(slotRow);
+						}
+					}
+					this.schedulePendingMaybeSyncResponseWaiter();
+					this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+				};
+				slotRow.activeReleases.add(release);
 				return {
 					hashes: acceptedHashes,
 					signal: targetLifecycle.controller.signal,
-					release: (options?: { fulfilled?: boolean }) => {
-						if (released) {
-							return;
-						}
-						released = true;
-						const pendingForTarget =
-							this.pendingMaybeSyncResponses.get(fromHash);
-						for (const authorization of authorizations) {
-							this.settlePendingMaybeSyncResponseAuthorization(
-								authorization,
-								options?.fulfilled === true,
-							);
-							if (pendingForTarget?.get(authorization.hash) === authorization) {
-								pendingForTarget.delete(authorization.hash);
-							}
-						}
-						if (pendingForTarget?.size === 0) {
-							this.pendingMaybeSyncResponses.delete(fromHash);
-						}
-						this.pendingMaybeSyncResponseCount -= authorizations.filter(
-							(authorization) => authorization.deliveryInFlight !== true,
-						).length;
-						targetLifecycle.responseLeases -= 1;
-						targetLifecycle.lifecycle.retainedWork -= 1;
-						remainingLeases -= 1;
-						if (remainingLeases === 0) {
-							slotRow.active -= 1;
-							if (slotRow.attached) {
-								this.activeMaybeSyncResponseCount -= 1;
-								const activeForPeer =
-									(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
-									1;
-								if (activeForPeer === 0) {
-									this.activeMaybeSyncResponseCountByPeer.delete(fromHash);
-								} else {
-									this.activeMaybeSyncResponseCountByPeer.set(
-										fromHash,
-										activeForPeer,
-									);
-								}
-								this.maybeDropIdleSyncResponseSlotRow(slotRow);
-							}
-						}
-						this.schedulePendingMaybeSyncResponseWaiter();
-						this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
-					},
+					release,
 				};
 			},
 		);
@@ -2884,6 +2929,23 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (row.active > 0) {
 			this.activeMaybeSyncResponseCount -= row.active;
 			this.activeMaybeSyncResponseCountByPeer.delete(peer);
+		}
+		if (row.pendingResponseHashes > 0) {
+			// Active authorizations' hash budget returns in aggregate with the
+			// row. The settled releases below (and any late ship-side release)
+			// see the detached row and skip the global budget.
+			this.pendingMaybeSyncResponseCount -= row.pendingResponseHashes;
+			row.pendingResponseHashes = 0;
+			this.schedulePendingMaybeSyncResponseWaiter();
+		}
+		// Counters are settled; now settle the outstanding active-response
+		// leases so their authorizations leave pendingMaybeSyncResponses and
+		// responseLeases/retainedWork drain, letting the dispatch lifecycle
+		// dispose. The released-guard makes the eventual ship-side release
+		// inert, and the closures captured THIS row (identity, not peer hash),
+		// so a reconnected successor's row is never touched.
+		for (const release of [...row.activeReleases]) {
+			release();
 		}
 	}
 

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -38,6 +38,10 @@ import {
 	QUEUED_SYNC_ALIAS_REFRESH_PENDING,
 } from "./pending-sync-store.js";
 import { emitSyncProfileDuration, syncProfileStart } from "./profile.js";
+import {
+	SyncPeerSlotRegistry,
+	type SyncPeerSlotRow,
+} from "./sync-peer-state.js";
 
 @variant([0, 1])
 export class RequestMaybeSync extends TransportMessage {
@@ -413,21 +417,6 @@ export type AuthorizedMaybeSyncResponseLease = {
 	release: (options?: { fulfilled?: boolean }) => void;
 };
 
-// Per-peer slot accounting for coordinate lookups, coordinate responses and
-// active maybe-sync responses. The underlying storage resolvers are not
-// universally abortable, so a release closure may settle long after the peer
-// disconnected (or never). Release closures capture the row object: once a
-// disconnect or close() detaches the row, the peer's slots return to the
-// aggregate quota immediately, and a late release only settles the detached
-// row — it never touches a reconnected successor's quota or the globals.
-type SyncResponseSlotRow = {
-	peer: string;
-	attached: boolean;
-	lookups: number;
-	responses: number;
-	active: number;
-};
-
 type SyncDispatchLifecycle = {
 	ownershipLifecycleController: AbortController;
 	callerSignal?: AbortSignal;
@@ -501,7 +490,17 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 	private pendingCoordinateLookupCountByPeer: Map<string, number>;
 	private pendingCoordinateResponseCount: number;
 	private pendingCoordinateResponseCountByPeer: Map<string, number>;
-	private syncResponseSlotRows: Map<string, SyncResponseSlotRow>;
+	// Per-peer slot rows for coordinate lookups, coordinate responses and
+	// active maybe-sync responses (shared registry; see sync-peer-state.ts
+	// for the lifetime policy). Release closures capture the row object:
+	// once a disconnect detaches the row, the peer's slots return to the
+	// aggregate quota immediately, and a late release only settles the
+	// detached row — it never touches a reconnected successor's quota.
+	private readonly peerSlotRows: SyncPeerSlotRegistry;
+
+	private get syncResponseSlotRows(): Map<string, SyncPeerSlotRow> {
+		return this.peerSlotRows.rows;
+	}
 
 	// map of hash to public keys that we can ask for entries
 	get syncInFlightQueue(): Map<SyncableKey, PublicSignKey[]> {
@@ -651,7 +650,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.pendingCoordinateLookupCountByPeer = new Map();
 		this.pendingCoordinateResponseCount = 0;
 		this.pendingCoordinateResponseCountByPeer = new Map();
-		this.syncResponseSlotRows = new Map();
+		this.peerSlotRows = new SyncPeerSlotRegistry();
 		this.rpc = properties.rpc;
 		this.log = properties.log;
 		this.entryIndex = properties.entryIndex;
@@ -2918,22 +2917,15 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		);
 	}
 
-	private getOrCreateSyncResponseSlotRow(peer: string): SyncResponseSlotRow {
-		let row = this.syncResponseSlotRows.get(peer);
-		if (!row) {
-			row = { peer, attached: true, lookups: 0, responses: 0, active: 0 };
-			this.syncResponseSlotRows.set(peer, row);
-		}
-		return row;
+	private getOrCreateSyncResponseSlotRow(peer: string): SyncPeerSlotRow {
+		return this.peerSlotRows.ensure(peer);
 	}
 
 	private detachSyncResponseSlotRow(peer: string): void {
-		const row = this.syncResponseSlotRows.get(peer);
+		const row = this.peerSlotRows.detach(peer);
 		if (!row) {
 			return;
 		}
-		row.attached = false;
-		this.syncResponseSlotRows.delete(peer);
 		if (row.lookups > 0) {
 			this.pendingCoordinateLookupCount -= row.lookups;
 			this.pendingCoordinateLookupCountByPeer.delete(peer);
@@ -2948,15 +2940,8 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		}
 	}
 
-	private maybeDropIdleSyncResponseSlotRow(row: SyncResponseSlotRow): void {
-		if (
-			row.attached &&
-			row.lookups === 0 &&
-			row.responses === 0 &&
-			row.active === 0
-		) {
-			this.syncResponseSlotRows.delete(row.peer);
-		}
+	private maybeDropIdleSyncResponseSlotRow(row: SyncPeerSlotRow): void {
+		this.peerSlotRows.maybeDropIdle(row);
 	}
 
 	private tryAcquireCoordinateLookup(peer: string): (() => void) | undefined {

--- a/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
+++ b/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
@@ -14,6 +14,15 @@
 // |                              |                    | in aggregate; late         |
 // |                              |                    | releases settle against    |
 // |                              |                    | the detached row)          |
+// | pendingResponseHashes        | consume accepts an | lease release settles      |
+// | (simple synchronizer only)   | authorization      | while attached; row        |
+// |                              | (custody moves     | DETACHES at peer           |
+// |                              | batch -> row)      | disconnect (budget returns |
+// |                              |                    | in aggregate)              |
+// | activeReleases               | consume creates an | release settles (self-     |
+// | (simple synchronizer only)   | active-response    | removal); detach invokes   |
+// |                              | lease              | the outstanding releases   |
+// |                              |                    | so retained work drains    |
 //
 // Slot accounting deliberately SURVIVES close()/open() generation rotation
 // on both synchronizers: the underlying storage resolvers and transport
@@ -32,6 +41,18 @@ export type SyncPeerSlotRow = {
 	lookups: number;
 	responses: number;
 	active: number;
+	// Portion of the simple synchronizer's global pending-response hash budget
+	// held by this peer's ACTIVE (consumed) authorizations. Batch-resident
+	// hashes stay charged against the batch; consume moves custody here so a
+	// disconnect can return the budget even when the response ship never
+	// settles. Always 0 on rateless rows.
+	pendingResponseHashes: number;
+	// Outstanding active-response lease releases (simple synchronizer only).
+	// Releases self-remove when the ship settles; detach invokes the
+	// remainder so responseLeases/retainedWork drain and the dispatch
+	// lifecycle can dispose — the released-guard makes the eventual late
+	// ship-side release inert. Always empty on rateless rows.
+	activeReleases: Set<() => void>;
 };
 
 export class SyncPeerSlotRegistry {
@@ -40,7 +61,15 @@ export class SyncPeerSlotRegistry {
 	ensure(peer: string): SyncPeerSlotRow {
 		let row = this.rows.get(peer);
 		if (!row) {
-			row = { peer, attached: true, lookups: 0, responses: 0, active: 0 };
+			row = {
+				peer,
+				attached: true,
+				lookups: 0,
+				responses: 0,
+				active: 0,
+				pendingResponseHashes: 0,
+				activeReleases: new Set(),
+			};
 			this.rows.set(peer, row);
 		}
 		return row;
@@ -67,7 +96,9 @@ export class SyncPeerSlotRegistry {
 			row.attached &&
 			row.lookups === 0 &&
 			row.responses === 0 &&
-			row.active === 0
+			row.active === 0 &&
+			row.pendingResponseHashes === 0 &&
+			row.activeReleases.size === 0
 		) {
 			this.rows.delete(row.peer);
 		}

--- a/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
+++ b/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
@@ -1,0 +1,75 @@
+// Per-peer sync slot state shared by the simple and rateless synchronizers
+// (stage-4 sync unification). One row per peer carries the response/lookup
+// slot accounting whose release closures may settle long after the peer is
+// gone; both synchronizers use the same registry and the same
+// capture-the-row identity pattern.
+//
+// Per-field lifetime policy (review this table when adding fields):
+//
+// | field                        | created            | cleared                    |
+// |------------------------------|--------------------|----------------------------|
+// | lookups / responses / active | first slot acquire | release closure settles;   |
+// |                              |                    | row DETACHES at peer       |
+// |                              |                    | disconnect (quota returns  |
+// |                              |                    | in aggregate; late         |
+// |                              |                    | releases settle against    |
+// |                              |                    | the detached row)          |
+//
+// Slot accounting deliberately SURVIVES close()/open() generation rotation
+// on both synchronizers: the underlying storage resolvers and transport
+// sends are not universally abortable, so cross-generation work stays
+// charged until it settles. Only a peer disconnect detaches a row.
+//
+// Deliberately host-side this stage (stage-5 folds them into the host peer
+// sessions): dispatch epochs and dispatch-target sets (benchmark-gated hot
+// path), pending-claim rows (owned by the pending-sync record store),
+// admission per-peer indexes (owned by the record store's reservation
+// objects) and the recently-sent exchange-head dedupe rows.
+
+export type SyncPeerSlotRow = {
+	peer: string;
+	attached: boolean;
+	lookups: number;
+	responses: number;
+	active: number;
+};
+
+export class SyncPeerSlotRegistry {
+	readonly rows = new Map<string, SyncPeerSlotRow>();
+
+	ensure(peer: string): SyncPeerSlotRow {
+		let row = this.rows.get(peer);
+		if (!row) {
+			row = { peer, attached: true, lookups: 0, responses: 0, active: 0 };
+			this.rows.set(peer, row);
+		}
+		return row;
+	}
+
+	// Detaches and returns the peer's row (or undefined when the peer holds
+	// no slots). The caller subtracts the returned counters from its
+	// aggregate quota; release closures that still hold the row settle
+	// against it aggregate-neutrally.
+	detach(peer: string): SyncPeerSlotRow | undefined {
+		const row = this.rows.get(peer);
+		if (!row) {
+			return undefined;
+		}
+		row.attached = false;
+		this.rows.delete(peer);
+		return row;
+	}
+
+	// Rows whose slots all settled while attached are dropped eagerly so the
+	// registry never accumulates idle peers between disconnects.
+	maybeDropIdle(row: SyncPeerSlotRow): void {
+		if (
+			row.attached &&
+			row.lookups === 0 &&
+			row.responses === 0 &&
+			row.active === 0
+		) {
+			this.rows.delete(row.peer);
+		}
+	}
+}

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -2680,7 +2680,7 @@ describe("sync-chunking", () => {
 		}
 	});
 
-	it("retains coordinate lookup permits across disconnect until work settles", async () => {
+	it("returns coordinate lookup permits when their peer disconnects", async () => {
 		const releases: ((hashes: string[]) => void)[] = [];
 		const resolveHashListForSymbols = sinon.stub().callsFake(
 			() =>
@@ -2722,23 +2722,20 @@ describe("sync-chunking", () => {
 				new RequestMaybeSyncCoordinate({ hashNumbers: [100n] }),
 				{ from: peerA } as any,
 			);
-			sync.onPeerDisconnected(peerA);
-			await sync.onMessage(
-				new RequestMaybeSyncCoordinate({ hashNumbers: [101n] }),
-				{ from: peerA } as any,
-			);
 			expect(resolveHashListForSymbols.callCount).to.equal(
 				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
 			);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(
-				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
-			);
 
-			releases.shift()!([]);
-			await pending.shift();
+			// Disconnect returns the peer's whole lookup quota immediately even
+			// though the resolver work is still alive; the detached slots settle
+			// aggregate-neutrally later.
+			sync.onPeerDisconnected(peerA);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(0);
+
 			pending.push(
 				sync.onMessage(
-					new RequestMaybeSyncCoordinate({ hashNumbers: [102n] }),
+					new RequestMaybeSyncCoordinate({ hashNumbers: [101n] }),
 					{ from: peerA } as any,
 				),
 			);
@@ -2747,6 +2744,16 @@ describe("sync-chunking", () => {
 					resolveHashListForSymbols.callCount ===
 					MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER + 1,
 			);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
+
+			// A pre-disconnect lookup settling late never decrements the
+			// reconnected peer's fresh accounting.
+			releases.shift()!([]);
+			await pending.shift();
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
+			expect(
+				(sync as any).pendingCoordinateLookupCountByPeer.get(peerA.hashcode()),
+			).to.equal(1);
 		} finally {
 			for (const release of releases) {
 				release([]);

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -2,8 +2,13 @@ import { Cache } from "@peerbit/cache";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { expect } from "chai";
 import sinon from "sinon";
+import { RatelessIBLTSynchronizer } from "../src/sync/rateless-iblt.js";
 import {
+	MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
 	PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+	RequestMaybeSyncCoordinate,
+	ResponseMaybeSync,
+	ResponseMaybeSyncCapabilities,
 	SimpleSyncronizer,
 } from "../src/sync/simple.js";
 
@@ -366,6 +371,340 @@ describe("sync-chunking memory pins", () => {
 			expect(sync.syncInFlightQueue.size).to.equal(0);
 			expectPendingSyncCensusEmpty(sync);
 		} finally {
+			await sync.close();
+		}
+	});
+});
+
+// Stage-4 memory-growth pins (the leak fix). Storage resolvers and transport
+// sends are not universally abortable: a call that never settles after its
+// peer disconnected must not pin the peer's (or the global) slot quota. The
+// release closures capture per-peer slot rows; disconnect detaches the row.
+describe("sync-chunking slot-quota pins", () => {
+	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+
+	before(async () => {
+		peerA = (await Ed25519Keypair.create()).publicKey;
+	});
+
+	const waitFor = async (condition: () => boolean) => {
+		for (let i = 0; i < 1_000; i++) {
+			if (condition()) {
+				return;
+			}
+			await Promise.resolve();
+		}
+		throw new Error("condition was not reached");
+	};
+
+	it("releases a disconnected peer's mid-lookup slots and restores the full quota", async () => {
+		const resolveHashesForSymbols = sinon.stub().returns(new Promise(() => {}));
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 100 }),
+			resolveHashesForSymbols,
+		});
+		try {
+			void sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				{ from: peerA } as any,
+			);
+			await waitFor(() => resolveHashesForSymbols.callCount === 1);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
+			expect(
+				(sync as any).pendingCoordinateLookupCountByPeer.get(peerA.hashcode()),
+			).to.equal(1);
+
+			sync.onPeerDisconnected(peerA);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(0);
+			expect((sync as any).syncResponseSlotRows.size).to.equal(0);
+
+			// The reconnected peer gets its full lookup quota back even though
+			// the old resolver calls never settle.
+			for (
+				let index = 0;
+				index < MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
+				index += 1
+			) {
+				void sync.onMessage(
+					new RequestMaybeSyncCoordinate({
+						hashNumbers: [BigInt(10 + index)],
+					}),
+					{ from: peerA } as any,
+				);
+			}
+			await waitFor(
+				() =>
+					resolveHashesForSymbols.callCount ===
+					1 + MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [99n] }),
+				{ from: peerA } as any,
+			);
+			expect(resolveHashesForSymbols.callCount).to.equal(
+				1 + MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("nets slot accounting to zero and drops the idle row when work settles", async () => {
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 100 }),
+			resolveHashListForSymbols: sinon.stub().returns(["settled-hash"]),
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 1,
+			fused: false,
+		});
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				{ from: peerA } as any,
+			);
+			expect(ship.calledOnce).to.equal(true);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCount).to.equal(0);
+			expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCountByPeer.size).to.equal(
+				0,
+			);
+			expect((sync as any).syncResponseSlotRows.size).to.equal(0);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("releases a blocked response-ship slot when the peer disconnects", async () => {
+		let releaseShip!: () => void;
+		const blockedShip = new Promise<{ messages: number; fused: boolean }>(
+			(resolve) => {
+				releaseShip = () => resolve({ messages: 1, fused: false });
+			},
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 100 }),
+			resolveHashListForSymbols: sinon.stub().returns(["ship-hash"]),
+		});
+		const ship = sinon
+			.stub(sync as any, "shipExchangeHeads")
+			.returns(blockedShip);
+		try {
+			const handling = sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				{ from: peerA } as any,
+			);
+			await waitFor(() => ship.callCount === 1);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCount).to.equal(1);
+
+			sync.onPeerDisconnected(peerA);
+			expect((sync as any).pendingCoordinateResponseCount).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCountByPeer.size).to.equal(
+				0,
+			);
+			expect((sync as any).syncResponseSlotRows.size).to.equal(0);
+
+			// The blocked ship settling late is aggregate-neutral.
+			releaseShip();
+			await handling;
+			expect((sync as any).pendingCoordinateResponseCount).to.equal(0);
+			expect((sync as any).pendingCoordinateResponseCountByPeer.size).to.equal(
+				0,
+			);
+		} finally {
+			releaseShip();
+			await sync.close();
+		}
+	});
+
+	it("releases a disconnected peer's active response slots without touching a successor", async () => {
+		const releases: (() => void)[] = [];
+		const sendRawExchangeHeads = sinon.stub().callsFake(
+			() =>
+				new Promise<number>((resolve) => {
+					releases.push(() => resolve(1));
+				}),
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const active: Promise<boolean>[] = [];
+		try {
+			const first = sync.expectMaybeSyncResponse({
+				hashes: ["slot-hash-0"],
+				targets: [peerA.hashcode()],
+			});
+			active.push(
+				sync.onMessage(
+					new ResponseMaybeSyncCapabilities({ hashes: ["slot-hash-0"] }),
+					{ from: peerA } as any,
+				),
+			);
+			await waitFor(() => sendRawExchangeHeads.callCount === 1);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
+
+			sync.onPeerDisconnected(peerA);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
+			expect((sync as any).activeMaybeSyncResponseCountByPeer.size).to.equal(0);
+
+			// The reconnected peer's fresh response work uses a fresh row.
+			const second = sync.expectMaybeSyncResponse({
+				hashes: ["slot-hash-1"],
+				targets: [peerA.hashcode()],
+			});
+			active.push(
+				sync.onMessage(
+					new ResponseMaybeSyncCapabilities({ hashes: ["slot-hash-1"] }),
+					{ from: peerA } as any,
+				),
+			);
+			await waitFor(() => sendRawExchangeHeads.callCount === 2);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
+
+			// The pre-disconnect ship settling late never decrements the
+			// successor's accounting.
+			releases.shift()!();
+			await active.shift();
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
+			expect(
+				(sync as any).activeMaybeSyncResponseCountByPeer.get(peerA.hashcode()),
+			).to.equal(1);
+
+			releases.shift()!();
+			await active.shift();
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
+			expect((sync as any).activeMaybeSyncResponseCountByPeer.size).to.equal(0);
+			first?.release();
+			second?.release();
+		} finally {
+			for (const release of releases) {
+				release();
+			}
+			await Promise.all(active);
+			await sync.close();
+		}
+	});
+});
+
+describe("rateless-iblt-syncronizer slot-quota pins", () => {
+	const waitFor = async (condition: () => boolean) => {
+		for (let i = 0; i < 1_000; i++) {
+			if (condition()) {
+				return;
+			}
+			await Promise.resolve();
+		}
+		throw new Error("condition was not reached");
+	};
+
+	const createRateless = () =>
+		new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			rangeIndex: {} as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 1000, ttl: 1000 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+		} as any);
+
+	const createEntries = (count = 400) => {
+		const entries = new Map<string, any>();
+		for (let index = 0; index < count; index += 1) {
+			const hash = `hash-${index}`;
+			entries.set(hash, {
+				hash,
+				hashNumber: BigInt(index + 1),
+				assignedToRangeBoundary: false,
+			});
+		}
+		return entries;
+	};
+
+	it("frees a disconnected peer's response slots while open keeps accounting", async () => {
+		const sync = createRateless();
+		const releases: (() => void)[] = [];
+		let blockShipments = true;
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(async () => {
+				if (blockShipments) {
+					await new Promise<void>((resolve) => releases.push(resolve));
+				}
+				return { messages: 1, fused: false, entries: 1 };
+			});
+		const from = { hashcode: () => "peer-a" } as any;
+		const handlings: Promise<boolean>[] = [];
+		try {
+			await sync.onMaybeMissingEntries({
+				entries: createEntries(),
+				targets: ["peer-a"],
+			});
+			handlings.push(
+				sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+					from,
+				} as any),
+			);
+			await waitFor(() => ship.callCount === 1);
+			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+
+			sync.onPeerDisconnected("peer-a");
+			expect((sync as any).activeRatelessResponseCount).to.equal(0);
+			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
+			expect((sync as any).outgoingSyncProcessByTarget.size).to.equal(0);
+			expect((sync as any).ratelessResponseSlotRows.size).to.equal(0);
+
+			// The reconnected peer's fresh process gets a fresh row.
+			await sync.onMaybeMissingEntries({
+				entries: createEntries(),
+				targets: ["peer-a"],
+			});
+			handlings.push(
+				sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-1"] }), {
+					from,
+				} as any),
+			);
+			await waitFor(() => ship.callCount === 2);
+			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+
+			// open() rotation deliberately does NOT clear slot accounting:
+			// cross-generation ship work is charged until it settles.
+			await sync.open();
+			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+
+			blockShipments = false;
+			for (const release of releases) {
+				release();
+			}
+			await Promise.all(handlings);
+			// The pre-disconnect lease settles aggregate-neutrally; the live
+			// lease returns its slot.
+			expect((sync as any).activeRatelessResponseCount).to.equal(0);
+			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
+		} finally {
+			blockShipments = false;
+			for (const release of releases) {
+				release();
+			}
 			await sync.close();
 		}
 	});

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -168,11 +168,24 @@ describe("sync-chunking memory pins", () => {
 	});
 
 	it("empties every pending-sync structure through per-peer claim removal", async () => {
-		const { sync } = createSync();
+		const coordinateToHash = new Cache<string>({ max: 1_000 });
+		const { sync } = createSync({ coordinateToHash });
 		try {
 			await sync.queueSync(["shared-key"], peerA, { skipCheck: true });
 			await sync.queueSync(["shared-key"], peerB, { skipCheck: true });
 			expect(sync.syncInFlightQueue.get("shared-key")!.length).to.equal(2);
+
+			// A bigint-keyed claim with populated coordinate alias mappings whose
+			// LAST claimant leaves through disconnect: last-claimant removal must
+			// clear the alias structures, not only clearSyncProcessKey.
+			await sync.queueSync([41n], peerB, { skipCheck: true });
+			coordinateToHash.add(41n, "alias-only-hash");
+			(sync as any).refreshQueuedSyncCoordinateAliases();
+			expect((sync as any).syncInFlightQueuedCoordinates.size).to.equal(1);
+			expect((sync as any).syncInFlightQueuedHashByCoordinate.size).to.equal(1);
+			expect(
+				(sync as any).syncInFlightQueuedCoordinatesByHash.size,
+			).to.equal(1);
 
 			sync.onPeerDisconnected(peerA);
 			expect(
@@ -183,10 +196,15 @@ describe("sync-chunking memory pins", () => {
 			expect(sync.syncInFlightQueueInverted.has(peerA.hashcode())).to.equal(
 				false,
 			);
-			expect((sync as any).pendingSyncClaimCount).to.equal(1);
+			expect((sync as any).pendingSyncClaimCount).to.equal(2);
 			expectClaimCountMatchesClaimants(sync);
 
 			sync.onPeerDisconnected(peerB);
+			expect((sync as any).syncInFlightQueuedCoordinates.size).to.equal(0);
+			expect((sync as any).syncInFlightQueuedHashByCoordinate.size).to.equal(0);
+			expect(
+				(sync as any).syncInFlightQueuedCoordinatesByHash.size,
+			).to.equal(0);
 			expectPendingSyncCensusEmpty(sync);
 		} finally {
 			await sync.close();
@@ -657,6 +675,10 @@ describe("sync-chunking slot-quota pins", () => {
 			await active.shift();
 			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
 			expect((sync as any).activeMaybeSyncResponseCountByPeer.size).to.equal(0);
+			// The successor's lease settled while ATTACHED (no disconnect): the
+			// idle row must drop eagerly from the registry, not linger until the
+			// next disconnect.
+			expect((sync as any).syncResponseSlotRows.size).to.equal(0);
 			first?.release();
 			second?.release();
 		} finally {
@@ -685,6 +707,11 @@ describe("sync-chunking dispatch-lifecycle pins", () => {
 		});
 		try {
 			const controller = new AbortController();
+			const addListener = sinon.spy(controller.signal, "addEventListener");
+			const removeListener = sinon.spy(
+				controller.signal,
+				"removeEventListener",
+			);
 			const reservation = sync.expectMaybeSyncResponse({
 				hashes: ["disposal-hash"],
 				targets: [peerA.hashcode()],
@@ -692,17 +719,42 @@ describe("sync-chunking dispatch-lifecycle pins", () => {
 			});
 			expect(reservation).to.not.equal(undefined);
 			expect((sync as any).syncDispatchTargets.size).to.equal(1);
+			const targetLifecycle = [
+				...(sync as any).syncDispatchTargets.get(peerA.hashcode()),
+			][0] as any;
 
 			controller.abort(new Error("caller aborted"));
 			reservation!.release();
 
-			// The disposed lifecycle leaves no reachable target lifecycles and
-			// its abort listeners are unpaired.
+			// The disposed lifecycle leaves no reachable target lifecycles, its
+			// raw retention counters settle at exactly zero, and every abort
+			// listener added on the caller signal has been removed.
 			expect((sync as any).syncDispatchTargets.size).to.equal(0);
+			expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+			expect(targetLifecycle.lifecycle.retainedWork).to.equal(0);
+			expect(targetLifecycle.responseLeases).to.equal(0);
+			const addedAbortListeners = addListener
+				.getCalls()
+				.filter((call) => call.args[0] === "abort")
+				.map((call) => call.args[1]);
+			expect(addedAbortListeners.length).to.be.greaterThan(0);
+			const removedAbortListeners = removeListener
+				.getCalls()
+				.filter((call) => call.args[0] === "abort")
+				.map((call) => call.args[1]);
+			for (const listener of addedAbortListeners) {
+				expect(removedAbortListeners).to.include(listener);
+			}
 
-			// A double release stays inert.
+			// A double release stays inert: the released-guard keeps the raw
+			// counters at exactly zero (an unguarded second release would drive
+			// responseLeases/retainedWork negative and allow premature disposal
+			// with live retained work) and leaves the disposed state unchanged.
 			reservation!.release();
 			expect((sync as any).syncDispatchTargets.size).to.equal(0);
+			expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+			expect(targetLifecycle.lifecycle.retainedWork).to.equal(0);
+			expect(targetLifecycle.responseLeases).to.equal(0);
 		} finally {
 			await sync.close();
 		}
@@ -803,6 +855,10 @@ describe("rateless-iblt-syncronizer slot-quota pins", () => {
 			// lease returns its slot.
 			expect((sync as any).activeRatelessResponseCount).to.equal(0);
 			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
+			// The successor's lease settled while ATTACHED (no disconnect): the
+			// idle row must drop eagerly from the registry, not linger until the
+			// next disconnect.
+			expect((sync as any).ratelessResponseSlotRows.size).to.equal(0);
 		} finally {
 			blockShipments = false;
 			for (const release of releases) {

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { RatelessIBLTSynchronizer } from "../src/sync/rateless-iblt.js";
 import {
+	MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
 	MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
 	PENDING_SIMPLE_SYNC_KEY_TTL_MS,
 	RequestMaybeSyncCoordinate,
@@ -367,9 +368,13 @@ describe("sync-chunking memory pins", () => {
 // release closures capture per-peer slot rows; disconnect detaches the row.
 describe("sync-chunking slot-quota pins", () => {
 	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+	let peerB: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
 
 	before(async () => {
-		peerA = (await Ed25519Keypair.create()).publicKey;
+		[peerA, peerB] = await Promise.all([
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+		]);
 	});
 
 	const waitFor = async (condition: () => boolean) => {
@@ -514,6 +519,79 @@ describe("sync-chunking slot-quota pins", () => {
 			);
 		} finally {
 			releaseShip();
+			await sync.close();
+		}
+	});
+
+	it("returns a flapping peer's active authorization hash budget on disconnect", async () => {
+		// Storage/transport ships are not universally abortable: a peer whose
+		// accepted (active) response authorizations never ship must not retain
+		// its pendingMaybeSyncResponseCount contribution past disconnect, and
+		// repeated acquire-hang-disconnect cycles must not ratchet the budget
+		// toward permanent global rejection.
+		const hangs: (() => void)[] = [];
+		const sendRawExchangeHeads = sinon.stub().callsFake(
+			() =>
+				new Promise<number>((resolve) => {
+					hangs.push(() => resolve(1));
+				}),
+		);
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			sendRawExchangeHeads,
+		});
+		const active: Promise<boolean>[] = [];
+		try {
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+			for (let cycle = 0; cycle < 2; cycle += 1) {
+				const hashes = [0, 1, 2].map((index) => `flap-${cycle}-${index}`);
+				const reservation = sync.expectMaybeSyncResponse({
+					hashes,
+					targets: [peerA.hashcode()],
+				});
+				expect(reservation).to.not.equal(undefined);
+				active.push(
+					sync.onMessage(new ResponseMaybeSyncCapabilities({ hashes }), {
+						from: peerA,
+					} as any),
+				);
+				await waitFor(() => sendRawExchangeHeads.callCount === cycle + 1);
+				// The caller gives up its reservation; only the hung ship's active
+				// authorizations remain charged against the hash budget.
+				reservation!.release();
+				expect((sync as any).pendingMaybeSyncResponseCount).to.equal(
+					hashes.length,
+				);
+
+				sync.onPeerDisconnected(peerA);
+				// The active authorizations' budget returns with the row (no
+				// ratchet across flap cycles)...
+				expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+				expect((sync as any).pendingMaybeSyncResponses.size).to.equal(0);
+				// ...and the settled leases drain retained work so the dispatch
+				// lifecycle disposes out of the registry.
+				expect((sync as any).syncDispatchTargets.size).to.equal(0);
+			}
+
+			// The full authorization window is reservable again after the flaps.
+			const reclaimed = sync.expectMaybeSyncResponse({
+				hashes: Array.from(
+					{ length: MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER },
+					(_, index) => `flap-reclaimed-${index}`,
+				),
+				targets: [peerB.hashcode()],
+			});
+			expect(reclaimed).to.not.equal(undefined);
+			reclaimed!.release();
+			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
+		} finally {
+			for (const hang of hangs) {
+				hang();
+			}
+			await Promise.all(active);
 			await sync.close();
 		}
 	});

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -64,25 +64,10 @@ describe("sync-chunking memory pins", () => {
 			anySync.pendingSyncExpiryHeap.length,
 			"pendingSyncExpiryHeap",
 		).to.equal(0);
-		expect(
-			anySync.pendingSyncKeyExpiryNodes.size,
-			"pendingSyncKeyExpiryNodes",
-		).to.equal(0);
+		expect(anySync.pendingSync.records.size, "pendingSync.records").to.equal(0);
 		expect(
 			anySync.pendingSyncAdmissionExpiryNodes.size,
 			"pendingSyncAdmissionExpiryNodes",
-		).to.equal(0);
-		expect(
-			anySync.syncInFlightQueueClaimants.size,
-			"syncInFlightQueueClaimants",
-		).to.equal(0);
-		expect(
-			anySync.syncInFlightQueueClaimantIndexes.size,
-			"syncInFlightQueueClaimantIndexes",
-		).to.equal(0);
-		expect(
-			anySync.syncInFlightQueueRoundRobinCursor.size,
-			"syncInFlightQueueRoundRobinCursor",
 		).to.equal(0);
 		expect(
 			anySync.syncInFlightQueuedCoordinates.size,
@@ -131,8 +116,8 @@ describe("sync-chunking memory pins", () => {
 	const expectClaimCountMatchesClaimants = (sync: SimpleSyncronizer<"u64">) => {
 		const anySync = sync as any;
 		let sum = 0;
-		for (const claimants of anySync.syncInFlightQueueClaimants.values()) {
-			sum += (claimants as Set<string>).size;
+		for (const record of anySync.pendingSync.records.values()) {
+			sum += (record.claimants as Set<string>).size;
 		}
 		expect(anySync.pendingSyncClaimCount).to.equal(sum);
 	};
@@ -278,26 +263,26 @@ describe("sync-chunking memory pins", () => {
 
 			// Cursor at the last slot, middle claimant removed: the last claimant
 			// swaps into the removed slot and the cursor follows it.
-			(sync as any).syncInFlightQueueRoundRobinCursor.set("rr-key", 2);
+			(sync as any).pendingSync.setRoundRobinCursor("rr-key", 2);
 			(sync as any).removePendingSyncClaim("rr-key", peerB.hashcode());
 			expect(
 				sync.syncInFlightQueue.get("rr-key")!.map((peer) => peer.hashcode()),
 			).to.deep.equal([peerA.hashcode(), peerC.hashcode()]);
-			expect(
-				(sync as any).syncInFlightQueueRoundRobinCursor.get("rr-key"),
-			).to.equal(1);
+			expect((sync as any).pendingSync.getRoundRobinCursor("rr-key")).to.equal(
+				1,
+			);
 			expectClaimCountMatchesClaimants(sync);
 
 			// Cursor before the removed slot stays put (modulo the new length).
 			await sync.queueSync(["rr-key"], peerB, { skipCheck: true });
-			(sync as any).syncInFlightQueueRoundRobinCursor.set("rr-key", 0);
+			(sync as any).pendingSync.setRoundRobinCursor("rr-key", 0);
 			(sync as any).removePendingSyncClaim("rr-key", peerC.hashcode());
 			expect(
 				sync.syncInFlightQueue.get("rr-key")!.map((peer) => peer.hashcode()),
 			).to.deep.equal([peerA.hashcode(), peerB.hashcode()]);
-			expect(
-				(sync as any).syncInFlightQueueRoundRobinCursor.get("rr-key"),
-			).to.equal(0);
+			expect((sync as any).pendingSync.getRoundRobinCursor("rr-key")).to.equal(
+				0,
+			);
 		} finally {
 			await sync.close();
 		}

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -1,0 +1,372 @@
+import { Cache } from "@peerbit/cache";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import { expect } from "chai";
+import sinon from "sinon";
+import {
+	PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+	SimpleSyncronizer,
+} from "../src/sync/simple.js";
+
+// Stage-4 sync-unification pins. These freeze the observable behavior of the
+// pending-sync structures (the syncInFlightQueue lockstep family) before the
+// record-store fold so every remove path can be proven equivalent:
+// TTL expiry, entry-added, per-peer claim removal (disconnect), coordinate
+// alias reconciliation, and close().
+describe("sync-chunking memory pins", () => {
+	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+	let peerB: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+	let peerC: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+
+	before(async () => {
+		[peerA, peerB, peerC] = await Promise.all([
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+			Ed25519Keypair.create().then((keypair) => keypair.publicKey),
+		]);
+	});
+
+	const createSync = (overrides?: {
+		log?: any;
+		coordinateToHash?: Cache<string>;
+		send?: sinon.SinonStub;
+	}) => {
+		const send = overrides?.send ?? sinon.stub().resolves();
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send } as any,
+			entryIndex: {} as any,
+			log: overrides?.log ?? ({ has: async () => false } as any),
+			coordinateToHash:
+				overrides?.coordinateToHash ?? new Cache<string>({ max: 1_000 }),
+		});
+		return { sync, send };
+	};
+
+	// The full census of the pending-sync key family. Every remove path must
+	// leave all of these empty; any structure that survives one of the five
+	// paths is a leak.
+	const expectPendingSyncCensusEmpty = (sync: SimpleSyncronizer<"u64">) => {
+		const anySync = sync as any;
+		expect(sync.syncInFlightQueue.size, "syncInFlightQueue").to.equal(0);
+		expect(
+			sync.syncInFlightQueueInverted.size,
+			"syncInFlightQueueInverted",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueueExpiresAt.size,
+			"syncInFlightQueueExpiresAt",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncExpiryHeap.length,
+			"pendingSyncExpiryHeap",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncKeyExpiryNodes.size,
+			"pendingSyncKeyExpiryNodes",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionExpiryNodes.size,
+			"pendingSyncAdmissionExpiryNodes",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueueClaimants.size,
+			"syncInFlightQueueClaimants",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueueClaimantIndexes.size,
+			"syncInFlightQueueClaimantIndexes",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueueRoundRobinCursor.size,
+			"syncInFlightQueueRoundRobinCursor",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueuedCoordinates.size,
+			"syncInFlightQueuedCoordinates",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueuedHashByCoordinate.size,
+			"syncInFlightQueuedHashByCoordinate",
+		).to.equal(0);
+		expect(
+			anySync.syncInFlightQueuedCoordinatesByHash.size,
+			"syncInFlightQueuedCoordinatesByHash",
+		).to.equal(0);
+		expect(anySync.pendingSyncClaimCount, "pendingSyncClaimCount").to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionCount,
+			"pendingSyncAdmissionCount",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionReservations.size,
+			"pendingSyncAdmissionReservations",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionReservationsByPeer.size,
+			"pendingSyncAdmissionReservationsByPeer",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionReservationsByIdentity.size,
+			"pendingSyncAdmissionReservationsByIdentity",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionCountByPeer.size,
+			"pendingSyncAdmissionCountByPeer",
+		).to.equal(0);
+		expect(
+			anySync.pendingSyncAdmissionIdentitiesByPeer.size,
+			"pendingSyncAdmissionIdentitiesByPeer",
+		).to.equal(0);
+		expect(sync.syncInFlight.size, "syncInFlight").to.equal(0);
+		expect(
+			anySync.syncInFlightTargetsByKey.size,
+			"syncInFlightTargetsByKey",
+		).to.equal(0);
+	};
+
+	const expectClaimCountMatchesClaimants = (sync: SimpleSyncronizer<"u64">) => {
+		const anySync = sync as any;
+		let sum = 0;
+		for (const claimants of anySync.syncInFlightQueueClaimants.values()) {
+			sum += (claimants as Set<string>).size;
+		}
+		expect(anySync.pendingSyncClaimCount).to.equal(sum);
+	};
+
+	it("empties every pending-sync structure on TTL expiry", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const { sync } = createSync();
+		try {
+			await sync.queueSync(["expiry-hash", 5n], peerA, { skipCheck: true });
+			expect(sync.syncInFlightQueue.size).to.equal(2);
+			expectClaimCountMatchesClaimants(sync);
+
+			await clock.tickAsync(PENDING_SIMPLE_SYNC_KEY_TTL_MS - 1);
+			expect(sync.syncInFlightQueue.size).to.equal(2);
+
+			await clock.tickAsync(1);
+			expectPendingSyncCensusEmpty(sync);
+			expect((sync as any).syncInFlightQueueExpiryTimer).to.equal(undefined);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("empties every pending-sync structure when entries arrive", async () => {
+		const { sync } = createSync();
+		try {
+			await sync.queueSync(["added-one", "added-two"], peerA, {
+				skipCheck: true,
+			});
+			await sync.queueSync(["added-one"], peerB, { skipCheck: true });
+			expectClaimCountMatchesClaimants(sync);
+
+			sync.onEntryAddedHash("added-one");
+			expect(sync.syncInFlightQueue.has("added-one")).to.equal(false);
+			expect(sync.syncInFlightQueue.has("added-two")).to.equal(true);
+			expectClaimCountMatchesClaimants(sync);
+
+			sync.onEntryAddedHashes(["added-two"]);
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("empties every pending-sync structure through per-peer claim removal", async () => {
+		const { sync } = createSync();
+		try {
+			await sync.queueSync(["shared-key"], peerA, { skipCheck: true });
+			await sync.queueSync(["shared-key"], peerB, { skipCheck: true });
+			expect(sync.syncInFlightQueue.get("shared-key")!.length).to.equal(2);
+
+			sync.onPeerDisconnected(peerA);
+			expect(
+				sync.syncInFlightQueue
+					.get("shared-key")!
+					.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerB.hashcode()]);
+			expect(sync.syncInFlightQueueInverted.has(peerA.hashcode())).to.equal(
+				false,
+			);
+			expect((sync as any).pendingSyncClaimCount).to.equal(1);
+			expectClaimCountMatchesClaimants(sync);
+
+			sync.onPeerDisconnected(peerB);
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("empties every pending-sync structure on close", async () => {
+		const { sync } = createSync();
+		try {
+			await sync.queueSync(["close-hash", 9n], peerA, { skipCheck: true });
+			await sync.queueSync(["close-hash"], peerB, { skipCheck: true });
+			expect(sync.pending).to.be.greaterThan(0);
+
+			await sync.close();
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("preserves the earliest deadline when a coordinate alias transplants claims", async () => {
+		const clock = sinon.useFakeTimers({
+			now: 100_000,
+			toFake: ["Date", "setTimeout", "clearTimeout"],
+		});
+		const coordinateToHash = new Cache<string>({ max: 1_000 });
+		const { sync } = createSync({ coordinateToHash });
+		const coordinate = 7n;
+		const lateHash = "late-alias-hash";
+		try {
+			await sync.queueSync([coordinate], peerA, { skipCheck: true });
+			const coordinateDeadline = (sync as any).syncInFlightQueueExpiresAt.get(
+				coordinate,
+			);
+			expect(coordinateDeadline).to.equal(
+				100_000 + PENDING_SIMPLE_SYNC_KEY_TTL_MS,
+			);
+
+			await clock.tickAsync(10_000);
+			await sync.queueSync([lateHash], peerB, { skipCheck: true });
+			expect(sync.syncInFlightQueue.has(lateHash)).to.equal(true);
+
+			coordinateToHash.add(coordinate, lateHash);
+			await sync.queueSync([lateHash], peerB, { skipCheck: true });
+
+			// The hash record folded into the coordinate record.
+			expect(sync.syncInFlightQueue.has(lateHash)).to.equal(false);
+			expect(
+				sync.syncInFlightQueue.get(coordinate)!.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerB.hashcode()]);
+			// The transplanted claim inherits the earlier (coordinate) deadline;
+			// repeated claims and additional peers must not slide it.
+			expect((sync as any).syncInFlightQueueExpiresAt.get(coordinate)).to.equal(
+				coordinateDeadline,
+			);
+			expectClaimCountMatchesClaimants(sync);
+
+			await clock.tickAsync(PENDING_SIMPLE_SYNC_KEY_TTL_MS - 10_000);
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+			clock.restore();
+		}
+	});
+
+	it("keeps exact round-robin cursor semantics on swap-remove of a middle claimant", async () => {
+		const { sync } = createSync();
+		try {
+			await sync.queueSync(["rr-key"], peerA, { skipCheck: true });
+			await sync.queueSync(["rr-key"], peerB, { skipCheck: true });
+			await sync.queueSync(["rr-key"], peerC, { skipCheck: true });
+			expect(
+				sync.syncInFlightQueue.get("rr-key")!.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerB.hashcode(), peerC.hashcode()]);
+
+			// Cursor at the last slot, middle claimant removed: the last claimant
+			// swaps into the removed slot and the cursor follows it.
+			(sync as any).syncInFlightQueueRoundRobinCursor.set("rr-key", 2);
+			(sync as any).removePendingSyncClaim("rr-key", peerB.hashcode());
+			expect(
+				sync.syncInFlightQueue.get("rr-key")!.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerC.hashcode()]);
+			expect(
+				(sync as any).syncInFlightQueueRoundRobinCursor.get("rr-key"),
+			).to.equal(1);
+			expectClaimCountMatchesClaimants(sync);
+
+			// Cursor before the removed slot stays put (modulo the new length).
+			await sync.queueSync(["rr-key"], peerB, { skipCheck: true });
+			(sync as any).syncInFlightQueueRoundRobinCursor.set("rr-key", 0);
+			(sync as any).removePendingSyncClaim("rr-key", peerC.hashcode());
+			expect(
+				sync.syncInFlightQueue.get("rr-key")!.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerB.hashcode()]);
+			expect(
+				(sync as any).syncInFlightQueueRoundRobinCursor.get("rr-key"),
+			).to.equal(0);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("hydrates directly seeded public queue maps and keeps counts exact", async () => {
+		const { sync } = createSync();
+		try {
+			// Tests and integrations seed the public maps directly; the defensive
+			// hydration branches must keep working through the record-store fold.
+			sync.syncInFlightQueue.set("seeded", [peerA]);
+			sync.syncInFlightQueueInverted.set(peerA.hashcode(), new Set(["seeded"]));
+			expect(
+				(sync as any).hasPendingSyncClaim("seeded", peerA.hashcode()),
+			).to.equal(true);
+			expect((sync as any).pendingSyncClaimCount).to.equal(1);
+
+			await sync.queueSync(["seeded"], peerB, { skipCheck: true });
+			expect(
+				sync.syncInFlightQueue.get("seeded")!.map((peer) => peer.hashcode()),
+			).to.deep.equal([peerA.hashcode(), peerB.hashcode()]);
+			expect((sync as any).pendingSyncClaimCount).to.equal(2);
+			expectClaimCountMatchesClaimants(sync);
+
+			sync.onEntryAddedHash("seeded");
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("sweeps a directly seeded in-flight row through the defensive scan", async () => {
+		const { sync } = createSync();
+		try {
+			// A directly seeded in-flight row has no reverse-index entry; the
+			// defensive scan must still find and remove it.
+			sync.syncInFlight.set(
+				peerA.hashcode(),
+				new Map([["only-inflight", { timestamp: Date.now() }]]),
+			);
+			sync.onEntryAddedHash("only-inflight");
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("does not dispatch claims captured under a rotated dispatch epoch", async () => {
+		let releaseHasMany!: (hashes: string[]) => void;
+		const hasMany = sinon.stub().returns(
+			new Promise<string[]>((resolve) => {
+				releaseHasMany = resolve;
+			}),
+		);
+		const { sync, send } = createSync({
+			log: { has: async () => false, hasMany } as any,
+		});
+		try {
+			const handling = sync.queueSync(["epoch-hash"], peerA);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(hasMany.calledOnce).to.equal(true);
+
+			// The peer disconnects while its admission lookup is still blocked:
+			// the captured dispatch epoch is deleted, so the resumed queueSync
+			// must not dispatch or retain claims for the stale epoch.
+			sync.onPeerDisconnected(peerA);
+			releaseHasMany([]);
+			await handling;
+
+			expect(send.called).to.equal(false);
+			expect(sync.syncInFlightQueue.size).to.equal(0);
+			expectPendingSyncCensusEmpty(sync);
+		} finally {
+			await sync.close();
+		}
+	});
+});

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -591,6 +591,46 @@ describe("sync-chunking slot-quota pins", () => {
 	});
 });
 
+describe("sync-chunking dispatch-lifecycle pins", () => {
+	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
+
+	before(async () => {
+		peerA = (await Ed25519Keypair.create()).publicKey;
+	});
+
+	it("caller-signal abort leaves no reachable dispatch target state", async () => {
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: {} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		try {
+			const controller = new AbortController();
+			const reservation = sync.expectMaybeSyncResponse({
+				hashes: ["disposal-hash"],
+				targets: [peerA.hashcode()],
+				signal: controller.signal,
+			});
+			expect(reservation).to.not.equal(undefined);
+			expect((sync as any).syncDispatchTargets.size).to.equal(1);
+
+			controller.abort(new Error("caller aborted"));
+			reservation!.release();
+
+			// The disposed lifecycle leaves no reachable target lifecycles and
+			// its abort listeners are unpaired.
+			expect((sync as any).syncDispatchTargets.size).to.equal(0);
+
+			// A double release stays inert.
+			reservation!.release();
+			expect((sync as any).syncDispatchTargets.size).to.equal(0);
+		} finally {
+			await sync.close();
+		}
+	});
+});
+
 describe("rateless-iblt-syncronizer slot-quota pins", () => {
 	const waitFor = async (condition: () => boolean) => {
 		for (let i = 0; i < 1_000; i++) {

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -64,6 +64,11 @@ const TARGETS = new Map([
 	["packages/programs/data/shared-log/src/replication-announcement.ts", []],
 	["packages/programs/data/shared-log/src/replicator-liveness.ts", []],
 	["packages/programs/data/shared-log/src/sync/factory.ts", []],
+	// Stage 4: the pending-sync record store moved the simple synchronizer's
+	// admission/claim state file-to-file. Its fields are deliberately plain
+	// (no visibility modifier, no _-prefix), so any future fence-pattern
+	// declaration matching DECL here is new growth and needs a design-note.
+	["packages/programs/data/shared-log/src/sync/pending-sync-store.ts", []],
 ]);
 // Token match is per camelCase/underscore segment so "generationOfLastPrune"
 // and "epochCounter" are caught while "aggregateTotals" is not.

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -69,6 +69,10 @@ const TARGETS = new Map([
 	// (no visibility modifier, no _-prefix), so any future fence-pattern
 	// declaration matching DECL here is new growth and needs a design-note.
 	["packages/programs/data/shared-log/src/sync/pending-sync-store.ts", []],
+	// Stage 4: the shared dispatch-lifecycle registry moved the simple and
+	// rateless synchronizers' duplicated lifecycle mechanics file-to-file.
+	["packages/programs/data/shared-log/src/sync/dispatch-lifecycle.ts", []],
+	["packages/programs/data/shared-log/src/sync/sync-peer-state.ts", []],
 ]);
 // Token match is per camelCase/underscore segment so "generationOfLastPrune"
 // and "epochCounter" are caught while "aggregateTotals" is not.


### PR DESCRIPTION
Final stage-4 PR: unifies the sync module's lockstep bookkeeping (roadmap B2) and fixes the disconnect leak class it exposed.

## What this does

- **Behavior pins first** (`test/sync-memory-pins.spec.ts`): a census of the 19-structure pending-sync family across all five remove paths (TTL expiry, entry-added, per-peer claim removal, alias reconcile, close), round-robin swap-remove cursor semantics, alias-transplant deadline preservation, seeded public-map hydration, and rotated-dispatch-epoch non-dispatch — green at the base commit before any production change.
- **Disconnect leak fix**: release closures now capture per-peer slot rows (coordinate lookups, coordinate responses, active maybe-sync responses, active rateless responses). `onPeerDisconnected` detaches the row, so never-settling resolvers no longer pin the peer's or the global quota; late releases settle aggregate-neutrally against the detached row and can never touch a reconnected successor's accounting. Memory-growth pins cover each scenario (red without the fix).
- **Pending-sync record store** (`src/sync/pending-sync-store.ts`): one `PendingSyncRecord` per key folds claimants, claimant indexes, the round-robin cursor, and expiry-heap nodes. The historical public `Map`s (`syncInFlightQueue`, `syncInFlightQueueInverted`, `syncInFlight`, `syncInFlightExpiresAt`, alias/admission maps) are preserved as the store's physical indexes under their old names, so external readers and sinon stubs keep working. One add path, unified removal, generalized hydration.
- **Shared per-peer slot-row registry** (`src/sync/sync-peer-state.ts`): both synchronizers use one registry with an explicit per-field lifetime policy (returned-on-detach vs settled-by-release vs close-survival).
- **Shared dispatch-lifecycle registry** (`src/sync/dispatch-lifecycle.ts`): injected epoch-identity vs set-membership activity strategies and retention hooks; the rateless `isRatelessRepairSessionActive`/`isIncomingSyncGenerationActive` predicates migrated onto the shared registry with byte-equivalent truth tables (~240 duplicated lines deleted).
- **Active-authorization budget return**: on disconnect, a peer's accepted maybe-sync authorizations return their `pendingMaybeSyncResponseCount` contribution to the global budget and their outstanding leases settle, so a flapping peer with never-settling sends can no longer ratchet the 10k budget to exhaustion (the pre-refactor code accidentally bounded this by permanently locking the stuck peer out). Custody of every reserved hash unit is exactly one of batch / delivery-in-flight / slot row, with a flap pin proving the budget returns across repeated cycles.

`simple.ts` drops from 4651 to ~3800 lines; the fence ratchet gains a `pending-sync-store` baseline entry and every baseline holds.

## Deliberate scope notes

- Detach is **disconnect-only**: close()/reopen survival of bounded active response work stays exactly as pinned (`retains bounded active response work across close and reopen`), including the rateless open carve-out.
- The pre-existing test that pinned the leaking behavior (`retains coordinate lookup permits across disconnect until work settles`) is rewritten to pin the new semantics (`returns coordinate lookup permits when their peer disconnects`).
- Dispatch epochs/target sets, admission per-peer indexes, and `recentlySentExchangeHeads` stay host-side: folding them is hot-path work that warrants a benchmark A/B gate, deferred to stage 5 (documented in the module header).
- The record store's internal fields (`claimants`, `claimantIndexes`, `rrCursor`, `keyExpiryNodes`) have no legacy accessors — zero external consumers existed.

## Validation

- Per-commit: build, repo lint, fence-ratchet + shard-coverage scripts, and the sync suite set (252–259 passing per run) — never committed red.
- Adversarial review (six dimensions, refute-oriented verify pass): 5 confirmed findings — 1 major (the budget ratchet above), 3 pin-strength gaps, 1 dead method — all fixed in the last three commits; each fix pin mutation-verified (fix reverted → pin red → restored; guard/branch deleted → pin red → restored, 5/5 mutants killed).
- Full closing sweep at tip, Node 22: unit 109, coordinate/prune/admission 120, sync family 220, integration 184 + 38, replication-degree slice 97, chaos 4 + 5, document durable-native consumer suites 68 — all green, exit codes captured directly.
