### PR TITLE
fix(shared-log): retain repair runner ownership

### DIFF
--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -1494,8 +1494,8 @@ const createRepairFrontierByMode = () =>
 	>(REPAIR_DISPATCH_MODES.map((mode) => [mode, new Map()]));
 
 const createRepairActiveTargetsByMode = () =>
-	new Map<RepairDispatchMode, Set<string>>(
-		REPAIR_DISPATCH_MODES.map((mode) => [mode, new Set()]),
+	new Map<RepairDispatchMode, Map<string, object>>(
+		REPAIR_DISPATCH_MODES.map((mode) => [mode, new Map()]),
 	);
 
 const createRepairFrontierBypassKnownPeersByMode = () =>
@@ -3246,7 +3246,7 @@ export class SharedLog<
 	>;
 	private _repairFrontierActiveTargetsByMode!: Map<
 		RepairDispatchMode,
-		Set<string>
+		Map<string, object>
 	>;
 	private _repairFrontierBypassKnownPeersByMode!: Map<
 		RepairDispatchMode,
@@ -7821,7 +7821,11 @@ export class SharedLog<
 		) {
 			return;
 		}
-		activeTargets.add(target);
+		const runnerToken = {};
+		activeTargets.set(target, runnerToken);
+		const isCurrentRunner = () =>
+			activeTargets.get(target) === runnerToken &&
+			this.isRepairLifecycleActive(repairLifecycleController);
 		const retrySchedule = resolveRepairRetrySchedule(
 			mode,
 			retryScheduleMs,
@@ -7840,12 +7844,12 @@ export class SharedLog<
 			let attemptIndex = 0;
 			try {
 				for (;;) {
-					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					if (!isCurrentRunner()) {
 						return;
 					}
 					const pending = this._repairFrontierByMode.get(mode)?.get(target);
 					if (!pending || pending.size === 0) {
-						if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+						if (!isCurrentRunner()) {
 							return;
 						}
 						this._repairFrontierBypassKnownPeersByMode
@@ -7872,7 +7876,7 @@ export class SharedLog<
 						continue;
 					}
 
-					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					if (!isCurrentRunner()) {
 						return;
 					}
 					await this.sendMaybeMissingEntriesNow(
@@ -7889,7 +7893,7 @@ export class SharedLog<
 						},
 						repairLifecycleController,
 					);
-					if (!this.isRepairLifecycleActive(repairLifecycleController)) {
+					if (!isCurrentRunner()) {
 						return;
 					}
 
@@ -7911,21 +7915,25 @@ export class SharedLog<
 					}
 				}
 			} finally {
-				activeTargets.delete(target);
-				if (
-					this.isRepairLifecycleActive(repairLifecycleController) &&
-					(this._repairFrontierByMode.get(mode)?.get(target)?.size || 0) > 0
-				) {
-					this.ensureRepairFrontierRunner(
-						mode,
-						target,
-						retryScheduleMs,
-						repairLifecycleController,
-					);
+				if (activeTargets.get(target) === runnerToken) {
+					activeTargets.delete(target);
+					if (
+						this.isRepairLifecycleActive(repairLifecycleController) &&
+						(this._repairFrontierByMode.get(mode)?.get(target)?.size || 0) > 0
+					) {
+						this.ensureRepairFrontierRunner(
+							mode,
+							target,
+							retryScheduleMs,
+							repairLifecycleController,
+						);
+					}
 				}
 			}
 		})().catch((error: any) => {
-			activeTargets.delete(target);
+			if (activeTargets.get(target) === runnerToken) {
+				activeTargets.delete(target);
+			}
 			if (this.isRepairLifecycleActive(repairLifecycleController)) {
 				logger.error(error);
 			}

--- a/packages/programs/data/shared-log/test/sync-session.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-session.spec.ts
@@ -1037,6 +1037,64 @@ describe("sync-repair-session", () => {
 		expect(result[0]!.unresolved).to.have.length(1);
 	});
 
+	it("keeps a successor repair-frontier runner owned when its predecessor settles", async () => {
+		const log = new SharedLog<unknown>();
+		log.closed = false;
+		const internals = log as any;
+		const target = "target";
+		const started: string[][] = [];
+		const releases: (() => void)[] = [];
+		const send = sinon
+			.stub(internals, "sendMaybeMissingEntriesNow")
+			.callsFake(async (...args: unknown[]) => {
+				started.push([...(args[1] as Map<string, unknown>).keys()]);
+				await new Promise<void>((resolve) => releases.push(resolve));
+			});
+
+		const dispatch = (hash: string) =>
+			internals.dispatchMaybeMissingEntries(
+				target,
+				new Map([[hash, { hash }]]),
+				{
+					bypassRecentDedupe: true,
+					mode: "churn",
+					retryScheduleMs: [0, 1_000],
+				},
+			);
+
+		try {
+			dispatch("old");
+			await Promise.resolve();
+			expect(started).to.deep.equal([["old"]]);
+			const active = internals._repairFrontierActiveTargetsByMode.get("churn");
+			const predecessorToken = active.get(target);
+
+			internals.removeRepairFrontierTarget(target);
+			dispatch("new");
+			await Promise.resolve();
+			expect(started).to.deep.equal([["old"], ["new"]]);
+			const successorToken = active.get(target);
+			expect(successorToken).to.not.equal(predecessorToken);
+
+			releases[0]!();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(started).to.deep.equal([["old"], ["new"]]);
+			expect(active.get(target)).to.equal(successorToken);
+
+			internals.clearRepairFrontierHashes(target, ["new"]);
+			releases[1]!();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(active.has(target)).to.be.false;
+		} finally {
+			for (const release of releases) {
+				release();
+			}
+			send.restore();
+		}
+	});
+
 	it("scopes removeReplicator warmup cancellation to the captured warmup generation", async () => {
 		const testSession = await TestSession.disconnected(2);
 		try {


### PR DESCRIPTION
## Summary

- assign each per-target repair-frontier runner an opaque ownership token
- prevent a cancelled predecessor from clearing or adopting a reconnected successor runner
- add a deterministic regression test covering predecessor/successor settlement ordering

## Validation

- shared-log dependency/build chain
- focused successor ownership regression
- full `sync-repair-session` suite (19 passing)
- `git diff --check`