### PR TITLE
feat(shared-log): add negotiated V2 sender streams

### DIFF
--- a/.changeset/v2-sender-readiness.md
+++ b/.changeset/v2-sender-readiness.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Add signed receiver-led replication-info V2 negotiation and bounded per-peer sender streams while retaining legacy announcements for mixed-version peers.

--- a/packages/programs/data/shared-log/src/exchange-heads.ts
+++ b/packages/programs/data/shared-log/src/exchange-heads.ts
@@ -351,10 +351,23 @@ export const SYNC_CAPABILITY_RAW_EXCHANGE_HEADS = 1;
 /**
  * Capability bit: the peer can decode the challenge-bound replication-info V2
  * variants [1, 6], [1, 7] and [1, 8]. This is decode support only and never
- * authorizes a sender to transmit V2. Use requires a separate receiver-led
- * negotiation that is intentionally outside this rollout.
+ * authorizes a sender to transmit V2. Use requires the separate receiver-led
+ * SEND/APPLY capability handshake below.
  */
 export const SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE = 1 << 1;
+
+/**
+ * Capability bit: the peer can honor a signed, receiver-led replication-info
+ * V2 request. This is distinct from decode support: released decode-only peers
+ * advertise bit 2 but intentionally drop every V2 frame.
+ */
+export const SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND = 1 << 2;
+
+/**
+ * Capability bit: the peer can authenticate and apply a receiver-bound V2
+ * stream. Sender-ready nodes do not advertise this until receive activation.
+ */
+export const SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY = 1 << 3;
 
 /**
  * One-shot capability advertisement, sent to a peer when it (or we) subscribe

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -154,7 +154,9 @@ import {
 	ResponseIPrune,
 	ResponseIPruneV2,
 	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
 	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
 	StashBackedRawExchangeHeadsMessage,
 	SyncCapabilitiesMessage,
 	collectRawExchangeHeadSendPlan,
@@ -235,6 +237,7 @@ import {
 	ReplicationAnnouncementCoordinator,
 	isTransientReplicationAnnouncementError,
 } from "./replication-announcement.js";
+import { ReplicationInfoV2SendCoordinator } from "./replication-info-v2-send.js";
 import {
 	type ReplicationDomainHash,
 	createReplicationDomainHash,
@@ -258,6 +261,7 @@ import {
 	type ReplicationLimits,
 	ReplicationPingMessage,
 	RequestReplicationInfoMessage,
+	RequestReplicationInfoV2Message,
 	ResponseRoleMessage,
 	StoppedReplicating,
 	decodeReplicas,
@@ -2024,7 +2028,12 @@ export class SharedLog<
 	// PeerSession the advert was staged under; promote/delete key off it.
 	private _openingSyncCapabilitiesByPeer!: Map<
 		string,
-		{ epoch: object; capabilities: number }
+		{
+			epoch: object;
+			capabilities: number;
+			transportSession?: bigint;
+			timestamp?: bigint;
+		}
 	>;
 	private _onFanoutDataFn?: (arg: any) => void;
 	private _onFanoutUnicastFn?: (arg: any) => void;
@@ -3225,6 +3234,7 @@ export class SharedLog<
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
 	private _announcements!: ReplicationAnnouncementCoordinator<R>;
+	private _v2Send!: ReplicationInfoV2SendCoordinator<R>;
 
 	// A fn for debouncing the calls for pruning
 	pruneDebouncedFn!: DebouncedAccumulatorMap<{
@@ -3286,6 +3296,10 @@ export class SharedLog<
 	// Sync capability bits advertised by peers (SyncCapabilitiesMessage), keyed
 	// by public key hash. Entries are dropped on unsubscribe/disconnect.
 	private _peerSyncCapabilities!: Map<string, number>;
+	// Signed transport session carried by the capability envelope. Kept in a
+	// parallel map so existing capability-number consumers remain unchanged.
+	private _peerSyncCapabilitySessions!: Map<string, bigint>;
+	private _peerSyncCapabilityTimestamps!: Map<string, bigint>;
 	// Pending live raw exchange-head gossip, coalesced per recipient set and
 	// flushed at the end of the current event-loop turn (or when a batch cap
 	// is hit). Only used when every recipient advertised raw capability.
@@ -3355,6 +3369,7 @@ export class SharedLog<
 				this._announcements.queueCurrentReplicationStateAnnouncementRepair(),
 			queueCurrentReplicationStateAnnouncementRetry: (error: unknown) =>
 				this._announcements.queueCurrentReplicationStateAnnouncementRetry(error),
+			enqueueReplicationInfoV2: (message) => this._v2Send.enqueue(message),
 			isClosed: () => this.closed,
 			getCloseSignal: () => this._closeController.signal,
 			getMyReplicationSegments: () => this.getMyReplicationSegments(),
@@ -3371,6 +3386,30 @@ export class SharedLog<
 			isAdaptiveReplicating: () => this._isAdaptiveReplicating,
 			callRebalanceParticipationDebounced: () =>
 				this.rebalanceParticipationDebounced?.call(),
+		});
+	}
+
+	private createReplicationInfoV2SendCoordinator(): ReplicationInfoV2SendCoordinator<R> {
+		return new ReplicationInfoV2SendCoordinator<R>({
+			getRpc: () => this.rpc,
+			getSelfKey: () => this.node.identity.publicKey,
+			getSenderTransportSession: () =>
+				BigInt(
+					(this.node.services.pubsub as unknown as { session: number }).session,
+				),
+			getMyReplicationSegments: () => this.getMyReplicationSegments(),
+			validatePersistedReplicationRangeSnapshot: (ranges) =>
+				this.validatePersistedReplicationRangeSnapshot(ranges),
+			isClosed: () => this.closed,
+			isPeerSessionOpen: (peerHash, peerSession) =>
+				this._peerSessions.isCurrent(peerHash, peerSession) &&
+				(peerSession as PeerSession).phase === "open" &&
+				!this._peerSessions.isReplicationInfoBlocked(peerHash) &&
+				this._peerSessions.isReceiveCleanupGateOpen(peerHash),
+			captureReplicationOwnershipLifecycle: () =>
+				this.captureReplicationOwnershipLifecycle(),
+			isReplicationOwnershipLifecycleActive: (controller) =>
+				this.isRepairLifecycleActive(controller),
 		});
 	}
 
@@ -3488,6 +3527,8 @@ export class SharedLog<
 		this._appendBackfillPendingByTarget = new Map();
 		this._topicSubscribersCache = new Map();
 		this._peerSyncCapabilities = new Map();
+		this._peerSyncCapabilitySessions = new Map();
+		this._peerSyncCapabilityTimestamps = new Map();
 		this._liveRawGossipBatches = new Map();
 		this._liveRawGossipFlushScheduled = false;
 		this.coordinateToHash = new Cache<string>({ max: 1e6, ttl: 1e4 });
@@ -3496,6 +3537,7 @@ export class SharedLog<
 		this._replicatorJoinEmitted = new Set();
 		this._replicatorsReconciled = false;
 		this._liveness = this.createReplicatorLivenessMonitor();
+		this._v2Send = this.createReplicationInfoV2SendCoordinator();
 		this._announcements = this.createReplicationAnnouncementCoordinator();
 		this.pendingMaturity = new Map();
 		this._closeController = new AbortController();
@@ -3989,6 +4031,97 @@ export class SharedLog<
 				SYNC_CAPABILITY_RAW_EXCHANGE_HEADS) !==
 			0
 		);
+	}
+
+	private observePeerSyncCapabilities(properties: {
+		peerHash: string;
+		capabilities: number;
+		transportSession?: bigint;
+		timestamp?: bigint;
+		openingSession?: PeerSession;
+	}): boolean {
+		const {
+			peerHash,
+			capabilities,
+			transportSession,
+			timestamp,
+			openingSession,
+		} = properties;
+		if (openingSession) {
+			const previous = this._openingSyncCapabilitiesByPeer.get(peerHash);
+			if (
+				transportSession !== undefined &&
+				timestamp !== undefined &&
+				previous?.epoch === openingSession &&
+				previous.transportSession === transportSession
+			) {
+				if (previous.timestamp !== undefined && timestamp < previous.timestamp) {
+					return false;
+				}
+				this._openingSyncCapabilitiesByPeer.set(peerHash, {
+					epoch: openingSession,
+					capabilities: previous.capabilities | capabilities,
+					transportSession,
+					timestamp:
+						previous.timestamp === undefined || timestamp > previous.timestamp
+							? timestamp
+							: previous.timestamp,
+				});
+				return true;
+			}
+			this._openingSyncCapabilitiesByPeer.set(peerHash, {
+				epoch: openingSession,
+				capabilities,
+				transportSession,
+				timestamp,
+			});
+			return true;
+		}
+
+		if (transportSession === undefined || timestamp === undefined) {
+			// Test/in-process synthetic contexts predate signed envelope captures.
+			// They may exercise capability-number behavior, but can never authorize V2.
+			this._peerSyncCapabilities.set(peerHash, capabilities);
+			this._peerSyncCapabilitySessions.delete(peerHash);
+			this._peerSyncCapabilityTimestamps.delete(peerHash);
+			this._v2Send.advancePeerCapability(peerHash);
+			return true;
+		}
+
+		const previousSession = this._peerSyncCapabilitySessions.get(peerHash);
+		const previousTimestamp = this._peerSyncCapabilityTimestamps.get(peerHash);
+		const sameTransportSession = previousSession === transportSession;
+		if (
+			sameTransportSession &&
+			previousTimestamp !== undefined &&
+			timestamp < previousTimestamp
+		) {
+			return false;
+		}
+		const previousCapabilities =
+			this._peerSyncCapabilities.get(peerHash) ?? 0;
+		const nextCapabilities = sameTransportSession
+			? previousCapabilities | capabilities
+			: capabilities;
+		const generationAdvanced =
+			!sameTransportSession ||
+			previousTimestamp === undefined ||
+			timestamp > previousTimestamp ||
+			nextCapabilities !== previousCapabilities;
+		this._peerSyncCapabilities.set(peerHash, nextCapabilities);
+		this._peerSyncCapabilitySessions.set(peerHash, transportSession);
+		this._peerSyncCapabilityTimestamps.set(
+			peerHash,
+			previousTimestamp === undefined ||
+				!sameTransportSession ||
+				timestamp > previousTimestamp
+				? timestamp
+				: previousTimestamp,
+		);
+		if (generationAdvanced) {
+			this._v2Send.advancePeerCapability(peerHash);
+		}
+		return true;
 	}
 
 	/**
@@ -13831,6 +13964,8 @@ export class SharedLog<
 			ttl: LEADER_PLAN_CACHE_TTL_MS,
 		});
 		this._peerSyncCapabilities = new Map();
+		this._peerSyncCapabilitySessions = new Map();
+		this._peerSyncCapabilityTimestamps = new Map();
 		this._liveRawGossipBatches = new Map();
 		this._liveRawGossipFlushScheduled = false;
 		this.coordinateToHash = new Cache<string>({ max: 1e6, ttl: 1e4 });
@@ -13847,6 +13982,8 @@ export class SharedLog<
 		this._lastLocalAppendAt = 0;
 		this._announcements ??= this.createReplicationAnnouncementCoordinator();
 		this._announcements.resetForOpen();
+		this._v2Send ??= this.createReplicationInfoV2SendCoordinator();
+		this._v2Send.resetForOpen();
 		const adaptiveReplicateOptions =
 			options?.replicate && isAdaptiveReplicatorOption(options.replicate)
 				? options.replicate
@@ -15339,6 +15476,9 @@ export class SharedLog<
 		this._liveness._replicatorLivenessFailures.delete(peerHash);
 		this._liveness._replicatorLastActivityAt.delete(peerHash);
 		this._peerSyncCapabilities.delete(peerHash);
+		this._peerSyncCapabilitySessions.delete(peerHash);
+		this._peerSyncCapabilityTimestamps.delete(peerHash);
+		this._v2Send.clearPeer(peerHash);
 		this.cleanupPendingIHavePeer(peerHash);
 		this.cleanupCheckedPrunePeer(
 			peerHash,
@@ -16348,6 +16488,9 @@ export class SharedLog<
 			this._openingSyncCapabilitiesByPeer?.clear();
 			this._gidPeersHistory?.clear();
 			this._peerSyncCapabilities?.clear();
+			this._peerSyncCapabilitySessions?.clear();
+			this._peerSyncCapabilityTimestamps?.clear();
+			this._v2Send?.clearForClose();
 			this._liveRawGossipBatches?.clear();
 			this._nativeSharedLogState?.clearGidPeers();
 			this._nativeBackbone?.clearGidPeers();
@@ -16480,12 +16623,14 @@ export class SharedLog<
 					}
 				}, 2_000);
 				try {
-					await this.rpc
-						.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
+					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
+					await Promise.all([
+						this.rpc.send(reset, {
 							priority: CONVERGENCE_MESSAGE_PRIORITY,
 							signal: abort.signal,
-						})
-						.catch(() => {});
+						}).catch(() => {}),
+						this._v2Send.sendTerminalReset(abort.signal),
+					]);
 				} finally {
 					clearTimeout(abortTimer);
 				}
@@ -16604,12 +16749,14 @@ export class SharedLog<
 					}
 				}, 2_000);
 				try {
-					await this.rpc
-						.send(new AllReplicatingSegmentsMessage({ segments: [] }), {
+					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
+					await Promise.all([
+						this.rpc.send(reset, {
 							priority: CONVERGENCE_MESSAGE_PRIORITY,
 							signal: abort.signal,
-						})
-						.catch(() => {});
+						}).catch(() => {}),
+						this._v2Send.sendTerminalReset(abort.signal),
+					]);
 				} finally {
 					clearTimeout(abortTimer);
 				}
@@ -17195,7 +17342,10 @@ export class SharedLog<
 				// allocation cost, and before liveness or apply-queue side effects.
 				this.validateStoppedReplicationAnnouncement(msg.segmentIds);
 			}
-			if (!context.from.equals(this.node.identity.publicKey)) {
+			if (
+				!context.from.equals(this.node.identity.publicKey) &&
+				!(msg instanceof RequestReplicationInfoV2Message)
+			) {
 				this._liveness.markReplicatorActivity(receiveFromHash);
 			}
 
@@ -18824,6 +18974,8 @@ export class SharedLog<
 					return;
 				} else if (msg instanceof SyncCapabilitiesMessage) {
 					if (!context.from.equals(this.node.identity.publicKey)) {
+						const capabilityTransportSession = context.message?.header?.session;
+						const capabilityTimestamp = context.message?.header?.timestamp;
 						// No await separates this from the capture above, so the captured
 						// window state is exact: the legacy re-read of the opening map here
 						// could never observe a different value.
@@ -18834,13 +18986,45 @@ export class SharedLog<
 							// A prior unsubscribe cleanup may still be ahead of this reconnect
 							// barrier. Stage the new generation's one-shot advertisement so that
 							// cleanup cannot erase it before the opening transition commits.
-							this._openingSyncCapabilitiesByPeer.set(receiveFromHash, {
-								epoch: receiveSession!,
+							this.observePeerSyncCapabilities({
+								peerHash: receiveFromHash,
 								capabilities: msg.capabilities,
+								transportSession: capabilityTransportSession,
+								timestamp: capabilityTimestamp,
+								openingSession: receiveSession!,
 							});
 						} else {
-							this._peerSyncCapabilities.set(receiveFromHash, msg.capabilities);
+							this.observePeerSyncCapabilities({
+								peerHash: receiveFromHash,
+								capabilities: msg.capabilities,
+								transportSession: capabilityTransportSession,
+								timestamp: capabilityTimestamp,
+							});
 						}
+					}
+					return;
+				} else if (msg instanceof RequestReplicationInfoV2Message) {
+					const requiredCapabilities =
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY;
+					if (
+						receiveSession &&
+						((this._peerSyncCapabilities.get(receiveFromHash) ?? 0) &
+							requiredCapabilities) ===
+							requiredCapabilities &&
+						this._peerSyncCapabilitySessions.get(receiveFromHash) ===
+							context.message.header.session &&
+						this._peerSyncCapabilityTimestamps.has(receiveFromHash) &&
+						context.message.header.timestamp >
+							this._peerSyncCapabilityTimestamps.get(receiveFromHash)! &&
+						this._v2Send.acceptRequest(msg, {
+							from: context.from,
+							peerSession: receiveSession,
+							receiverTransportSession: context.message.header.session,
+							requestTimestamp: context.message.header.timestamp,
+						})
+					) {
+						this._liveness.markReplicatorActivity(receiveFromHash);
 					}
 					return;
 				} else if (await this.syncronizer.onMessage(msg, context)) {
@@ -19157,6 +19341,7 @@ export class SharedLog<
 		}
 		const segments = replicationSegments.map((x) => x.toReplicationRange());
 		this.validatePersistedReplicationRangeSnapshot(segments);
+		this._v2Send.enqueueSnapshotForPeer(receiveFromHash);
 
 		await this.rpc
 			.send(new AllReplicatingSegmentsMessage({ segments }), {
@@ -22599,6 +22784,12 @@ export class SharedLog<
 		if (!ownsSubscriptionEpoch()) {
 			return;
 		}
+		// A destination stream is scoped to exactly one topic-subscription
+		// session. Abort the predecessor synchronously before either barrier can
+		// yield; a late queue completion must never enter the new session.
+		this._v2Send.clearPeer(peerHash);
+		this._peerSyncCapabilitySessions.delete(peerHash);
+		this._peerSyncCapabilityTimestamps.delete(peerHash);
 		if (subscribed) {
 			const pendingOpeningCapabilities =
 				this._openingSyncCapabilitiesByPeer.get(peerHash);
@@ -22638,6 +22829,22 @@ export class SharedLog<
 						peerHash,
 						openingCapabilities.capabilities,
 					);
+					if (openingCapabilities.transportSession === undefined) {
+						this._peerSyncCapabilitySessions.delete(peerHash);
+					} else {
+						this._peerSyncCapabilitySessions.set(
+							peerHash,
+							openingCapabilities.transportSession,
+						);
+					}
+					if (openingCapabilities.timestamp === undefined) {
+						this._peerSyncCapabilityTimestamps.delete(peerHash);
+					} else {
+						this._peerSyncCapabilityTimestamps.set(
+							peerHash,
+							openingCapabilities.timestamp,
+						);
+					}
 					this._openingSyncCapabilitiesByPeer.delete(peerHash);
 				}
 				this._peerSessions.unblockReplicationInfo(peerHash);
@@ -22717,11 +22924,13 @@ export class SharedLog<
 		this._liveness.markReplicatorActivity(peerHash);
 		this._peerSessions.markOpen(peerHash, expectedSubscriptionEpoch);
 
-		// Decode support is advertised independently from use permission. Every
-		// replication-info send below and in the announcement coordinator remains
-		// on the legacy wire format until a later receiver-led negotiation exists.
+		// Decode support and receiver-led negotiation readiness are separate bits.
+		// This node never initiates a request in this rollout; normal replication
+		// announcements remain legacy unless a peer explicitly grants one signed,
+		// session-bound V2 destination stream.
 		const receiveCapabilities =
 			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
 			(this._logProperties?.sync?.rawExchangeHeads === true
 				? SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
 				: 0);

--- a/packages/programs/data/shared-log/src/replication-announcement.ts
+++ b/packages/programs/data/shared-log/src/replication-announcement.ts
@@ -204,7 +204,15 @@ export type ReplicationAnnouncementDeps<R extends "u32" | "u64"> = {
 	// Owner-routed so coordinator spies keep observing re-entrant queueing.
 	queueCurrentReplicationStateAnnouncementRepair: () => void;
 	queueCurrentReplicationStateAnnouncementRetry: (error: unknown) => boolean;
+	// Best-effort sidecar. The legacy publish remains the primary operation and
+	// retains its exact rejection/retry semantics during mixed-version rollout.
+	enqueueReplicationInfoV2: (message: LegacyReplicationInfoMessage) => void;
 };
+
+type LegacyReplicationInfoMessage =
+	| AllReplicatingSegmentsMessage
+	| AddedReplicationSegmentMessage
+	| StoppedReplicating;
 
 export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	replicationAnnouncementRetryDebounced:
@@ -611,10 +619,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	}
 
 	async sendReplicationAnnouncement(
-		message:
-			| AllReplicatingSegmentsMessage
-			| AddedReplicationSegmentMessage
-			| StoppedReplicating,
+		message: LegacyReplicationInfoMessage,
 		ownershipLifecycleController = this.deps.captureReplicationOwnershipLifecycle(),
 		options?: { shouldSend?: () => boolean },
 	): Promise<void> {
@@ -639,6 +644,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				// after that stale send settles.
 				this.rotateAnnouncementSession();
 				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
+				this.deps.enqueueReplicationInfoV2(message);
 				try {
 					await this.deps.getRpc().send(message, {
 						priority: CONVERGENCE_MESSAGE_PRIORITY,

--- a/packages/programs/data/shared-log/src/replication-info-v2-send.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-send.ts
@@ -1,0 +1,568 @@
+import { serialize } from "@dao-xyz/borsh";
+import { type PublicSignKey, randomBytes, sha256Sync } from "@peerbit/crypto";
+import { logger as loggerFn } from "@peerbit/logger";
+import type { RPC } from "@peerbit/rpc";
+import {
+	AcknowledgeDelivery,
+	CONVERGENCE_MESSAGE_PRIORITY,
+} from "@peerbit/stream-interface";
+import type { TransportMessage } from "./message.js";
+import type { ReplicationRangeIndexable } from "./ranges.js";
+import { concat, fromString } from "uint8arrays";
+import {
+	AddedReplicationInfoV2Message,
+	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
+	RequestReplicationInfoV2Message,
+	StoppedReplicating,
+	StoppedReplicationInfoV2Message,
+} from "./replication.js";
+
+const logger = loggerFn("peerbit:shared-log:replication-info-v2-send");
+
+const MAX_U64 = (1n << 64n) - 1n;
+const RECEIVER_BINDING_DOMAIN = fromString(
+	"peerbit/shared-log/replication-info-v2/receiver-binding/v1",
+);
+
+const lengthPrefixed = (bytes: Uint8Array): Uint8Array => {
+	const length = new Uint8Array(4);
+	new DataView(length.buffer).setUint32(0, bytes.byteLength, true);
+	return concat([length, bytes]);
+};
+
+const u64LittleEndian = (value: bigint): Uint8Array => {
+	const bytes = new Uint8Array(8);
+	new DataView(bytes.buffer).setBigUint64(0, value, true);
+	return bytes;
+};
+
+/**
+ * Derive the token echoed by V2 data frames. Delivery recipients are unsigned,
+ * so the receiver's nonce alone is not a destination binding. Folding both
+ * authenticated identities and signed transport sessions into the 32-byte
+ * field prevents a copied request nonce from creating an interchangeable
+ * stream for another receiver.
+ */
+export const deriveReplicationInfoV2ReceiverBinding = (properties: {
+	receiverChallenge: Uint8Array;
+	receiver: PublicSignKey;
+	receiverTransportSession: bigint;
+	sender: PublicSignKey;
+	senderTransportSession: bigint;
+}): Uint8Array =>
+	sha256Sync(
+		concat([
+			lengthPrefixed(RECEIVER_BINDING_DOMAIN),
+			lengthPrefixed(properties.receiverChallenge),
+			lengthPrefixed(serialize(properties.receiver)),
+			u64LittleEndian(properties.receiverTransportSession),
+			lengthPrefixed(serialize(properties.sender)),
+			u64LittleEndian(properties.senderTransportSession),
+		]),
+	);
+
+export type LegacyReplicationInfoMessage =
+	| AllReplicatingSegmentsMessage
+	| AddedReplicationSegmentMessage
+	| StoppedReplicating;
+
+type SendRequest =
+	| { kind: "snapshot" }
+	| { kind: "message"; message: LegacyReplicationInfoMessage };
+
+export type ReplicationInfoV2SendState = {
+	peerHash: string;
+	target: PublicSignKey;
+	peerSession: object;
+	receiverTransportSession: bigint;
+	senderTransportSession: bigint;
+	lastRequestTimestamp: bigint;
+	receiverRequestChallenge: Uint8Array;
+	receiverChallenge: Uint8Array;
+	senderEpoch: Uint8Array;
+	ownershipLifecycleController: AbortController;
+	nextSequence: bigint;
+	established: boolean;
+	suspended: boolean;
+	inFlightSequence?: bigint;
+	controller: AbortController;
+	pending?: SendRequest;
+	worker?: Promise<void>;
+};
+
+export type ReplicationInfoV2SendDeps<R extends "u32" | "u64"> = {
+	getRpc: () => RPC<TransportMessage, TransportMessage>;
+	getSelfKey: () => PublicSignKey;
+	getSenderTransportSession: () => bigint;
+	getMyReplicationSegments: () => Promise<ReplicationRangeIndexable<R>[]>;
+	validatePersistedReplicationRangeSnapshot: (
+		ranges: readonly { mode: unknown }[],
+	) => void;
+	isClosed: () => boolean;
+	isPeerSessionOpen: (peerHash: string, peerSession: object) => boolean;
+	captureReplicationOwnershipLifecycle: () => AbortController;
+	isReplicationOwnershipLifecycleActive: (
+		controller: AbortController,
+	) => boolean;
+};
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+	if (left.byteLength !== right.byteLength) {
+		return false;
+	}
+	for (let index = 0; index < left.byteLength; index++) {
+		if (left[index] !== right[index]) {
+			return false;
+		}
+	}
+	return true;
+};
+
+/**
+ * Per-destination V2 sender streams. Each stream retains at most one in-flight
+ * operation and one pending operation. A second pending mutation coalesces to
+ * a freshly collected authoritative snapshot, bounding memory at O(peers).
+ */
+export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
+	_senderEpoch!: Uint8Array;
+	_sendStates!: Map<string, ReplicationInfoV2SendState>;
+	_spentPeerSessions!: WeakSet<object>;
+	_retiringWorkersByPeer!: Map<string, Promise<void>>;
+
+	constructor(private readonly deps: ReplicationInfoV2SendDeps<R>) {
+		this._senderEpoch = randomBytes(32);
+		this._sendStates = new Map();
+		this._spentPeerSessions = new WeakSet();
+		this._retiringWorkersByPeer = new Map();
+	}
+
+	resetForOpen(): void {
+		this.clearForClose();
+		this._senderEpoch = randomBytes(32);
+		this._sendStates = new Map();
+		this._spentPeerSessions = new WeakSet();
+	}
+
+	clearForClose(): void {
+		for (const state of [...(this._sendStates?.values() ?? [])]) {
+			this.clearState(state);
+		}
+		this._sendStates?.clear();
+	}
+
+	clearPeer(peerHash: string, expectedSession?: object): void {
+		const state = this._sendStates.get(peerHash);
+		if (!state || (expectedSession && state.peerSession !== expectedSession)) {
+			return;
+		}
+		this.clearState(state);
+	}
+
+	advancePeerCapability(peerHash: string): void {
+		const state = this._sendStates.get(peerHash);
+		if (state) {
+			this.clearState(state);
+		}
+	}
+
+	private clearState(state: ReplicationInfoV2SendState): void {
+		this.trackRetiringWorker(state);
+		state.controller.abort();
+		if (this._sendStates.get(state.peerHash) === state) {
+			this._sendStates.delete(state.peerHash);
+		}
+	}
+
+	private trackRetiringWorker(state: ReplicationInfoV2SendState): void {
+		const worker = state.worker;
+		if (!worker) {
+			return;
+		}
+		const previous = this._retiringWorkersByPeer.get(state.peerHash);
+		if (previous === worker) {
+			return;
+		}
+		const retirement = previous
+			? Promise.allSettled([previous, worker]).then(() => undefined)
+			: worker;
+		this._retiringWorkersByPeer.set(state.peerHash, retirement);
+		const forget = () => {
+			if (this._retiringWorkersByPeer.get(state.peerHash) === retirement) {
+				this._retiringWorkersByPeer.delete(state.peerHash);
+			}
+		};
+		void retirement.then(forget, forget);
+	}
+
+	private isDestinationCurrent(state: ReplicationInfoV2SendState): boolean {
+		return (
+			!this.deps.isClosed() &&
+			!state.controller.signal.aborted &&
+			this._sendStates.get(state.peerHash) === state &&
+			this.deps.isPeerSessionOpen(state.peerHash, state.peerSession) &&
+			this.deps.getSenderTransportSession() === state.senderTransportSession
+		);
+	}
+
+	private isCurrent(state: ReplicationInfoV2SendState): boolean {
+		return (
+			this.isDestinationCurrent(state) &&
+			this.deps.isReplicationOwnershipLifecycleActive(
+				state.ownershipLifecycleController,
+			)
+		);
+	}
+
+	/**
+	 * Accept a signed receiver request. An exact newer retry asks for another
+	 * full snapshot without resetting the epoch/sequence. A different challenge
+	 * cannot replace the first binding within one PeerSession; this prevents a
+	 * signed request flood from spawning unbounded orphan snapshot reads.
+	 */
+	acceptRequest(
+		request: RequestReplicationInfoV2Message,
+		properties: {
+			from: PublicSignKey;
+			peerSession: object;
+			receiverTransportSession: bigint;
+			requestTimestamp: bigint;
+		},
+	): boolean {
+		const self = this.deps.getSelfKey();
+		const senderTransportSession = this.deps.getSenderTransportSession();
+		if (
+			properties.from.equals(self) ||
+			!request.intendedSender.equals(self) ||
+			request.senderSession !== senderTransportSession
+		) {
+			return false;
+		}
+
+		const peerHash = properties.from.hashcode();
+		if (
+			this._retiringWorkersByPeer.has(peerHash) ||
+			this._spentPeerSessions.has(properties.peerSession) ||
+			!this.deps.isPeerSessionOpen(peerHash, properties.peerSession)
+		) {
+			return false;
+		}
+
+		let previous = this._sendStates.get(peerHash);
+		if (
+			previous &&
+			(previous.peerSession !== properties.peerSession ||
+				previous.senderTransportSession !== senderTransportSession)
+		) {
+			this.clearState(previous);
+			previous = undefined;
+			if (this._retiringWorkersByPeer.has(peerHash)) {
+				return false;
+			}
+		}
+		if (previous) {
+			const sameBinding =
+				previous.peerSession === properties.peerSession &&
+				previous.receiverTransportSession ===
+					properties.receiverTransportSession &&
+				bytesEqual(
+					previous.receiverRequestChallenge,
+					request.receiverChallenge,
+				);
+			if (sameBinding) {
+				if (properties.requestTimestamp <= previous.lastRequestTimestamp) {
+					return false;
+				}
+				previous.lastRequestTimestamp = properties.requestTimestamp;
+				previous.suspended = false;
+				this.enqueueState(previous, { kind: "snapshot" });
+				return true;
+			}
+
+			return false;
+		}
+
+		const ownershipLifecycleController =
+			this.deps.captureReplicationOwnershipLifecycle();
+		const state: ReplicationInfoV2SendState = {
+			peerHash,
+			target: properties.from,
+			peerSession: properties.peerSession,
+			receiverTransportSession: properties.receiverTransportSession,
+			senderTransportSession,
+			lastRequestTimestamp: properties.requestTimestamp,
+			receiverRequestChallenge: request.receiverChallenge.slice(),
+			receiverChallenge: deriveReplicationInfoV2ReceiverBinding({
+				receiverChallenge: request.receiverChallenge,
+				receiver: properties.from,
+				receiverTransportSession: properties.receiverTransportSession,
+				sender: self,
+				senderTransportSession,
+			}),
+			senderEpoch: this._senderEpoch.slice(),
+			nextSequence: 1n,
+			established: false,
+			suspended: false,
+			controller: new AbortController(),
+			ownershipLifecycleController,
+		};
+		this._sendStates.set(peerHash, state);
+		this.enqueueState(state, { kind: "snapshot" });
+		return true;
+	}
+
+	enqueue(message: LegacyReplicationInfoMessage): void {
+		for (const state of [...this._sendStates.values()]) {
+			this.enqueueState(state, { kind: "message", message });
+		}
+	}
+
+	enqueueSnapshotForPeer(peerHash: string): void {
+		const state = this._sendStates.get(peerHash);
+		if (state) {
+			this.enqueueState(state, { kind: "snapshot" });
+		}
+	}
+
+	private enqueueState(
+		state: ReplicationInfoV2SendState,
+		request: SendRequest,
+	): void {
+		if (!this.isCurrent(state)) {
+			state.pending = undefined;
+			if (
+				!this.isDestinationCurrent(state) ||
+				this.deps.isReplicationOwnershipLifecycleActive(
+					state.ownershipLifecycleController,
+				)
+			) {
+				this.clearState(state);
+			}
+			return;
+		}
+		if (state.suspended) {
+			state.pending = undefined;
+			return;
+		}
+
+		if (!state.worker) {
+			state.pending = request;
+			let worker: Promise<void>;
+			worker = Promise.resolve()
+				.then(() => this.runWorker(state))
+				.catch((error) => {
+					const ownershipActive =
+						this.deps.isReplicationOwnershipLifecycleActive(
+							state.ownershipLifecycleController,
+						);
+					if (
+						ownershipActive &&
+						!state.controller.signal.aborted &&
+						!this.deps.isClosed()
+					) {
+						logger.trace(
+							"Replication-info V2 destination stream failed for %s: %s",
+							state.peerHash,
+							(error as Error)?.message ?? String(error),
+						);
+					}
+					state.pending = undefined;
+					const ordinaryFailure =
+						ownershipActive && this.isDestinationCurrent(state);
+					if (ordinaryFailure) {
+						if (state.inFlightSequence !== undefined) {
+							state.inFlightSequence = undefined;
+							if (state.nextSequence > MAX_U64) {
+								this._spentPeerSessions.add(state.peerSession);
+								this.clearState(state);
+								return;
+							}
+						}
+						// A delivery error is ambiguous: the receiver may already have
+						// applied this sequence. Retain the exact grant, stop ordinary
+						// deltas, and require a newer same-challenge request to resume
+						// with an authoritative Full at the next safe sequence.
+						state.suspended = true;
+						return;
+					}
+					if (!this.isDestinationCurrent(state)) {
+						this.clearState(state);
+					}
+				})
+				.finally(() => {
+					if (state.worker === worker) {
+						state.worker = undefined;
+						// An enqueue can land after runWorker observes an empty slot but
+						// before this promise reaction clears `worker`. Re-arm that item
+						// here so the one-slot bound cannot become a stranded queue.
+						const pending = state.pending;
+						if (pending && this.isCurrent(state)) {
+							state.pending = undefined;
+							this.enqueueState(state, pending);
+						}
+					}
+				});
+			state.worker = worker;
+			return;
+		}
+
+		if (!state.pending) {
+			state.pending = request;
+			return;
+		}
+
+		// One pending item is the hard bound. Once another mutation arrives,
+		// replace the pending delta with a current authoritative snapshot.
+		state.pending = { kind: "snapshot" };
+	}
+
+	private async createMessage(
+		state: ReplicationInfoV2SendState,
+		request: SendRequest,
+	): Promise<
+		| FullReplicationInfoV2Message
+		| AddedReplicationInfoV2Message
+		| StoppedReplicationInfoV2Message
+	> {
+		const common = {
+			receiverChallenge: state.receiverChallenge.slice(),
+			senderEpoch: state.senderEpoch.slice(),
+			sequence: state.nextSequence,
+		};
+		if (request.kind === "snapshot") {
+			const segments = (await this.deps.getMyReplicationSegments()).map(
+				(range) => range.toReplicationRange(),
+			);
+			this.deps.validatePersistedReplicationRangeSnapshot(segments);
+			return new FullReplicationInfoV2Message({ ...common, segments });
+		}
+		if (request.message instanceof AllReplicatingSegmentsMessage) {
+			const segments = request.message.segments;
+			this.deps.validatePersistedReplicationRangeSnapshot(segments);
+			return new FullReplicationInfoV2Message({ ...common, segments });
+		}
+		if (request.message instanceof AddedReplicationSegmentMessage) {
+			return new AddedReplicationInfoV2Message({
+				...common,
+				segments: request.message.segments,
+			});
+		}
+		return new StoppedReplicationInfoV2Message({
+			...common,
+			segmentIds: request.message.segmentIds,
+		});
+	}
+
+	private async runWorker(state: ReplicationInfoV2SendState): Promise<void> {
+		while (this.isCurrent(state)) {
+			const request = state.pending;
+			if (!request) {
+				return;
+			}
+			state.pending = undefined;
+			if (state.nextSequence > MAX_U64) {
+				this.clearState(state);
+				return;
+			}
+
+			const message = await this.createMessage(state, request);
+			if (!this.isCurrent(state)) {
+				return;
+			}
+			// Consume the sequence before the transport attempt. From this point on
+			// delivery is ambiguous even if ownership aborts before the await
+			// continuation runs, so `nextSequence` always remains the next value that
+			// has never been attempted with different content.
+			state.inFlightSequence = state.nextSequence;
+			state.nextSequence += 1n;
+			await this.deps.getRpc().send(message, {
+				mode: new AcknowledgeDelivery({
+					to: [state.target],
+					redundancy: 1,
+				}),
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
+				signal: AbortSignal.any([
+					state.controller.signal,
+					state.ownershipLifecycleController.signal,
+				]),
+			});
+			state.inFlightSequence = undefined;
+			if (!this.isCurrent(state)) {
+				return;
+			}
+			state.established = true;
+			if (state.nextSequence > MAX_U64) {
+				this._spentPeerSessions.add(state.peerSession);
+				this.clearState(state);
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Terminal close/drop runs after the normal ownership generation is aborted.
+	 * Send an authoritative empty Full directly from the retained destination
+	 * bindings. `nextSequence` is consumed before every transport attempt, so it
+	 * is always safe for different terminal content even if a just-aborted frame
+	 * was delivered. Receivers admit Full gaps as authoritative resynchronization.
+	 */
+	async sendTerminalReset(signal: AbortSignal): Promise<void> {
+		const sends: Promise<unknown>[] = [];
+		for (const state of [...this._sendStates.values()]) {
+			if (
+				signal.aborted ||
+				!this.isDestinationCurrent(state) ||
+				state.nextSequence > MAX_U64
+			) {
+				continue;
+			}
+			state.pending = undefined;
+			const message = new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverChallenge.slice(),
+				senderEpoch: state.senderEpoch.slice(),
+				sequence: state.nextSequence,
+				segments: [],
+			});
+			sends.push(
+				this.deps.getRpc().send(message, {
+					mode: new AcknowledgeDelivery({
+						to: [state.target],
+						redundancy: 1,
+					}),
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
+					signal,
+				}),
+			);
+		}
+		await Promise.allSettled(sends);
+	}
+
+	async drain(signal?: AbortSignal): Promise<void> {
+		while (!signal?.aborted) {
+			const workers = [
+				...[...this._sendStates.values()]
+					.map((state) => state.worker)
+					.filter((worker): worker is Promise<void> => worker != null),
+				...this._retiringWorkersByPeer.values(),
+			];
+			const uniqueWorkers = [...new Set(workers)];
+			if (uniqueWorkers.length === 0) {
+				return;
+			}
+			const settled = Promise.allSettled(uniqueWorkers).then(() => undefined);
+			if (!signal) {
+				await settled;
+			} else {
+				await new Promise<void>((resolve) => {
+					const onAbort = () => resolve();
+					signal.addEventListener("abort", onAbort, { once: true });
+					void settled.then(() => {
+						signal.removeEventListener("abort", onAbort);
+						resolve();
+					});
+				});
+			}
+		}
+	}
+}

