### PR TITLE
fix(document): normalize duplicate log package entries

### DIFF
--- a/.changeset/document-cross-copy-entry.md
+++ b/.changeset/document-cross-copy-entry.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/document": patch
+"@peerbit/log": patch
+---
+
+Normalize log entries from duplicate package installations across both sides of
+remote indexed-query responses, preventing valid responses from timing out or
+being rejected when the same `@peerbit/log` version has multiple runtime class
+identities.

--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -517,6 +517,44 @@ type EntryWithMetaBytes = {
 	getHashDigestBytes?: () => Uint8Array | undefined;
 };
 
+/**
+ * Package managers can install the same @peerbit/log version at more than one
+ * physical path. Those entries retain the full Entry contract but fail a
+ * local instanceof check because their constructor has a different identity.
+ */
+const isFullEntry = (value: unknown): value is Entry<any> => {
+	if (value instanceof Entry) {
+		return true;
+	}
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const candidate = value as Partial<Entry<any>>;
+	return (
+		typeof candidate.hash === "string" &&
+		typeof candidate.init === "function" &&
+		typeof candidate.getNext === "function" &&
+		typeof candidate.getClock === "function" &&
+		typeof candidate.getStorageBytes === "function" &&
+		typeof candidate.verifySignatures === "function"
+	);
+};
+
+const normalizeFullEntry = <T>(value: unknown): Entry<T> => {
+	if (value instanceof Entry) {
+		return value as Entry<T>;
+	}
+	const entry = value as Entry<any>;
+	const normalized = deserialize(entry.getStorageBytes(), Entry) as Entry<T>;
+	if (normalized.hash && normalized.hash !== entry.hash) {
+		throw new Error(
+			"Entry hash changed while normalizing its runtime identity",
+		);
+	}
+	normalized.hash = entry.hash;
+	return normalized;
+};
+
 type MutationCallback = (...args: any[]) => any;
 
 @variant(0)
@@ -3882,7 +3920,7 @@ export class Log<T> {
 				continue;
 			}
 			let nextEntry: Entry<any>;
