### PR TITLE
test(document): stabilize observer mixed-sort topology

### DIFF
--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -14038,6 +14038,20 @@ describe("index", () => {
 					// TODO separate setup so we don't need to close store 2 test here
 					await stores[2].close();
 					await stores[0].docs.log.replicate(false);
+					expect(await stores[0].docs.log.isReplicating()).to.be.false;
+					const writerHash = session.peers[1].identity.publicKey.hashcode();
+					await waitForResolved(
+						async () =>
+							expect([
+								...(await stores[0].docs.log.getReplicators()),
+							]).to.have.members([writerHash]),
+						{
+							timeout: 30_000,
+							delayInterval: 100,
+							timeoutMessage:
+								"observer topology did not converge to the writer",
+						},
+					);
 					const fanout = {
 						root: getDocumentTestFanout(session.peers[1]).publicKeyHash,
 						channel: {
@@ -14059,9 +14073,6 @@ describe("index", () => {
 						}
 						await (store.docs.log as any)._openFanoutChannel(fanout);
 					}
-					await waitForResolved(async () =>
-						expect((await stores[0].docs.log.getReplicators()).size).equal(1),
-					);
 					let data: number[] = [];
 					for (let i = 0; i < 100; i++) {
 						let doc = new Document({


### PR DESCRIPTION
## Summary
- wait for the resolved observer member set after disabling replication
- require the exact writer topology before setting up mixed-sort fanout
- remove the later size-only wait that could accept the wrong member

## Validation
- full workspace build on Node 22
- 26/26 focused default-core repetitions
- 2/2 focused Rust-core repetitions
- targeted document package build

This is a test-only stabilization and does not change a publishable package.