--- a/packages/programs/data/shared-log/src/replication.ts
+++ b/packages/programs/data/shared-log/src/replication.ts
@@ -7,7 +7,7 @@ import {
 	variant,
 	vec,
 } from "@dao-xyz/borsh";
-import { randomBytes } from "@peerbit/crypto";
+import { PublicSignKey, randomBytes } from "@peerbit/crypto";
 import { type Index } from "@peerbit/indexer-interface";
 import { TransportMessage } from "./message.js";
 import {
@@ -126,10 +126,11 @@ export class ReplicationPingMessage extends TransportMessage {
 }
 
 /**
- * Decode-first replication-info V2 messages. This rollout only registers and
- * advertises the final wire schemas; it never sends or applies these messages.
- * A later negotiated phase must bind the signed transport session and an
- * outstanding receiver challenge before any V2 payload is used.
+ * Challenge-bound replication-info V2 messages. Their `receiverChallenge`
+ * field carries a derived receiver binding, not the request's raw nonce. The
+ * binding covers both authenticated identities and signed transport sessions.
+ * Sender-ready nodes may emit them only after a signed, session-bound receiver
+ * request. Receive/apply activation remains separately capability-gated.
  */
 @variant([1, 6])
 export class FullReplicationInfoV2Message extends TransportMessage {
@@ -212,6 +213,39 @@ export class StoppedReplicationInfoV2Message extends TransportMessage {
 		this.senderEpoch = properties.senderEpoch;
 		this.sequence = properties.sequence;
 		this.segmentIds = properties.segmentIds;
+	}
+}
+
+/**
+ * Signed, receiver-led permission for one sender to start a V2 stream.
+ *
+ * The transport delivery target is deliberately unsigned because relays may
+ * rewrite it. Carry the intended sender in the signed payload so a valid
+ * request cannot be retargeted to another peer. `senderSession` is copied from
+ * the sender's signed capability envelope and binds the request to that exact
+ * transport incarnation.
+ */
+@variant([1, 9])
+export class RequestReplicationInfoV2Message extends TransportMessage {
+	/** Random receiver nonce used as input to the V2 receiver-binding hash. */
+	@field({ type: fixedArray("u8", 32) })
+	receiverChallenge: Uint8Array;
+
+	@field({ type: PublicSignKey })
+	intendedSender: PublicSignKey;
+
+	@field({ type: "u64" })
+	senderSession: bigint;
+
+	constructor(properties: {
+		receiverChallenge: Uint8Array;
+		intendedSender: PublicSignKey;
+		senderSession: bigint;
+	}) {
+		super();
+		this.receiverChallenge = properties.receiverChallenge;
+		this.intendedSender = properties.intendedSender;
+		this.senderSession = properties.senderSession;
 	}
 }
 

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -1,10 +1,13 @@
 import { deserialize, serialize } from "@dao-xyz/borsh";
+import { Ed25519PublicKey } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/test-utils";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
 	SYNC_CAPABILITY_RAW_EXCHANGE_HEADS,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
 	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
 import { TransportMessage } from "../src/message.js";
@@ -17,6 +20,7 @@ import {
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
 	FullReplicationInfoV2Message,
+	RequestReplicationInfoV2Message,
 	StoppedReplicating,
 	StoppedReplicationInfoV2Message,
 } from "../src/replication.js";
@@ -28,12 +32,17 @@ const SENDER_EPOCH = Uint8Array.from(
 	(_, index) => 0xff - index,
 );
 const SEQUENCE = 0x0102030405060708n;
+const SENDER_SESSION = 0x1112131415161718n;
+const INTENDED_SENDER = new Ed25519PublicKey({
+	publicKey: Uint8Array.from({ length: 32 }, (_, index) => 0x80 + index),
+});
 
 const RECEIVER_CHALLENGE_HEX =
 	"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 const SENDER_EPOCH_HEX =
 	"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0efeeedecebeae9e8e7e6e5e4e3e2e1e0";
 const SEQUENCE_HEX = "0807060504030201";
+const SENDER_SESSION_HEX = "1817161514131211";
 
 const hex = (value: unknown): string =>
 	Buffer.from(serialize(value)).toString("hex");
@@ -111,6 +120,37 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				SEQUENCE,
 			);
 		}