-			if (e instanceof Entry) {
+			if (isFullEntry(e)) {
 				nextEntry = e;
 			} else {
 				const resolved = await this.entryIndex.get(e.hash);
@@ -4303,22 +4341,23 @@ export class Log<T> {
 							entriesOrLog.map((element) =>
 								typeof element === "string"
 									? element
-									: element instanceof Entry
+									: isFullEntry(element)
 										? element.hash
 										: element instanceof ShallowEntry
 											? element.hash
-											: element.entry.hash,
+											: (element as EntryWithRefs<T>).entry.hash,
 							),
 						);
 
 			entries = [];
 			for (const element of entriesOrLog) {
-				if (element instanceof Entry) {
-					if (existingHashes.has(element.hash)) {
+				if (isFullEntry(element)) {
+					const fullEntry = normalizeFullEntry<T>(element);
+					if (existingHashes.has(fullEntry.hash)) {
 						continue;
 					}
-					entries.push(element);
-					references.set(element.hash, element);
+					entries.push(fullEntry);
+					references.set(fullEntry.hash, fullEntry);
 					continue;
 				}
 
@@ -4380,9 +4419,10 @@ export class Log<T> {
 					continue;
 				}
 
-				entries.push(element.entry);
-				references.set(element.entry.hash, element.entry);
-				for (const ref of element.references) {
+				const entryWithRefs = element as EntryWithRefs<T>;
+				entries.push(entryWithRefs.entry);
+				references.set(entryWithRefs.entry.hash, entryWithRefs.entry);
+				for (const ref of entryWithRefs.references) {
 					references.set(ref.hash, ref);
 				}
 			}

--- a/packages/log/test/join.spec.ts
+++ b/packages/log/test/join.spec.ts
@@ -171,6 +171,26 @@ describe("join", function () {
 			expect(await log2.length).equal(1);
 		});
 
+		it("joins an entry from another runtime class identity", async () => {
+			const { entry } = await log1.append(new Uint8Array([0, 1]));
+			const foreignEntry = new Proxy(entry, {
+				get(target, property) {
+					const value = Reflect.get(target, property, target);
+					return typeof value === "function" ? value.bind(target) : value;
+				},
+				getPrototypeOf: () => Object.prototype,
+			}) as Entry<Uint8Array>;
+
+			expect(foreignEntry).not.to.be.instanceOf(Entry);
+			await log2.join([foreignEntry]);
+
+			expect(await log2.has(entry.hash)).to.be.true;
+			expect(log2.length).equal(1);
+			const joined = await log2.get(entry.hash);
+			expect(joined).to.be.instanceOf(Entry);
+			expect(joined).not.to.equal(foreignEntry);
+		});
+
 		it("will no-refetch blocks when already joined by has", async () => {
 			await log1.append(new Uint8Array([0, 1]));
 			const blockGet = log2["_storage"].get.bind(log2.blocks);

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -24,7 +24,7 @@ import {
 import { CachedIndex, type QueryCacheOptions } from "@peerbit/indexer-cache";
 import * as indexerTypes from "@peerbit/indexer-interface";
 import { HashmapIndex } from "@peerbit/indexer-simple";
-import { BORSH_ENCODING, type Encoding, type Entry } from "@peerbit/log";
+import { BORSH_ENCODING, type Encoding, Entry } from "@peerbit/log";
 import { logger as loggerFn } from "@peerbit/logger";
 import { ClosedError, Program } from "@peerbit/program";
 import {
@@ -1233,6 +1233,35 @@ export class DocumentIndex<
 		return { resolved, heads };
 	}
 
+	/**
+	 * Return a head that the local document-interface Entry schema can encode.
+	 * Consumers can install the same @peerbit/log version at more than one
+	 * physical path, giving its Entry class more than one runtime identity.
+	 * Rehydrate only foreign or hollow entries through this log's block store;
+	 * the normal colocated path preserves the existing Entry object.
+	 */
+	private getSerializableHead(
+		head: Entry<Operation> | undefined,
+	): MaybePromise<Entry<Operation> | undefined> {
+		const hash = head?.hash;
+		if (!hash) {
+			return head;
+		}
+		if (head instanceof Entry) {
+			try {
+				head.getStorageBytes();
+				return head;
+			} catch {
+				// A native-backed head may be hollow until read from the block store.
+			}
+			return Entry.fromMultihash<Operation>(
+				this._log.log.blocks,
+				hash,
+			).catch(() => head);
+		}
+		return Entry.fromMultihash<Operation>(this._log.log.blocks, hash);
+	}
+
 	private async wrapPushResults(
 		matches: Array<WithContext<T> | WithContext<I>>,
 		resolve: boolean,
@@ -1270,6 +1299,9 @@ export class DocumentIndex<
 				headsByMatch[position] = indexedBatch.heads[i];
 			}
 		}
+		const serializableHeads = await Promise.all(
+			headsByMatch.map((head) => this.getSerializableHead(head)),
+		);
 		const results: types.Result[] = [];
 		for (let i = 0; i < matches.length; i++) {
 			const match = matches[i]!;
@@ -1304,7 +1336,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = headsByMatch[i];
+				const head = serializableHeads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1315,7 +1347,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const indexed = match as WithContext<I>;
-				const head = headsByMatch[i];
+				const head = serializableHeads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: indexed.__context,
@@ -1350,6 +1382,9 @@ export class DocumentIndex<
 			: await this._log.log.getMany(
 					drained.map((entry) => entry.value.__context.head),
 				);
+		const serializableHeads = await Promise.all(
+			heads.map((head) => this.getSerializableHead(head)),
+		);
 		const results: types.Result[] = [];
 		for (let i = 0; i < drained.length; i++) {
 			const entry = drained[i]!;
@@ -1371,7 +1406,7 @@ export class DocumentIndex<
 					continue;
 				}
 
-				const head = heads[i];
+				const head = serializableHeads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -1381,7 +1416,7 @@ export class DocumentIndex<
 					}),
 				);
 			} else {
-				const head = heads[i];
+				const head = serializableHeads[i];
 				results.push(
 					new types.ResultIndexedValue({
 						context: entry.value.__context,
@@ -3775,6 +3810,9 @@ export class DocumentIndex<
 						candidates.map(({ result }) => result.value.__context.head),
 					)
 				: [];
+		const serializableHeads = resolveDocumentsFlag
+			? heads
+			: await Promise.all(heads.map((head) => this.getSerializableHead(head)));
 		const filteredResults: types.Result[] = [];
 		for (let i = 0; i < candidates.length; i++) {
 			const { result, indexed: indexedUnwrapped } = candidates[i]!;
@@ -3795,7 +3833,7 @@ export class DocumentIndex<
 				);
 			} else {
 				const context = result.value.__context;
-				const head = heads[i];
+				const head = serializableHeads[i];
 				if (replicateIndexFlag) {
 					if (!head) {
 						continue;

--- a/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
+++ b/packages/programs/data/document/document/test/NATIVE_CONFORMANCE.md
@@ -215,6 +215,14 @@ objects through the block store. The #1027 helper remains a defensive
 serialization check, but normal native full reads arrive complete before the
 document RPC boundary.
 
+The batched-head path also preserves that boundary when package managers place
+the same `@peerbit/log` version at multiple physical paths. Such entries are
+structurally valid but fail borsh's runtime class check, so only those foreign
+instances are rehydrated through the local block store before the response is
+encoded. On receipt, the lower log recognizes the full structural Entry
+contract and normalizes it into the receiving log's local runtime identity
+instead of mistaking it for an `EntryWithRefs` wrapper.
+
 ### Not yet catalogued (deferred, out of scope for this leg)
 
 The `updates`, `replication`, `remote`, `acl`, `program as value`, `migration`,

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -19541,6 +19541,38 @@ describe("index", () => {
 				expect((getRemote as any)["__indexed"]).to.exist;
 			});
 
+			it("rehydrates a foreign Entry identity before an indexed RPC response", async () => {
+				const local = await stores[0].docs.index.get("1", { resolve: false });
+				const headHash = local!.__context.head;
+				const log = (stores[0].docs.index as any)._log.log;
+				const getMany = log.getMany.bind(log);
+				let foreignHeads = 0;
+				const getManyStub = sinon
+					.stub(log, "getMany")
+					.callsFake(async (...args: unknown[]) =>
+						(await getMany(args[0] as string[])).map(
+							(head: Entry<Operation> | undefined) => {
+								if (head?.hash !== headHash) {
+									return head;
+								}
+								foreignHeads++;
+								return { hash: head.hash } as unknown as Entry<Operation>;
+							},
+						),
+					);
+
+				try {
+					const remote = await stores[1].docs.index.get("1", {
+						resolve: false,
+					});
+					expect(foreignHeads).to.be.greaterThan(0);
+					expect(remote!.nameTransformed).to.eq("NAME1");
+					expect((remote as any)["__indexed"]).to.exist;
+				} finally {
+					getManyStub.restore();
+				}
+			});
+
 			it("uses indexed requests for replicated resolved remote get", async () => {
 				const processQuerySpy = sinon.spy(stores[0].docs.index, "processQuery");
 				try {


### PR DESCRIPTION
## Summary

- rehydrate indexed-result heads into the Document package graph before RPC encoding when duplicate @peerbit/log installations give entries different runtime identities
- normalize structurally complete foreign entries into the receiving Log runtime before join processing
- retain the normal same-copy object path and reject an embedded hash mismatch during normalization

## Validation

- @peerbit/log and @peerbit/document builds pass on Node 22
- focused Log cross-runtime regression: 1 passing
- focused Document indexed-query regressions: 5 passing
- exact released downstream cohort (Peerbit Examples file-share) with distinct physical @peerbit/log 6.2.14 copies: 226/226 tests passing
- previously failing non-replicating observer deletion passes in 765 ms after hotpatching these exact changes

The downstream failure without this change occurs before the response can be used: borsh rejects the sender-side Entry class identity, and accepting that object structurally on receipt is insufficient because later SharedLog code expects its own local Entry identity.