### PR TITLE
fix(shared-log): retain physical sync permits across disconnect

### DIFF
--- a/.changeset/bound-sync-disconnect-work.md
+++ b/.changeset/bound-sync-disconnect-work.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Keep global synchronization work limits charged until non-abortable lookups and response shipments settle, while releasing disconnected peers' per-generation quota and lifecycle state immediately.

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -865,8 +865,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 	private activeRatelessResponseCountByPeer: Map<string, number>;
 	// Per-peer slot rows for active rateless responses (shared registry; see
 	// sync-peer-state.ts for the lifetime policy). Release closures capture
-	// the row: after a disconnect detaches it, the peer's quota returns
-	// immediately and a late release only settles the detached row.
+	// the row: disconnect returns current-generation quota and logical
+	// ownership immediately, while the global physical permit remains charged
+	// until the shipment actually settles.
 	private readonly ratelessPeerSlotRows: SyncPeerSlotRegistry;
 	private ratelessClosed: boolean;
 
@@ -2265,36 +2266,49 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			target,
 			(this.activeRatelessResponseCountByPeer.get(target) ?? 0) + 1,
 		);
-		let released = false;
+		let logicalReleased = false;
+		let physicalReleased = false;
+		const releaseLogical = () => {
+			if (logicalReleased) {
+				return;
+			}
+			logicalReleased = true;
+			slotRow.activeReleases.delete(releaseLogical);
+			targetLifecycle.responseLeases -= 1;
+			this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
+		};
+		slotRow.activeReleases.add(releaseLogical);
 		return {
 			process,
 			authorized,
 			remaining,
 			signal: targetLifecycle.controller.signal,
 			release: (options) => {
-				if (released) {
+				if (physicalReleased) {
 					return;
 				}
-				released = true;
-				if (options?.rollback) {
-					for (const hash of authorized) {
-						process.consumedResponseHashes.delete(hash);
+				physicalReleased = true;
+				try {
+					releaseLogical();
+				} finally {
+					if (options?.rollback) {
+						for (const hash of authorized) {
+							process.consumedResponseHashes.delete(hash);
+						}
 					}
-				}
-				targetLifecycle.responseLeases -= 1;
-				slotRow.active -= 1;
-				if (slotRow.attached) {
 					this.activeRatelessResponseCount -= 1;
-					const activeForPeer =
-						(this.activeRatelessResponseCountByPeer.get(target) ?? 1) - 1;
-					if (activeForPeer === 0) {
-						this.activeRatelessResponseCountByPeer.delete(target);
-					} else {
-						this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
+					slotRow.active -= 1;
+					if (slotRow.attached) {
+						const activeForPeer =
+							(this.activeRatelessResponseCountByPeer.get(target) ?? 1) - 1;
+						if (activeForPeer === 0) {
+							this.activeRatelessResponseCountByPeer.delete(target);
+						} else {
+							this.activeRatelessResponseCountByPeer.set(target, activeForPeer);
+						}
+						this.ratelessPeerSlotRows.maybeDropIdle(slotRow);
 					}
-					this.ratelessPeerSlotRows.maybeDropIdle(slotRow);
 				}
-				this.maybeDisposeRatelessDispatchLifecycle(targetLifecycle.lifecycle);
 			},
 		};
 	}
@@ -2308,9 +2322,11 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		if (!row) {
 			return;
 		}
-		if (row.active > 0) {
-			this.activeRatelessResponseCount -= row.active;
-			this.activeRatelessResponseCountByPeer.delete(peer);
+		this.activeRatelessResponseCountByPeer.delete(peer);
+		// Release logical lifecycle ownership immediately. Each underlying
+		// shipment retains its global physical-work permit until its own finally.
+		for (const releaseLogical of [...row.activeReleases]) {
+			releaseLogical();
 		}
 	}
 
@@ -3217,10 +3233,9 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 				new Error("rateless sync target disconnected"),
 			);
 		}
-		// A response ship for this peer may never settle. Detach the slot row so
-		// the quota returns immediately; late releases settle against the
-		// detached row. Note: open() deliberately does NOT clear this
-		// accounting — cross-generation work is still charged until it settles.
+		// A response ship for this peer may never settle. Detach current-generation
+		// quota and logical ownership, but keep its global physical permit charged
+		// until settlement. open() likewise preserves physical accounting.
 		this.detachRatelessResponseSlotRow(target);
 		return this.simple.onPeerDisconnected(target);
 	}

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -1982,16 +1982,17 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				}
 			}
 		}