+	});
+
+	it("pins the signed receiver request tag and sender binding", () => {
+		const request = new RequestReplicationInfoV2Message({
+			receiverChallenge: RECEIVER_CHALLENGE,
+			intendedSender: INTENDED_SENDER,
+			senderSession: SENDER_SESSION,
+		});
+		const intendedSenderHex = `00${Buffer.from(
+			INTENDED_SENDER.publicKey,
+		).toString("hex")}`;
+		expect(hex(request)).to.equal(
+			`000109${RECEIVER_CHALLENGE_HEX}${intendedSenderHex}${SENDER_SESSION_HEX}`,
+		);
+
+		const decoded = deserialize(
+			serialize(request),
+			TransportMessage,
+		) as RequestReplicationInfoV2Message;
+		expect(decoded).to.be.instanceOf(RequestReplicationInfoV2Message);
+		expect(decoded.intendedSender.equals(INTENDED_SENDER)).to.be.true;
+		expect(decoded.senderSession).to.equal(SENDER_SESSION);
+		expect(() =>
+			serialize(
+				new RequestReplicationInfoV2Message({
+					receiverChallenge: new Uint8Array(31),
+					intendedSender: INTENDED_SENDER,
+					senderSession: SENDER_SESSION,
+				}),
+			),
+		).to.throw();
 	});
 
 	it("round-trips the unchanged replication payload schemas", () => {
@@ -208,9 +248,11 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("pins the decode-only capability vocabulary", () => {
+	it("pins the decode, send and apply capability vocabulary", () => {
 		expect(SYNC_CAPABILITY_RAW_EXCHANGE_HEADS).to.equal(1);
 		expect(SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE).to.equal(2);
+		expect(SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND).to.equal(4);
+		expect(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY).to.equal(8);
 		expect(hex(new SyncCapabilitiesMessage())).to.equal("00000a01000000");
 		expect(
 			hex(
@@ -222,12 +264,10 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		expect(
 			hex(
 				new SyncCapabilitiesMessage({
-					capabilities:
-						SYNC_CAPABILITY_RAW_EXCHANGE_HEADS |
-						SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+					capabilities: 15,
 				}),
 			),
-		).to.equal("00000a03000000");
+		).to.equal("00000a0f000000");
 	});
 
 	it("drops unsolicited V2 before receive state or side effects", async () => {
@@ -277,7 +317,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises decode support while every replication send stays legacy", async () => {
+	it("advertises sender readiness while ordinary replication sends stay legacy", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -308,8 +348,17 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE);
 			expect(
 				capability!.capabilities &
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND);
+			expect(
+				capability!.capabilities &
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			).to.equal(0);
+			expect(
+				capability!.capabilities &
 					~(
 						SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
 						SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
 					),
 			).to.equal(0);
@@ -321,6 +370,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			expect(
 				sent.some(
 					(message) =>
+						message instanceof RequestReplicationInfoV2Message ||
 						message instanceof FullReplicationInfoV2Message ||
 						message instanceof AddedReplicationInfoV2Message ||
 						message instanceof StoppedReplicationInfoV2Message,
@@ -332,7 +382,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises decode support before replication snapshot retrieval", async () => {
+	it("advertises sender readiness before replication snapshot retrieval", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -364,6 +414,14 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			expect(
 				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE);
+			expect(
+				capability!.capabilities &
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND);
+			expect(
+				capability!.capabilities &
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			).to.equal(0);
 		} finally {
 			send.restore();
 			snapshot.restore();

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -1,0 +1,748 @@
+import { Ed25519PublicKey } from "@peerbit/crypto";
+import { AcknowledgeDelivery } from "@peerbit/stream-interface";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import {
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+	SyncCapabilitiesMessage,
+} from "../src/exchange-heads.js";
+import {
+	ReplicationInfoV2SendCoordinator,
+	deriveReplicationInfoV2ReceiverBinding,
+	type ReplicationInfoV2SendState,
+} from "../src/replication-info-v2-send.js";
+import {
+	AddedReplicationInfoV2Message,
+	AddedReplicationSegmentMessage,
+	FullReplicationInfoV2Message,
+	RequestReplicationInfoV2Message,
+} from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+const key = (value: number) =>
+	new Ed25519PublicKey({ publicKey: new Uint8Array(32).fill(value) });
+
+const challenge = (value: number) => new Uint8Array(32).fill(value);
+
+describe("receive admission replication-info V2 sender streams", () => {
+	const self = key(1);
+	const peerA = key(2);
+	const peerB = key(3);
+	const senderTransportSession = 0x20000000000001n;
+	let closed: boolean;
+	let openSessions: Set<object>;
+	let rpcSend: sinon.SinonStub;
+	let getSegments: sinon.SinonStub;
+	let ownershipController: AbortController;
+	let coordinator: ReplicationInfoV2SendCoordinator<"u32">;
+
+	const makeRequest = (
+		receiverChallenge: Uint8Array,
+		intendedSender = self,
+		senderSession = senderTransportSession,
+	) =>
+		new RequestReplicationInfoV2Message({
+			receiverChallenge,
+			intendedSender,
+			senderSession,
+		});
+
+	const accept = (
+		from: Ed25519PublicKey,
+		peerSession: object,
+		receiverChallenge: Uint8Array,
+		requestTimestamp = 1n,
+		request = makeRequest(receiverChallenge),
+	) =>
+		coordinator.acceptRequest(request, {
+			from,
+			peerSession,
+			receiverTransportSession: BigInt(from.publicKey[0]),
+			requestTimestamp,
+		});
+
+	beforeEach(() => {
+		closed = false;
+		openSessions = new Set();
+		rpcSend = sinon.stub().resolves([]);
+		getSegments = sinon.stub().resolves([]);
+		ownershipController = new AbortController();
+		coordinator = new ReplicationInfoV2SendCoordinator<"u32">({
+			getRpc: () => ({ send: rpcSend }) as any,
+			getSelfKey: () => self,
+			getSenderTransportSession: () => senderTransportSession,
+			getMyReplicationSegments: getSegments,
+			validatePersistedReplicationRangeSnapshot: () => {},
+			isClosed: () => closed,
+			isPeerSessionOpen: (_peerHash, peerSession) =>
+				openSessions.has(peerSession),
+			captureReplicationOwnershipLifecycle: () => ownershipController,
+			isReplicationOwnershipLifecycleActive: (controller) =>
+				controller === ownershipController && !controller.signal.aborted,
+		});
+	});
+
+	afterEach(() => {
+		coordinator.clearForClose();
+		sinon.restore();
+	});
+
+	it("rejects self, retargeted, wrong-session and non-open requests", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(self, peerSession, challenge(1))).to.be.false;
+		expect(
+			accept(
+				peerA,
+				peerSession,
+				challenge(2),
+				1n,
+				makeRequest(challenge(2), peerB),
+			),
+		).to.be.false;
+		expect(
+			accept(
+				peerA,
+				peerSession,
+				challenge(3),
+				1n,
+				makeRequest(challenge(3), self, senderTransportSession + 1n),
+			),
+		).to.be.false;
+		openSessions.delete(peerSession);
+		expect(accept(peerA, peerSession, challenge(4))).to.be.false;
+		await coordinator.drain();
+		expect(rpcSend.notCalled).to.be.true;
+		expect(coordinator._sendStates.size).to.equal(0);
+	});
+
+	it("starts at sequence one with a receiver-bound authoritative snapshot", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const receiverChallenge = challenge(5);
+		expect(accept(peerA, peerSession, receiverChallenge)).to.be.true;
+		await coordinator.drain();
+
+		expect(rpcSend.calledOnce).to.be.true;
+		const [message, options] = rpcSend.firstCall.args;
+		expect(message).to.be.instanceOf(FullReplicationInfoV2Message);
+		expect(message.sequence).to.equal(1n);
+		expect([...message.receiverChallenge]).to.deep.equal([
+			...deriveReplicationInfoV2ReceiverBinding({
+				receiverChallenge,
+				receiver: peerA,
+				receiverTransportSession: 2n,
+				sender: self,
+				senderTransportSession,
+			}),
+		]);
+		expect([...message.receiverChallenge]).to.not.deep.equal([
+			...receiverChallenge,
+		]);
+		expect(Buffer.from(message.receiverChallenge).toString("hex")).to.equal(
+			"e5947998ab731e87a670da4b2d1a8e7b46a59df06e6f9c77f1910a9d63d49746",
+		);
+		expect(options.mode).to.be.instanceOf(AcknowledgeDelivery);
+		expect(options.mode.to).to.have.length(1);
+		expect(options.mode.to[0]).to.equal(peerA.hashcode());
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(state.established).to.be.true;
+		expect(state.nextSequence).to.equal(2n);
+	});
+
+	it("retries an exact newer request without resetting its stream", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const receiverChallenge = challenge(6);
+		expect(accept(peerA, peerSession, receiverChallenge, 10n)).to.be.true;
+		await coordinator.drain();
+		const epoch = (
+			rpcSend.firstCall.args[0] as FullReplicationInfoV2Message
+		).senderEpoch.slice();
+
+		expect(accept(peerA, peerSession, receiverChallenge, 10n)).to.be.false;
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+
+		expect(accept(peerA, peerSession, receiverChallenge, 11n)).to.be.true;
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		const retried = rpcSend.secondCall.args[0] as FullReplicationInfoV2Message;
+		expect(retried.sequence).to.equal(2n);
+		expect([...retried.senderEpoch]).to.deep.equal([...epoch]);
+	});
+
+	it("pins the first challenge and bounds a different-challenge flood", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const snapshot = pDefer<never[]>();
+		getSegments.returns(snapshot.promise);
+		expect(accept(peerA, peerSession, challenge(7), 20n)).to.be.true;
+		await waitForResolved(() => expect(getSegments.calledOnce).to.be.true);
+		const firstState = coordinator._sendStates.get(peerA.hashcode())!;
+
+		for (let index = 0; index < 10_000; index++) {
+			expect(
+				accept(peerA, peerSession, challenge(8), 21n + BigInt(index)),
+			).to.be.false;
+		}
+		expect(getSegments.calledOnce).to.be.true;
+		expect(rpcSend.notCalled).to.be.true;
+		expect(coordinator._sendStates.get(peerA.hashcode())).to.equal(firstState);
+		expect(firstState.controller.signal.aborted).to.be.false;
+
+		snapshot.resolve([]);
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+	});
+
+	it("serializes capability rebinds behind a retiring snapshot read", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const firstSnapshot = pDefer<never[]>();
+		getSegments.onFirstCall().returns(firstSnapshot.promise);
+		expect(accept(peerA, peerSession, challenge(18), 30n)).to.be.true;
+		await waitForResolved(() => expect(getSegments.calledOnce).to.be.true);
+
+		coordinator.advancePeerCapability(peerA.hashcode());
+		expect(coordinator._sendStates.size).to.equal(0);
+		expect(coordinator._retiringWorkersByPeer.size).to.equal(1);
+		let drainSettled = false;
+		const drain = coordinator.drain().then(() => {
+			drainSettled = true;
+		});
+		await Promise.resolve();
+		expect(drainSettled).to.be.false;
+		const abort = new AbortController();
+		const abortableDrain = coordinator.drain(abort.signal);
+		abort.abort();
+		await abortableDrain;
+		expect(drainSettled).to.be.false;
+		for (let index = 0; index < 10_000; index++) {
+			coordinator.advancePeerCapability(peerA.hashcode());
+			expect(
+				accept(peerA, peerSession, challenge(19), 31n + BigInt(index)),
+			).to.be.false;
+		}
+		expect(getSegments.calledOnce).to.be.true;
+		expect(rpcSend.notCalled).to.be.true;
+
+		firstSnapshot.resolve([]);
+		await drain;
+		expect(drainSettled).to.be.true;
+		expect(coordinator._retiringWorkersByPeer.size).to.equal(0);
+		expect(coordinator._spentPeerSessions.has(peerSession)).to.be.false;
+		expect(accept(peerA, peerSession, challenge(19), 10_031n)).to.be.true;
+		await coordinator.drain();
+		expect(getSegments.callCount).to.equal(2);
+		expect(rpcSend.calledOnce).to.be.true;
+	});
+
+	it("serializes a reconnect behind the previous session's snapshot read", async () => {
+		const oldPeerSession = {};
+		const newPeerSession = {};
+		openSessions.add(oldPeerSession);
+		const firstSnapshot = pDefer<never[]>();
+		getSegments.onFirstCall().returns(firstSnapshot.promise);
+		expect(accept(peerA, oldPeerSession, challenge(22), 40n)).to.be.true;
+		await waitForResolved(() => expect(getSegments.calledOnce).to.be.true);
+
+		openSessions.delete(oldPeerSession);
+		openSessions.add(newPeerSession);
+		expect(accept(peerA, newPeerSession, challenge(23), 41n)).to.be.false;
+		expect(coordinator._sendStates.size).to.equal(0);
+		expect(coordinator._retiringWorkersByPeer.size).to.equal(1);
+		expect(getSegments.calledOnce).to.be.true;
+
+		firstSnapshot.resolve([]);
+		await coordinator.drain();
+		expect(coordinator._retiringWorkersByPeer.size).to.equal(0);
+		expect(accept(peerA, newPeerSession, challenge(23), 42n)).to.be.true;
+		await coordinator.drain();
+		expect(getSegments.callCount).to.equal(2);
+		expect(rpcSend.calledOnce).to.be.true;
+	});
+
+	it("keeps independent sequences and challenges for two destinations", async () => {
+		const sessionA = {};
+		const sessionB = {};
+		openSessions.add(sessionA);
+		openSessions.add(sessionB);
+		expect(accept(peerA, sessionA, challenge(9))).to.be.true;
+		expect(accept(peerB, sessionB, challenge(9))).to.be.true;
+		await coordinator.drain();
+
+		const messages = rpcSend.args.map(
+			(args) => args[0] as FullReplicationInfoV2Message,
+		);
+		expect(messages).to.have.length(2);
+		expect(messages.every((message) => message.sequence === 1n)).to.be.true;
+		expect(messages[0]).to.not.equal(messages[1]);
+		expect(
+			new Set(
+				messages.map((message) =>
+					Buffer.from(message.receiverChallenge).toString("hex"),
+				),
+			).size,
+		).to.equal(2);
+	});
+
+	it("bounds a blocked destination to one coalesced pending snapshot", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const firstSend = pDefer<void>();
+		rpcSend.onFirstCall().returns(firstSend.promise);
+		expect(accept(peerA, peerSession, challenge(11))).to.be.true;
+		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
+
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		for (let index = 0; index < 10_000; index++) {
+			coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		}
+		const state = coordinator._sendStates.get(
+			peerA.hashcode(),
+		) as ReplicationInfoV2SendState;
+		expect(state.pending).to.deep.equal({ kind: "snapshot" });
+
+		firstSend.resolve();
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.secondCall.args[0]).to.be.instanceOf(
+			FullReplicationInfoV2Message,
+		);
+		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
+	});
+
+	it("suspends only a failing destination and resumes with a safe Full", async () => {
+		const sessionA = {};
+		const sessionB = {};
+		openSessions.add(sessionA);
+		openSessions.add(sessionB);
+		let failA = true;
+		rpcSend.callsFake(async (_message, options) => {
+			if (failA && options.mode.to[0] === peerA.hashcode()) {
+				throw new Error("peer A delivery failed");
+			}
+			return [];
+		});
+
+		expect(accept(peerA, sessionA, challenge(12))).to.be.true;
+		expect(accept(peerB, sessionB, challenge(13))).to.be.true;
+		await coordinator.drain();
+		const failedState = coordinator._sendStates.get(peerA.hashcode());
+		expect(failedState?.suspended).to.be.true;
+		expect(failedState?.nextSequence).to.equal(2n);
+		expect(coordinator._sendStates.get(peerB.hashcode())?.established).to.be
+			.true;
+		coordinator.clearPeer(peerB.hashcode());
+		rpcSend.resetHistory();
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		expect(accept(peerA, sessionA, challenge(12), 1n)).to.be.false;
+		await coordinator.drain();
+		expect(rpcSend.notCalled).to.be.true;
+
+		failA = false;
+		expect(accept(peerA, sessionA, challenge(12), 2n)).to.be.true;
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+		const resumed = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		expect(resumed.sequence).to.equal(2n);
+		expect(failedState?.suspended).to.be.false;
+		expect(failedState?.established).to.be.true;
+	});
+
+	it("never wraps or recreates a stream after u64 exhaustion", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const receiverChallenge = challenge(17);
+		expect(accept(peerA, peerSession, receiverChallenge)).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		state.nextSequence = (1n << 64n) - 1n;
+		rpcSend.resetHistory();
+
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
+		expect(coordinator._sendStates.has(peerA.hashcode())).to.be.false;
+
+		rpcSend.resetHistory();
+		expect(accept(peerA, peerSession, receiverChallenge, 2n)).to.be.false;
+		await coordinator.drain();
+		expect(rpcSend.notCalled).to.be.true;
+	});
+
+	it("fences normal sends on ownership abort and retains a terminal reset", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		let first = true;
+		rpcSend.callsFake(async (_message, options) => {
+			if (!first) {
+				return [];
+			}
+			first = false;
+			await new Promise<void>((_resolve, reject) => {
+				options.signal.addEventListener(
+					"abort",
+					() => reject(new Error("ownership aborted")),
+					{ once: true },
+				);
+			});
+			return [];
+		});
+
+		expect(accept(peerA, peerSession, challenge(16))).to.be.true;
+		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
+		ownershipController.abort();
+		await coordinator.drain();
+		const retained = coordinator._sendStates.get(peerA.hashcode());
+		expect(retained).to.exist;
+		expect(retained!.established).to.be.false;
+
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.callCount).to.equal(2);
+		const terminal = rpcSend.secondCall.args[0] as FullReplicationInfoV2Message;
+		expect(terminal.sequence).to.equal(2n);
+		expect(terminal.segments).to.deep.equal([]);
+	});
+
+	it("uses the last safe u64 sequence for an idle terminal reset", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(24))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		state.nextSequence = (1n << 64n) - 1n;
+		rpcSend.resetHistory();
+		ownershipController.abort();
+
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.calledOnce).to.be.true;
+		const terminal = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		expect(terminal.sequence).to.equal((1n << 64n) - 1n);
+		expect(terminal.segments).to.deep.equal([]);
+	});
+
+	it("uses the last safe u64 sequence after an ambiguous predecessor", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(25))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		state.nextSequence = (1n << 64n) - 2n;
+		rpcSend.rejects(new Error("ambiguous predecessor"));
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await coordinator.drain();
+		expect(state.suspended).to.be.true;
+		expect(state.nextSequence).to.equal((1n << 64n) - 1n);
+		rpcSend.resetHistory();
+		rpcSend.resolves([]);
+		ownershipController.abort();
+
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.calledOnce).to.be.true;
+		const terminal = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		expect(terminal.sequence).to.equal((1n << 64n) - 1n);
+		expect(terminal.segments).to.deep.equal([]);
+	});
+
+	it("rotates the sender epoch and aborts old queues across reopen", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(14))).to.be.true;
+		await coordinator.drain();
+		const oldState = coordinator._sendStates.get(peerA.hashcode())!;
+		const oldEpoch = oldState.senderEpoch.slice();
+
+		coordinator.resetForOpen();
+		expect(oldState.controller.signal.aborted).to.be.true;
+		expect(coordinator._sendStates.size).to.equal(0);
+		expect([...coordinator._senderEpoch]).to.not.deep.equal([...oldEpoch]);
+	});
+
+	it("serializes incremental messages after the initial full", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(15))).to.be.true;
+		await coordinator.drain();
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await coordinator.drain();
+
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.secondCall.args[0]).to.be.instanceOf(
+			AddedReplicationInfoV2Message,
+		);
+		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
+	});
+});
+
+describe("receive admission replication-info V2 sender integration", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		sinon.restore();
+		await session?.stop();
+		session = undefined;
+	});
+
+	it("requires current signed capabilities before honoring a request", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiverTransportSession = 77n;
+		const localTransportSession = BigInt(log.node.services.pubsub.session);
+		const request = new RequestReplicationInfoV2Message({
+			receiverChallenge: challenge(20),
+			intendedSender: log.node.identity.publicKey,
+			senderSession: localTransportSession,
+		});
+		const send = sinon.stub(log.rpc, "send").resolves([] as any);
+		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
+		const context = (transportSession: bigint, timestamp: bigint) =>
+			({
+				from: remote,
+				message: { header: { session: transportSession, timestamp } },
+			}) as any;
+
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+		);
+		log._peerSyncCapabilitySessions.set(remoteHash, receiverTransportSession);
+		log._peerSyncCapabilityTimestamps.set(remoteHash, 0n);
+		await log.onMessage(request, context(receiverTransportSession, 1n));
+		expect(send.notCalled).to.be.true;
+		expect(activity.notCalled).to.be.true;
+		expect(log._v2Send._sendStates.size).to.equal(0);
+
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+		);
+		await log.onMessage(request, context(receiverTransportSession + 1n, 2n));
+		expect(send.notCalled).to.be.true;
+		expect(activity.notCalled).to.be.true;
+
+		await log.onMessage(request, context(receiverTransportSession, 3n));
+		await waitForResolved(() =>
+			expect(
+				send.calledWith(sinon.match.instanceOf(FullReplicationInfoV2Message)),
+			).to.be.true,
+		);
+		expect(activity.calledOnceWith(remoteHash)).to.be.true;
+		const state = log._v2Send._sendStates.get(remoteHash);
+		expect(state.peerSession).to.equal(peerSession);
+		expect(state.receiverTransportSession).to.equal(receiverTransportSession);
+
+		await log._v2Send.drain();
+		send.resetHistory();
+		activity.resetHistory();
+		await log.onMessage(request, context(receiverTransportSession, 3n));
+		expect(send.notCalled).to.be.true;
+		expect(activity.notCalled).to.be.true;
+	});
+
+	it("adds a directed V2 sidecar without changing the legacy primary send", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiverTransportSession = 88n;
+		log._peerSyncCapabilities.set(
+			remoteHash,
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+		);
+		log._peerSyncCapabilitySessions.set(remoteHash, receiverTransportSession);
+		log._peerSyncCapabilityTimestamps.set(remoteHash, 0n);
+		const send = sinon.stub(log.rpc, "send").resolves([] as any);
+		const request = new RequestReplicationInfoV2Message({
+			receiverChallenge: challenge(21),
+			intendedSender: log.node.identity.publicKey,
+			senderSession: BigInt(log.node.services.pubsub.session),
+		});
+		await log.onMessage(request, {
+			from: remote,
+			message: {
+				header: { session: receiverTransportSession, timestamp: 1n },
+			},
+		} as any);
+		await log._v2Send.drain();
+		send.resetHistory();
+
+		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
+		await log._announcements.sendReplicationAnnouncement(legacy);
+		await log._v2Send.drain();
+		expect(send.calledWith(legacy)).to.be.true;
+		const v2 = send.args
+			.map((args: any[]) => args[0])
+			.find(
+				(message: unknown) => message instanceof AddedReplicationInfoV2Message,
+			) as AddedReplicationInfoV2Message | undefined;
+		expect(v2).to.exist;
+		expect(v2!.sequence).to.equal(2n);
+	});
+
+	it("keeps capabilities monotonic and fences the previous grant generation", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiverTransportSession = 99n;
+		const context = (timestamp: bigint) =>
+			({
+				from: remote,
+				message: {
+					header: { session: receiverTransportSession, timestamp },
+				},
+			}) as any;
+
+		await log.onMessage(
+			new SyncCapabilitiesMessage({
+				capabilities:
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			}),
+			context(10n),
+		);
+		const request = (value: number) =>
+			new RequestReplicationInfoV2Message({
+				receiverChallenge: challenge(value),
+				intendedSender: log.node.identity.publicKey,
+				senderSession: BigInt(log.node.services.pubsub.session),
+			});
+		let blockFirst = true;
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (_message, options: any) => {
+				if (!blockFirst) {
+					return [] as any;
+				}
+				blockFirst = false;
+				await new Promise<void>((_resolve, reject) => {
+					options.signal.addEventListener(
+						"abort",
+						() => reject(new Error("capability generation advanced")),
+						{ once: true },
+					);
+				});
+				return [] as any;
+			});
+
+		await log.onMessage(request(30), context(11n));
+		await waitForResolved(() => expect(send.calledOnce).to.be.true);
+		await log.onMessage(
+			new SyncCapabilitiesMessage({ capabilities: 0 }),
+			context(12n),
+		);
+		expect(log._v2Send._sendStates.size).to.equal(0);
+		expect(
+			log._peerSyncCapabilities.get(remoteHash) &
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+		).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY);
+		expect(log._peerSyncCapabilityTimestamps.get(remoteHash)).to.equal(12n);
+		await waitForResolved(() =>
+			expect(log._v2Send._retiringWorkersByPeer.size).to.equal(0),
+		);
+
+		await log.onMessage(request(30), context(11n));
+		expect(send.calledOnce).to.be.true;
+		await log.onMessage(request(31), context(12n));
+		expect(send.calledOnce).to.be.true;
+		await log.onMessage(request(31), context(13n));
+		await waitForResolved(() => expect(send.callCount).to.equal(2));
+		await log._v2Send.drain();
+		expect(log._v2Send._sendStates.get(remoteHash)?.established).to.be.true;
+	});
+
+	it("keeps opening-barrier capabilities monotonic within a signed session", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		const receiverTransportSession = 101n;
+		const context = (timestamp: bigint) =>
+			({
+				from: remote,
+				message: {
+					header: { session: receiverTransportSession, timestamp },
+				},
+			}) as any;
+		peerSession.beginOpeningBarrier();
+		log._peerSessions.blockReplicationInfo(remoteHash);
+
+		try {
+			await log.onMessage(
+				new SyncCapabilitiesMessage({
+					capabilities:
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+				}),
+				context(10n),
+			);
+			await log.onMessage(
+				new SyncCapabilitiesMessage({
+					capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+				}),
+				context(9n),
+			);
+			let staged = log._openingSyncCapabilitiesByPeer.get(remoteHash);
+			expect(staged.capabilities).to.equal(
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			);
+			expect(staged.timestamp).to.equal(10n);
+
+			await log.onMessage(
+				new SyncCapabilitiesMessage({
+					capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+				}),
+				context(11n),
+			);
+			staged = log._openingSyncCapabilitiesByPeer.get(remoteHash);
+			expect(staged.capabilities).to.equal(
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			);
+			expect(staged.transportSession).to.equal(receiverTransportSession);
+			expect(staged.timestamp).to.equal(11n);
+			expect(log._peerSyncCapabilities.has(remoteHash)).to.be.false;
+		} finally {
+			log._openingSyncCapabilitiesByPeer.delete(remoteHash);
+			log._peerSessions.unblockReplicationInfo(remoteHash);
+			peerSession.finishOpeningBarrier();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- add distinct decode, sender-readiness, and receiver-apply capability bits plus a signed receiver request bound to the intended sender and transport sessions
- add bounded per-destination V2 sender streams with receiver-derived bindings, sender epochs, bigint sequences, lifecycle fences, coalescing, and safe ambiguous-delivery recovery
- retain legacy announcements as the primary mixed-version path; this slice advertises decode and send readiness, never APPLY, and never initiates a V2 request

## Validation

- `pnpm run build`
- focused replication-info V2 tests: 28 passing
- full `@peerbit/shared-log` package: 2,405 passing, 10 pending