### PR TITLE
chore: release repair runner ownership fix

### DIFF
--- a/.changeset/repair-runner-ownership.md
+++ b/.changeset/repair-runner-ownership.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Keep replacement repair-frontier runners owned when cancelled predecessors settle.


### PR DESCRIPTION
## Summary

- add the missing patch changeset for the repair-frontier runner ownership fix merged in #1192
- ensure the corrected `@peerbit/shared-log` code enters the normal version and publish flow

## Validation

- `pnpm changeset status`
- `git diff --check`