-		let remainingLeases = acceptedByLifecycle.size;
+		let remainingPhysicalLeases = acceptedByLifecycle.size;
 		return [...acceptedByLifecycle].map(
 			([targetLifecycle, { hashes: acceptedHashes, authorizations }]) => {
-				let released = false;
-				const release = (options?: { fulfilled?: boolean }) => {
-					if (released) {
+				let logicalReleased = false;
+				let physicalReleased = false;
+				const releaseLogical = (options?: { fulfilled?: boolean }) => {
+					if (logicalReleased) {
 						return;
 					}
-					released = true;
-					slotRow.activeReleases.delete(release);
+					logicalReleased = true;
+					slotRow.activeReleases.delete(releaseLogical);
 					const pendingForTarget = this.pendingMaybeSyncResponses.get(fromHash);
 					for (const authorization of authorizations) {
 						this.settlePendingMaybeSyncResponseAuthorization(
@@ -2017,11 +2018,19 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 					// finishDelivery) remain charged.
 					targetLifecycle.responseLeases -= 1;
 					targetLifecycle.lifecycle.retainedWork -= 1;
-					remainingLeases -= 1;
-					if (remainingLeases === 0) {
+					this.schedulePendingMaybeSyncResponseWaiter();
+					this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
+				};
+				const releasePhysical = () => {
+					if (physicalReleased) {
+						return;
+					}
+					physicalReleased = true;
+					remainingPhysicalLeases -= 1;
+					if (remainingPhysicalLeases === 0) {
 						slotRow.active -= 1;
+						this.activeMaybeSyncResponseCount -= 1;
 						if (slotRow.attached) {
-							this.activeMaybeSyncResponseCount -= 1;
 							const activeForPeer =
 								(this.activeMaybeSyncResponseCountByPeer.get(fromHash) ?? 1) -
 								1;
@@ -2036,14 +2045,18 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 							this.maybeDropIdleSyncResponseSlotRow(slotRow);
 						}
 					}
-					this.schedulePendingMaybeSyncResponseWaiter();
-					this.maybeDisposeSyncDispatchLifecycle(targetLifecycle.lifecycle);
 				};
-				slotRow.activeReleases.add(release);
+				slotRow.activeReleases.add(releaseLogical);
 				return {
 					hashes: acceptedHashes,
 					signal: targetLifecycle.controller.signal,
-					release,
+					release: (options?: { fulfilled?: boolean }) => {
+						try {
+							releaseLogical(options);
+						} finally {
+							releasePhysical();
+						}
+					},
 				};
 			},
 		);
@@ -2681,11 +2694,26 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				return true;
 			}
 			const target = from.hashcode();
-			const releaseLookup = this.tryAcquireCoordinateLookup(target);
-			if (!releaseLookup) {
+			const lookupPermit = this.tryAcquireCoordinateLookup(target);
+			if (!lookupPermit) {
 				return true;
 			}
+			const { release: releaseLookup, row: slotRow } = lookupPermit;
 			const lifecycle = this.captureSyncDispatchLifecycle([target]);
+			let lifecycleFinished = false;
+			const finishLifecycle = () => {
+				if (lifecycleFinished) {
+					return;
+				}
+				lifecycleFinished = true;
+				slotRow.activeReleases.delete(finishLifecycle);
+				this.finishSyncDispatchLifecycle(lifecycle);
+				this.maybeDropIdleSyncResponseSlotRow(slotRow);
+			};
+			// Dispatch completion is logical ownership. A disconnected peer must
+			// not retain this lifecycle/listeners while a non-abortable lookup or
+			// shipment keeps only its global physical permit alive.
+			slotRow.activeReleases.add(finishLifecycle);
 			let lookupReleased = false;
 			const finishLookup = () => {
 				if (lookupReleased) {
@@ -2757,7 +2785,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 				return true;
 			} finally {
 				finishLookup();
-				this.finishSyncDispatchLifecycle(lifecycle);
+				finishLifecycle();
 			}
 		} else {
 			return false; // no message was consumed
@@ -2844,18 +2872,12 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		if (!row) {
 			return;
 		}
-		if (row.lookups > 0) {
-			this.pendingCoordinateLookupCount -= row.lookups;
-			this.pendingCoordinateLookupCountByPeer.delete(peer);
-		}
-		if (row.responses > 0) {
-			this.pendingCoordinateResponseCount -= row.responses;
-			this.pendingCoordinateResponseCountByPeer.delete(peer);
-		}
-		if (row.active > 0) {
-			this.activeMaybeSyncResponseCount -= row.active;
-			this.activeMaybeSyncResponseCountByPeer.delete(peer);
-		}
+		// Disconnect returns only the current peer generation's quota. The
+		// global counters represent physically live, potentially non-abortable
+		// work and remain charged until each captured release actually settles.
+		this.pendingCoordinateLookupCountByPeer.delete(peer);
+		this.pendingCoordinateResponseCountByPeer.delete(peer);
+		this.activeMaybeSyncResponseCountByPeer.delete(peer);
 		if (row.pendingResponseHashes > 0) {
 			// Active authorizations' hash budget returns in aggregate with the
 			// row. The settled releases below (and any late ship-side release)
@@ -2864,12 +2886,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			row.pendingResponseHashes = 0;
 			this.schedulePendingMaybeSyncResponseWaiter();
 		}
-		// Counters are settled; now settle the outstanding active-response
-		// leases so their authorizations leave pendingMaybeSyncResponses and
-		// responseLeases/retainedWork drain, letting the dispatch lifecycle
-		// dispose. The released-guard makes the eventual ship-side release
-		// inert, and the closures captured THIS row (identity, not peer hash),
-		// so a reconnected successor's row is never touched.
+		// Settle only logical active-response ownership so authorizations leave
+		// pendingMaybeSyncResponses and responseLeases/retainedWork drain. The
+		// eventual ship-side release still returns its global physical permit.
+		// Closures capture THIS row (identity, not peer hash), so a reconnected
+		// successor's row is never touched.
 		for (const release of [...row.activeReleases]) {
 			release();
 		}
@@ -2879,7 +2900,9 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 		this.peerSlotRows.maybeDropIdle(row);
 	}
 
-	private tryAcquireCoordinateLookup(peer: string): (() => void) | undefined {
+	private tryAcquireCoordinateLookup(
+		peer: string,
+	): { row: SyncPeerSlotRow; release: () => void } | undefined {
 		if (!this.canStartPendingSyncLookup(peer)) {
 			return undefined;
 		}
@@ -2891,17 +2914,17 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 0) + 1,
 		);
 		let released = false;
-		return () => {
+		const release = () => {
 			if (released) {
 				return;
 			}
 			released = true;
 			row.lookups -= 1;
+			this.pendingCoordinateLookupCount -= 1;
 			if (!row.attached) {
-				// The quota already returned in aggregate when the row detached.
+				// Per-peer quota returned when this generation detached.
 				return;
 			}
-			this.pendingCoordinateLookupCount -= 1;
 			const remaining =
 				(this.pendingCoordinateLookupCountByPeer.get(peer) ?? 1) - 1;
 			if (remaining === 0) {
@@ -2911,6 +2934,7 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			}
 			this.maybeDropIdleSyncResponseSlotRow(row);
 		};
+		return { row, release };
 	}
 
 	private tryAcquireCoordinateResponse(peer: string): (() => void) | undefined {
@@ -2936,11 +2960,11 @@ export class SimpleSyncronizer<R extends "u32" | "u64">
 			}
 			released = true;
 			row.responses -= 1;
+			this.pendingCoordinateResponseCount -= 1;
 			if (!row.attached) {
-				// The quota already returned in aggregate when the row detached.
+				// Per-peer quota returned when this generation detached.
 				return;
 			}
-			this.pendingCoordinateResponseCount -= 1;
 			const remaining =
 				(this.pendingCoordinateResponseCountByPeer.get(peer) ?? 1) - 1;
 			if (remaining === 0) {

--- a/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
+++ b/packages/programs/data/shared-log/src/sync/sync-peer-state.ts
@@ -8,26 +8,27 @@
 //
 // | field                        | created            | cleared                    |
 // |------------------------------|--------------------|----------------------------|
-// | lookups / responses / active | first slot acquire | release closure settles;   |
-// |                              |                    | row DETACHES at peer       |
-// |                              |                    | disconnect (quota returns  |
-// |                              |                    | in aggregate; late         |
-// |                              |                    | releases settle against    |
-// |                              |                    | the detached row)          |
+// | lookups / responses / active | first slot acquire | physical release settles;  |
+// |                              |                    | row DETACH only removes    |
+// |                              |                    | current peer-generation    |
+// |                              |                    | quota (global quota stays  |
+// |                              |                    | charged until settlement)  |
 // | pendingResponseHashes        | consume accepts an | lease release settles      |
 // | (simple synchronizer only)   | authorization      | while attached; row        |
 // |                              | (custody moves     | DETACHES at peer           |
 // |                              | batch -> row)      | disconnect (budget returns |
 // |                              |                    | in aggregate)              |
-// | activeReleases               | consume creates an | release settles (self-     |
-// | (simple synchronizer only)   | active-response    | removal); detach invokes   |
-// |                              | lease              | the outstanding releases   |
-// |                              |                    | so retained work drains    |
+// | activeReleases               | active-response or | logical release settles    |
+// |                              | coordinate         | (self-removal); detach     |
+// |                              | dispatch starts    | invokes outstanding        |
+// |                              |                    | logical releases so        |
+// |                              |                    | retained work drains       |
 //
-// Slot accounting deliberately SURVIVES close()/open() generation rotation
-// on both synchronizers: the underlying storage resolvers and transport
-// sends are not universally abortable, so cross-generation work stays
-// charged until it settles. Only a peer disconnect detaches a row.
+// Global physical-work accounting deliberately SURVIVES both close()/open()
+// generation rotation and peer disconnect: the underlying storage resolvers
+// and transport sends are not universally abortable, so cross-generation
+// work stays charged until it settles. Disconnect only detaches the row from
+// the current peer generation and releases logical lifecycle ownership.
 //
 // Deliberately host-side this stage (stage-5 folds them into the host peer
 // sessions): dispatch epochs and dispatch-target sets (benchmark-gated hot
@@ -47,11 +48,11 @@ export type SyncPeerSlotRow = {
 	// disconnect can return the budget even when the response ship never
 	// settles. Always 0 on rateless rows.
 	pendingResponseHashes: number;
-	// Outstanding active-response lease releases (simple synchronizer only).
-	// Releases self-remove when the ship settles; detach invokes the
-	// remainder so responseLeases/retainedWork drain and the dispatch
-	// lifecycle can dispose — the released-guard makes the eventual late
-	// ship-side release inert. Always empty on rateless rows.
+	// Outstanding disconnect-time LOGICAL releases. Both synchronizers put
+	// active-response lifecycle cleanup here; Simple also puts coordinate
+	// dispatch completion here. Detach invokes the remainder so retained work
+	// and dispatch listeners drain. Each eventual async completion separately
+	// returns its global physical permit exactly once.
 	activeReleases: Set<() => void>;
 };
 
@@ -75,10 +76,10 @@ export class SyncPeerSlotRegistry {
 		return row;
 	}
 
-	// Detaches and returns the peer's row (or undefined when the peer holds
-	// no slots). The caller subtracts the returned counters from its
-	// aggregate quota; release closures that still hold the row settle
-	// against it aggregate-neutrally.
+	// Detaches and returns the peer's row (or undefined when the peer holds no
+	// slots). The caller drops only current-generation/per-peer accounting and
+	// logical ownership. Physical release closures retain this row by identity
+	// and return global quota only when the underlying work actually settles.
 	detach(peer: string): SyncPeerSlotRow | undefined {
 		const row = this.rows.get(peer);
 		if (!row) {

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -2693,7 +2693,7 @@ describe("sync-chunking", () => {
 		}
 	});
 
-	it("returns coordinate lookup permits when their peer disconnects", async () => {
+	it("keeps coordinate lookup permits globally charged across disconnect", async () => {
 		const releases: ((hashes: string[]) => void)[] = [];
 		const resolveHashListForSymbols = sinon.stub().callsFake(
 			() =>
@@ -2739,11 +2739,12 @@ describe("sync-chunking", () => {
 				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
 			);
 
-			// Disconnect returns the peer's whole lookup quota immediately even
-			// though the resolver work is still alive; the detached slots settle
-			// aggregate-neutrally later.
+			// Disconnect returns the current peer generation's quota immediately,
+			// but the non-abortable resolver work remains globally charged.
 			sync.onPeerDisconnected(peerA);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
 			expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(0);
 
 			pending.push(
@@ -2757,13 +2758,17 @@ describe("sync-chunking", () => {
 					resolveHashListForSymbols.callCount ===
 					MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER + 1,
 			);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER + 1,
+			);
 
-			// A pre-disconnect lookup settling late never decrements the
-			// reconnected peer's fresh accounting.
+			// A pre-disconnect lookup settling late returns its global permit but
+			// never decrements the reconnected peer's fresh per-peer accounting.
 			releases.shift()!([]);
 			await pending.shift();
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
+			expect((sync as any).pendingCoordinateLookupCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			);
 			expect(
 				(sync as any).pendingCoordinateLookupCountByPeer.get(peerA.hashcode()),
 			).to.equal(1);

--- a/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-memory-pins.spec.ts
@@ -2,9 +2,16 @@ import { Cache } from "@peerbit/cache";
 import { Ed25519Keypair } from "@peerbit/crypto";
 import { expect } from "chai";
 import sinon from "sinon";
-import { RatelessIBLTSynchronizer } from "../src/sync/rateless-iblt.js";
 import {
+	MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL,
+	RatelessIBLTSynchronizer,
+} from "../src/sync/rateless-iblt.js";
+import {
+	MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL,
+	MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_GLOBAL,
+	MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER,
 	MAX_PENDING_SIMPLE_SYNC_KEYS_PER_PEER,
+	MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL,
 	MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
 	PENDING_SIMPLE_SYNC_KEY_TTL_MS,
 	RequestMaybeSyncCoordinate,
@@ -393,10 +400,11 @@ describe("sync-chunking memory pins", () => {
 	});
 });
 
-// Stage-4 memory-growth pins (the leak fix). Storage resolvers and transport
-// sends are not universally abortable: a call that never settles after its
-// peer disconnected must not pin the peer's (or the global) slot quota. The
-// release closures capture per-peer slot rows; disconnect detaches the row.
+// Stage-4 memory-growth pins. Storage resolvers and transport sends are not
+// universally abortable: disconnect must detach the peer generation without
+// returning the GLOBAL physical-work permit until the call actually settles.
+// Otherwise repeated reconnects bypass the global cap. Release closures
+// capture per-peer slot rows so late settlement cannot touch a successor row.
 describe("sync-chunking slot-quota pins", () => {
 	let peerA: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
 	let peerB: Awaited<ReturnType<typeof Ed25519Keypair.create>>["publicKey"];
@@ -418,7 +426,7 @@ describe("sync-chunking slot-quota pins", () => {
 		throw new Error("condition was not reached");
 	};
 
-	it("releases a disconnected peer's mid-lookup slots and restores the full quota", async () => {
+	it("keeps disconnected never-settling lookups within the global physical-work cap", async () => {
 		const resolveHashesForSymbols = sinon.stub().returns(new Promise(() => {}));
 		const sync = new SimpleSyncronizer<"u64">({
 			rpc: { send: sinon.stub().resolves() } as any,
@@ -428,50 +436,67 @@ describe("sync-chunking slot-quota pins", () => {
 			resolveHashesForSymbols,
 		});
 		try {
+			for (
+				let cycle = 0;
+				cycle <
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL /
+					MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
+				cycle += 1
+			) {
+				for (
+					let index = 0;
+					index < MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
+					index += 1
+				) {
+					void sync.onMessage(
+						new RequestMaybeSyncCoordinate({
+							hashNumbers: [BigInt(cycle * 100 + index)],
+						}),
+						{ from: peerA } as any,
+					);
+				}
+				const expected = (cycle + 1) * MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
+				await waitFor(() => resolveHashesForSymbols.callCount === expected);
+				expect((sync as any).pendingCoordinateLookupCount).to.equal(expected);
+				expect(
+					(sync as any).pendingCoordinateLookupCountByPeer.get(
+						peerA.hashcode(),
+					),
+				).to.equal(MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER);
+				const targetLifecycles = [
+					...((sync as any).syncDispatchRegistry.activeTargets.get(
+						peerA.hashcode(),
+					) ?? []),
+				] as any[];
+
+				sync.onPeerDisconnected(peerA);
+				// Logical/per-peer state is fresh for a reconnect, while the old
+				// non-abortable calls remain globally charged.
+				expect((sync as any).pendingCoordinateLookupCount).to.equal(expected);
+				expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(
+					0,
+				);
+				expect((sync as any).peerSlotRows.rows.size).to.equal(0);
+				expect(
+					(sync as any).syncDispatchRegistry.activeTargets.has(
+						peerA.hashcode(),
+					),
+				).to.equal(false);
+				for (const targetLifecycle of targetLifecycles) {
+					expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+				}
+			}
+
 			void sync.onMessage(
-				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+				new RequestMaybeSyncCoordinate({ hashNumbers: [999n] }),
 				{ from: peerA } as any,
 			);
-			await waitFor(() => resolveHashesForSymbols.callCount === 1);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(1);
-			expect(
-				(sync as any).pendingCoordinateLookupCountByPeer.get(peerA.hashcode()),
-			).to.equal(1);
-
-			sync.onPeerDisconnected(peerA);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
-			expect((sync as any).pendingCoordinateLookupCountByPeer.size).to.equal(0);
-			expect((sync as any).peerSlotRows.rows.size).to.equal(0);
-
-			// The reconnected peer gets its full lookup quota back even though
-			// the old resolver calls never settle.
-			for (
-				let index = 0;
-				index < MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER;
-				index += 1
-			) {
-				void sync.onMessage(
-					new RequestMaybeSyncCoordinate({
-						hashNumbers: [BigInt(10 + index)],
-					}),
-					{ from: peerA } as any,
-				);
-			}
-			await waitFor(
-				() =>
-					resolveHashesForSymbols.callCount ===
-					1 + MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+			await Promise.resolve();
+			expect(resolveHashesForSymbols.callCount).to.equal(
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL,
 			);
 			expect((sync as any).pendingCoordinateLookupCount).to.equal(
-				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
-			);
-
-			await sync.onMessage(
-				new RequestMaybeSyncCoordinate({ hashNumbers: [99n] }),
-				{ from: peerA } as any,
-			);
-			expect(resolveHashesForSymbols.callCount).to.equal(
-				1 + MAX_PENDING_SIMPLE_SYNC_LOOKUPS_PER_PEER,
+				MAX_PENDING_SIMPLE_SYNC_LOOKUPS_GLOBAL,
 			);
 		} finally {
 			await sync.close();
@@ -508,7 +533,7 @@ describe("sync-chunking slot-quota pins", () => {
 		}
 	});
 
-	it("releases a blocked response-ship slot when the peer disconnects", async () => {
+	it("keeps disconnected response ships within the global physical-work cap", async () => {
 		let releaseShip!: () => void;
 		const blockedShip = new Promise<{ messages: number; fused: boolean }>(
 			(resolve) => {
@@ -525,31 +550,74 @@ describe("sync-chunking slot-quota pins", () => {
 		const ship = sinon
 			.stub(sync as any, "shipExchangeHeads")
 			.returns(blockedShip);
+		const handlings: Promise<boolean>[] = [];
 		try {
-			const handling = sync.onMessage(
-				new RequestMaybeSyncCoordinate({ hashNumbers: [1n] }),
+			for (
+				let cycle = 0;
+				cycle <
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_GLOBAL /
+					MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER;
+				cycle += 1
+			) {
+				for (
+					let index = 0;
+					index < MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER;
+					index += 1
+				) {
+					handlings.push(
+						sync.onMessage(
+							new RequestMaybeSyncCoordinate({
+								hashNumbers: [BigInt(cycle * 100 + index)],
+							}),
+							{ from: peerA } as any,
+						),
+					);
+				}
+				const expected =
+					(cycle + 1) * MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_PER_PEER;
+				await waitFor(() => ship.callCount === expected);
+				expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
+				expect((sync as any).pendingCoordinateResponseCount).to.equal(expected);
+
+				const targetLifecycles = [
+					...((sync as any).syncDispatchRegistry.activeTargets.get(
+						peerA.hashcode(),
+					) ?? []),
+				] as any[];
+				sync.onPeerDisconnected(peerA);
+				expect((sync as any).pendingCoordinateResponseCount).to.equal(expected);
+				expect(
+					(sync as any).pendingCoordinateResponseCountByPeer.size,
+				).to.equal(0);
+				expect((sync as any).peerSlotRows.rows.size).to.equal(0);
+				expect(
+					(sync as any).syncDispatchRegistry.activeTargets.has(
+						peerA.hashcode(),
+					),
+				).to.equal(false);
+				for (const targetLifecycle of targetLifecycles) {
+					expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+				}
+			}
+
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [999n] }),
 				{ from: peerA } as any,
 			);
-			await waitFor(() => ship.callCount === 1);
-			expect((sync as any).pendingCoordinateLookupCount).to.equal(0);
-			expect((sync as any).pendingCoordinateResponseCount).to.equal(1);
-
-			sync.onPeerDisconnected(peerA);
-			expect((sync as any).pendingCoordinateResponseCount).to.equal(0);
-			expect((sync as any).pendingCoordinateResponseCountByPeer.size).to.equal(
-				0,
+			expect(ship.callCount).to.equal(
+				MAX_PENDING_SIMPLE_COORDINATE_RESPONSES_GLOBAL,
 			);
-			expect((sync as any).peerSlotRows.rows.size).to.equal(0);
 
-			// The blocked ship settling late is aggregate-neutral.
+			// Only actual settlement returns the global physical-work permits.
 			releaseShip();
-			await handling;
+			await Promise.all(handlings);
 			expect((sync as any).pendingCoordinateResponseCount).to.equal(0);
 			expect((sync as any).pendingCoordinateResponseCountByPeer.size).to.equal(
 				0,
 			);
 		} finally {
 			releaseShip();
+			await Promise.all(handlings);
 			await sync.close();
 		}
 	});
@@ -577,7 +645,11 @@ describe("sync-chunking slot-quota pins", () => {
 		const active: Promise<boolean>[] = [];
 		try {
 			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
-			for (let cycle = 0; cycle < 2; cycle += 1) {
+			for (
+				let cycle = 0;
+				cycle < MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL;
+				cycle += 1
+			) {
 				const hashes = [0, 1, 2].map((index) => `flap-${cycle}-${index}`);
 				const reservation = sync.expectMaybeSyncResponse({
 					hashes,
@@ -607,6 +679,12 @@ describe("sync-chunking slot-quota pins", () => {
 				expect((sync as any).syncDispatchRegistry.activeTargets.size).to.equal(
 					0,
 				);
+				// Logical cleanup is immediate, but each non-abortable shipment still
+				// owns one global physical-work permit until it settles.
+				expect((sync as any).activeMaybeSyncResponseCount).to.equal(cycle + 1);
+				expect((sync as any).activeMaybeSyncResponseCountByPeer.size).to.equal(
+					0,
+				);
 			}
 
 			// The full authorization window is reservable again after the flaps.
@@ -618,6 +696,15 @@ describe("sync-chunking slot-quota pins", () => {
 				targets: [peerB.hashcode()],
 			});
 			expect(reclaimed).to.not.equal(undefined);
+			await sync.onMessage(
+				new ResponseMaybeSyncCapabilities({ hashes: ["flap-reclaimed-0"] }),
+				{ from: peerB } as any,
+			);
+			// The logical authorization window is available, but the live physical
+			// shipments still enforce the independent global admission cap.
+			expect(sendRawExchangeHeads.callCount).to.equal(
+				MAX_ACTIVE_SIMPLE_SYNC_RESPONSES_GLOBAL,
+			);
 			reclaimed!.release();
 			expect((sync as any).pendingMaybeSyncResponseCount).to.equal(0);
 		} finally {
@@ -625,11 +712,12 @@ describe("sync-chunking slot-quota pins", () => {
 				hang();
 			}
 			await Promise.all(active);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
 			await sync.close();
 		}
 	});
 
-	it("releases a disconnected peer's active response slots without touching a successor", async () => {
+	it("keeps old active response work globally charged without touching a successor", async () => {
 		const releases: (() => void)[] = [];
 		const sendRawExchangeHeads = sinon.stub().callsFake(
 			() =>
@@ -658,10 +746,22 @@ describe("sync-chunking slot-quota pins", () => {
 			);
 			await waitFor(() => sendRawExchangeHeads.callCount === 1);
 			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
+			first?.release();
+			const firstTargetLifecycles = [
+				...((sync as any).syncDispatchRegistry.activeTargets.get(
+					peerA.hashcode(),
+				) ?? []),
+			] as any[];
 
 			sync.onPeerDisconnected(peerA);
-			expect((sync as any).activeMaybeSyncResponseCount).to.equal(0);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
 			expect((sync as any).activeMaybeSyncResponseCountByPeer.size).to.equal(0);
+			expect(
+				(sync as any).syncDispatchRegistry.activeTargets.has(peerA.hashcode()),
+			).to.equal(false);
+			for (const targetLifecycle of firstTargetLifecycles) {
+				expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+			}
 
 			// The reconnected peer's fresh response work uses a fresh row.
 			const second = sync.expectMaybeSyncResponse({
@@ -675,7 +775,8 @@ describe("sync-chunking slot-quota pins", () => {
 				),
 			);
 			await waitFor(() => sendRawExchangeHeads.callCount === 2);
-			expect((sync as any).activeMaybeSyncResponseCount).to.equal(1);
+			expect((sync as any).activeMaybeSyncResponseCount).to.equal(2);
+			second?.release();
 
 			// The pre-disconnect ship settling late never decrements the
 			// successor's accounting.
@@ -694,8 +795,6 @@ describe("sync-chunking slot-quota pins", () => {
 			// idle row must drop eagerly from the registry, not linger until the
 			// next disconnect.
 			expect((sync as any).peerSlotRows.rows.size).to.equal(0);
-			first?.release();
-			second?.release();
 		} finally {
 			for (const release of releases) {
 				release();
@@ -812,7 +911,7 @@ describe("rateless-iblt-syncronizer slot-quota pins", () => {
 		return entries;
 	};
 
-	it("frees a disconnected peer's response slots while open keeps accounting", async () => {
+	it("detaches rateless logical state while physical work stays globally charged", async () => {
 		const sync = createRateless();
 		const releases: (() => void)[] = [];
 		let blockShipments = true;
@@ -838,12 +937,20 @@ describe("rateless-iblt-syncronizer slot-quota pins", () => {
 			);
 			await waitFor(() => ship.callCount === 1);
 			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+			const firstTargetLifecycle = [
+				...(sync as any).ratelessDispatchRegistry.activeTargets.get("peer-a"),
+			][0] as any;
 
 			sync.onPeerDisconnected("peer-a");
-			expect((sync as any).activeRatelessResponseCount).to.equal(0);
+			expect((sync as any).activeRatelessResponseCount).to.equal(1);
 			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
 			expect((sync as any).outgoingSyncProcessByTarget.size).to.equal(0);
 			expect((sync as any).ratelessPeerSlotRows.rows.size).to.equal(0);
+			expect(
+				(sync as any).ratelessDispatchRegistry.activeTargets.has("peer-a"),
+			).to.equal(false);
+			expect(firstTargetLifecycle.responseLeases).to.equal(0);
+			expect(firstTargetLifecycle.lifecycle.disposed).to.equal(true);
 
 			// The reconnected peer's fresh process gets a fresh row.
 			await sync.onMaybeMissingEntries({
@@ -856,20 +963,25 @@ describe("rateless-iblt-syncronizer slot-quota pins", () => {
 				} as any),
 			);
 			await waitFor(() => ship.callCount === 2);
-			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+			expect((sync as any).activeRatelessResponseCount).to.equal(2);
 
 			// open() rotation deliberately does NOT clear slot accounting:
 			// cross-generation ship work is charged until it settles.
 			await sync.open();
-			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+			expect((sync as any).activeRatelessResponseCount).to.equal(2);
 
 			blockShipments = false;
-			for (const release of releases) {
-				release();
-			}
-			await Promise.all(handlings);
-			// The pre-disconnect lease settles aggregate-neutrally; the live
-			// lease returns its slot.
+			releases.shift()!();
+			await handlings.shift();
+			// The old row returns only its global permit; the successor's attached
+			// per-peer accounting is untouched.
+			expect((sync as any).activeRatelessResponseCount).to.equal(1);
+			expect(
+				(sync as any).activeRatelessResponseCountByPeer.get("peer-a"),
+			).to.equal(1);
+
+			releases.shift()!();
+			await handlings.shift();
 			expect((sync as any).activeRatelessResponseCount).to.equal(0);
 			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
 			// The successor's lease settled while ATTACHED (no disconnect): the
@@ -881,6 +993,124 @@ describe("rateless-iblt-syncronizer slot-quota pins", () => {
 			for (const release of releases) {
 				release();
 			}
+			await sync.close();
+		}
+	});
+
+	it("keeps flapping rateless response ships within the global cap", async () => {
+		const sync = createRateless();
+		const releases: (() => void)[] = [];
+		const ship = sinon
+			.stub(sync.simple, "shipAuthorizedMaybeSyncResponse")
+			.callsFake(
+				() =>
+					new Promise<{ messages: number; fused: boolean; entries: number }>(
+						(resolve) => {
+							releases.push(() =>
+								resolve({ messages: 1, fused: false, entries: 1 }),
+							);
+						},
+					),
+			);
+		const from = { hashcode: () => "peer-a" } as any;
+		const handlings: Promise<boolean>[] = [];
+		try {
+			for (
+				let cycle = 0;
+				cycle < MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL;
+				cycle += 1
+			) {
+				await sync.onMaybeMissingEntries({
+					entries: createEntries(),
+					targets: ["peer-a"],
+				});
+				handlings.push(
+					sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+						from,
+					} as any),
+				);
+				await waitFor(() => ship.callCount === cycle + 1);
+				const targetLifecycle = [
+					...(sync as any).ratelessDispatchRegistry.activeTargets.get("peer-a"),
+				][0] as any;
+
+				sync.onPeerDisconnected("peer-a");
+				expect((sync as any).activeRatelessResponseCount).to.equal(cycle + 1);
+				expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(
+					0,
+				);
+				expect((sync as any).outgoingSyncProcessByTarget.size).to.equal(0);
+				expect((sync as any).ratelessPeerSlotRows.rows.size).to.equal(0);
+				expect(
+					(sync as any).ratelessDispatchRegistry.activeTargets.has("peer-a"),
+				).to.equal(false);
+				expect(targetLifecycle.responseLeases).to.equal(0);
+				expect(targetLifecycle.lifecycle.disposed).to.equal(true);
+			}
+
+			// A fresh process can exist, but its response is not admitted while all
+			// 32 physical shipments are still alive.
+			await sync.onMaybeMissingEntries({
+				entries: createEntries(),
+				targets: ["peer-a"],
+			});
+			await sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+				from,
+			} as any);
+			expect(ship.callCount).to.equal(MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL);
+			sync.onPeerDisconnected("peer-a");
+
+			// One old settlement creates exactly one global opening.
+			releases.shift()!();
+			await handlings.shift();
+			expect((sync as any).activeRatelessResponseCount).to.equal(
+				MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL - 1,
+			);
+			await sync.onMaybeMissingEntries({
+				entries: createEntries(),
+				targets: ["peer-a"],
+			});
+			handlings.push(
+				sync.onMessage(new ResponseMaybeSync({ hashes: ["hash-0"] }), {
+					from,
+				} as any),
+			);
+			await waitFor(
+				() => ship.callCount === MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL + 1,
+			);
+			expect((sync as any).activeRatelessResponseCount).to.equal(
+				MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL,
+			);
+			expect(
+				(sync as any).activeRatelessResponseCountByPeer.get("peer-a"),
+			).to.equal(1);
+			const successorLifecycle = [
+				...(sync as any).ratelessDispatchRegistry.activeTargets.get("peer-a"),
+			][0] as any;
+
+			// A second old row settles without touching the successor's per-peer row.
+			releases.shift()!();
+			await handlings.shift();
+			expect((sync as any).activeRatelessResponseCount).to.equal(
+				MAX_ACTIVE_RATELESS_RESPONSES_GLOBAL - 1,
+			);
+			expect(
+				(sync as any).activeRatelessResponseCountByPeer.get("peer-a"),
+			).to.equal(1);
+
+			sync.onPeerDisconnected("peer-a");
+			expect((sync as any).activeRatelessResponseCountByPeer.size).to.equal(0);
+			expect(
+				(sync as any).ratelessDispatchRegistry.activeTargets.has("peer-a"),
+			).to.equal(false);
+			expect(successorLifecycle.responseLeases).to.equal(0);
+			expect(successorLifecycle.lifecycle.disposed).to.equal(true);
+		} finally {
+			for (const release of releases) {
+				release();
+			}
+			await Promise.all(handlings);
+			expect((sync as any).activeRatelessResponseCount).to.equal(0);
 			await sync.close();
 		}
 	});


### PR DESCRIPTION
## Summary

- keep global physical sync-work permits charged until non-abortable lookups and response shipments actually settle
- detach per-peer generation quota and dispatch lifecycle state immediately on disconnect
- ensure late completions from an old connection cannot mutate a reconnected peer row
- cover Simple and Rateless disconnect/reconnect flapping through their 32-operation global caps

## Why

The shared-log refactor returned both per-peer and global counters at disconnect even when the underlying storage resolver or transport send remained alive. A peer could repeatedly reconnect and recycle its per-peer quota, bypassing the global cap and accumulating unresolved work, retained buffers, and async frames.

## Validation

- focused disconnect/accounting suite: 8 passing
- broader focused lifecycle/accounting suite: 68 passing
- shared-log build passes
- full shared-log run: 2347 passing, 10 pending; one timing-sensitive raw-send telemetry assertion failed, then passed on exact reruns on both untouched master and this branch. That path does not exercise disconnect accounting.