### PR TITLE
fix(vite): normalize private e2e version

### DIFF
--- a/packages/clients/vite/e2e/package.json
+++ b/packages/clients/vite/e2e/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vite-plugin-test",
 	"private": true,
-	"version": "0.0.1s",
+	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
Normalize the malformed private Vite e2e fixture version from 0.0.1s to canonical semver 0.0.1.

This package is private and unpublished, so no changeset is required. The normalization is a prerequisite for enforcing canonical workspace version metadata in the changeset coverage guard.