### PR TITLE
feat(shared-log): activate replication info v2 receiver

### DIFF
--- a/.changeset/v2-receiver-apply.md
+++ b/.changeset/v2-receiver-apply.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Activate authenticated replication-info V2 receive/apply with session-bound negotiation, sender sequence ordering, lifecycle recovery, and permanent per-session legacy cutover.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -130,6 +130,14 @@ import {
 	type CheckedPruneRetryIdentity,
 	type CheckedPruneRetryState,
 } from "./checked-prune.js";
+import {
+	CoordinatePersistenceCoordinator,
+	type MaybePromise,
+	combineCoordinateDeleteHashes,
+	isPromiseLike,
+	mapMaybePromise,
+	normalizedHashValues,
+} from "./coordinate-persistence.js";
 import { type CPUUsage, CPUUsageIntervalLag } from "./cpu.js";
 import {
 	type DebouncedAccumulatorMap,
@@ -181,14 +189,6 @@ import {
 	materializeVerifiedRawExchangeHeadsMessage,
 } from "./exchange-heads.js";
 import { FanoutEnvelope } from "./fanout-envelope.js";
-import {
-	CoordinatePersistenceCoordinator,
-	type MaybePromise,
-	combineCoordinateDeleteHashes,
-	isPromiseLike,
-	mapMaybePromise,
-	normalizedHashValues,
-} from "./coordinate-persistence.js";
 import { InstanceLifecycle } from "./instance-lifecycle.js";
 import {
 	MAX_U32,
@@ -201,10 +201,7 @@ import { JoinWarmupCoordinator, type WarmupSession } from "./join-warmup.js";
 import { LeaderPlanCache } from "./leader-plan-cache.js";
 import { TransportMessage } from "./message.js";
 import { NativeBackboneWriteThroughBlockStore } from "./native-write-through-block-store.js";
-import {
-	type PeerSession,
-	PeerSessionRegistry,
-} from "./peer-session.js";
+import { type PeerSession, PeerSessionRegistry } from "./peer-session.js";
 import { PIDReplicationController } from "./pid.js";
 import {
 	type EntryReplicated,
@@ -237,7 +234,6 @@ import {
 	ReplicationAnnouncementCoordinator,
 	isTransientReplicationAnnouncementError,
 } from "./replication-announcement.js";
-import { ReplicationInfoV2SendCoordinator } from "./replication-info-v2-send.js";
 import {
 	type ReplicationDomainHash,
 	createReplicationDomainHash,
@@ -252,18 +248,24 @@ import {
 	type ReplicationDomain,
 	type ReplicationDomainConstructor,
 } from "./replication-domain.js";
+import { ReplicationInfoV2ReceiveCoordinator } from "./replication-info-v2-receive.js";
+import { ReplicationInfoV2SendCoordinator } from "./replication-info-v2-send.js";
 import {
 	AbsoluteReplicas,
+	AddedReplicationInfoV2Message,
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
 	MinReplicas,
 	ReplicationError,
+	type ReplicationInfoV2Message,
 	type ReplicationLimits,
 	ReplicationPingMessage,
 	RequestReplicationInfoMessage,
 	RequestReplicationInfoV2Message,
 	ResponseRoleMessage,
 	StoppedReplicating,
+	StoppedReplicationInfoV2Message,
 	decodeReplicas,
 	encodeReplicas,
 	isReplicationInfoV2Message,
@@ -354,6 +356,7 @@ type ReceiveLaneContext = {
 	fromHash: string;
 	session: PeerSession | null;
 	lifecycleController: AbortController | undefined;
+	ownershipLifecycleController: AbortController;
 	receiveEpoch: object | null;
 	syncProfile: SyncProfileFn | undefined;
 	lease: PeerReceiveLease;
@@ -560,6 +563,7 @@ type ReplicationRangeDeletionOutcome<R extends "u32" | "u64"> = {
 	removed: ReplicationRangeIndexable<R>[];
 	retained: ReplicationRangeIndexable<R>[];
 	ownerHasRanges: boolean;
+	rollback: () => Promise<void>;
 	error?: unknown;
 };
 
@@ -632,7 +636,8 @@ export type NativeBackboneCoordinateRollback<R extends "u32" | "u64"> = {
 	generations: Map<string, number>;
 };
 
-export type RepairDispatchEntry<R extends "u32" | "u64"> = ResidentCoordinateEntry<R>;
+export type RepairDispatchEntry<R extends "u32" | "u64"> =
+	ResidentCoordinateEntry<R>;
 
 type PreparedLocalAppendCommit<R extends "u32" | "u64"> = {
 	hash: string;
@@ -1090,7 +1095,6 @@ const isReplicationOptionsDependentOnPreviousState = async (
 
 	return false;
 };
-
 
 export interface IndexableDomain<R extends "u32" | "u64"> {
 	numbers: Numbers<R>;
@@ -1990,7 +1994,8 @@ export class SharedLog<
 	}
 
 	get _nativeBackboneCoordinateJournalLastFlushMs(): number {
-		return this._coordinates?._nativeBackboneCoordinateJournalLastFlushMs as number;
+		return this._coordinates
+			?._nativeBackboneCoordinateJournalLastFlushMs as number;
 	}
 
 	set _nativeBackboneCoordinateJournalLastFlushMs(value: number) {
@@ -3077,7 +3082,8 @@ export class SharedLog<
 		if (!lowerMarkerCommitted) {
 			if (intent.coordinates.length > 0) {
 				const mutationGenerations =
-					(this._coordinates._nativeCoordinateMutationGenerations ??= new Map());
+					(this._coordinates._nativeCoordinateMutationGenerations ??=
+						new Map());
 				const rollback: NativeBackboneCoordinateRollback<R> = {
 					hashes: new Set(),
 					entries: new Map(),
@@ -3109,7 +3115,10 @@ export class SharedLog<
 						);
 					}
 				}
-				await this._coordinates.rollbackNativeBackboneCoordinateAppendDurably("", rollback);
+				await this._coordinates.rollbackNativeBackboneCoordinateAppendDurably(
+					"",
+					rollback,
+				);
 			}
 			for (const document of intent.documents) {
 				this.restoreNativeBackboneDocument({
@@ -3234,6 +3243,7 @@ export class SharedLog<
 		| ReturnType<typeof debounceFixedInterval>
 		| undefined;
 	private _announcements!: ReplicationAnnouncementCoordinator<R>;
+	private _v2Receive!: ReplicationInfoV2ReceiveCoordinator;
 	private _v2Send!: ReplicationInfoV2SendCoordinator<R>;
 
 	// A fn for debouncing the calls for pruning
@@ -3368,16 +3378,20 @@ export class SharedLog<
 			queueCurrentReplicationStateAnnouncementRepair: () =>
 				this._announcements.queueCurrentReplicationStateAnnouncementRepair(),
 			queueCurrentReplicationStateAnnouncementRetry: (error: unknown) =>
-				this._announcements.queueCurrentReplicationStateAnnouncementRetry(error),
+				this._announcements.queueCurrentReplicationStateAnnouncementRetry(
+					error,
+				),
 			enqueueReplicationInfoV2: (message) => this._v2Send.enqueue(message),
 			isClosed: () => this.closed,
 			getCloseSignal: () => this._closeController.signal,
 			getMyReplicationSegments: () => this.getMyReplicationSegments(),
 			validatePersistedReplicationRangeSnapshot: (ranges) =>
 				this.validatePersistedReplicationRangeSnapshot(ranges),
-			getSubscribers: () => this.node.services.pubsub.getSubscribers(this.topic),
+			getSubscribers: () =>
+				this.node.services.pubsub.getSubscribers(this.topic),
 			getSelfHash: () => this.node.identity.publicKey.hashcode(),
-			isBlockedPeer: (hash) => this._peerSessions.isReplicationInfoBlocked(hash),
+			isBlockedPeer: (hash) =>
+				this._peerSessions.isReplicationInfoBlocked(hash),
 			getRpc: () => this.rpc,
 			captureReplicationOwnershipLifecycle: () =>
 				this.captureReplicationOwnershipLifecycle(),
@@ -3413,6 +3427,114 @@ export class SharedLog<
 		});
 	}
 
+	private replicationInfoV2ReceiveCapabilities(): number {
+		return (
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY |
+			(this._logProperties?.sync?.rawExchangeHeads === true
+				? SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
+				: 0)
+		);
+	}
+
+	private async advertiseReplicationInfoV2ReceiveCapability(properties: {
+		target: PublicSignKey;
+		peerSession: PeerSession;
+		receiveEpoch: object | null;
+		signal: AbortSignal;
+	}): Promise<
+		{ receiverTransportSession: bigint; requestNotBeforeMs: number } | undefined
+	> {
+		const peerHash = properties.target.hashcode();
+		const receiverTransportSession = BigInt(
+			(this.node.services.pubsub as unknown as { session: number }).session,
+		);
+		await this.rpc.send(
+			new SyncCapabilitiesMessage({
+				capabilities: this.replicationInfoV2ReceiveCapabilities(),
+			}),
+			{
+				mode: new AcknowledgeDelivery({
+					redundancy: 1,
+					to: [properties.target],
+				}),
+				priority: CONVERGENCE_MESSAGE_PRIORITY,
+				signal: properties.signal,
+			},
+		);
+		if (
+			properties.signal.aborted ||
+			this.closed ||
+			!this._peerSessions.isCurrent(peerHash, properties.peerSession) ||
+			properties.peerSession.phase !== "open" ||
+			!properties.peerSession.isActive() ||
+			!this._peerSessions.isReceiveEpochCurrent(
+				peerHash,
+				properties.receiveEpoch,
+			) ||
+			this._peerSessions.isReplicationInfoBlocked(peerHash) ||
+			!this._peerSessions.isReceiveCleanupGateOpen(peerHash) ||
+			BigInt(
+				(this.node.services.pubsub as unknown as { session: number }).session,
+			) !== receiverTransportSession
+		) {
+			return undefined;
+		}
+		return {
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		};
+	}
+
+	private createReplicationInfoV2ReceiveCoordinator(): ReplicationInfoV2ReceiveCoordinator {
+		return new ReplicationInfoV2ReceiveCoordinator({
+			getSelfKey: () => this.node.identity.publicKey,
+			getReceiverTransportSession: () =>
+				BigInt(
+					(this.node.services.pubsub as unknown as { session: number }).session,
+				),
+			isClosed: () => this.closed,
+			isPeerStateCurrent: (peerHash, peerSession, receiveEpoch) =>
+				this._peerSessions.isCurrent(peerHash, peerSession) &&
+				(peerSession as PeerSession).phase === "open" &&
+				(peerSession as PeerSession).isActive() &&
+				this._peerSessions.isReceiveEpochCurrent(peerHash, receiveEpoch) &&
+				!this._peerSessions.isReplicationInfoBlocked(peerHash) &&
+				this._peerSessions.isReceiveCleanupGateOpen(peerHash),
+			isSenderTransportSessionCurrent: (peerHash, senderTransportSession) =>
+				this._peerSyncCapabilitySessions.get(peerHash) ===
+				senderTransportSession,
+			sendRequest: async (request, target, signal) => {
+				await this.rpc.send(request, {
+					mode: new AcknowledgeDelivery({ redundancy: 1, to: [target] }),
+					priority: CONVERGENCE_MESSAGE_PRIORITY,
+					signal,
+				});
+			},
+			refreshLocalCapability: (properties) =>
+				this.advertiseReplicationInfoV2ReceiveCapability({
+					target: properties.target,
+					peerSession: properties.peerSession as PeerSession,
+					receiveEpoch: properties.receiveEpoch,
+					signal: properties.signal,
+				}),
+			onRequestError: (error) => {
+				if (
+					isNotStartedError(error as Error) ||
+					(this.closed && error instanceof AbortError)
+				) {
+					return;
+				}
+				logger.trace(
+					`Replication-info V2 recovery request failed: ${
+						(error as Error)?.message ?? String(error)
+					}`,
+				);
+			},
+		});
+	}
+
 	private createReplicatorLivenessMonitor(): ReplicatorLivenessMonitor {
 		return new ReplicatorLivenessMonitor({
 			// Sweep-driven probes and activity marks dispatch through the owner so
@@ -3443,7 +3565,8 @@ export class SharedLog<
 					}),
 				);
 			},
-			isBlockedPeer: (hash) => this._peerSessions.isReplicationInfoBlocked(hash),
+			isBlockedPeer: (hash) =>
+				this._peerSessions.isReplicationInfoBlocked(hash),
 			scheduleReplicationInfoRequests: (peer, replicationLifecycleController) =>
 				this.scheduleReplicationInfoRequests(
 					peer,
@@ -3537,6 +3660,7 @@ export class SharedLog<
 		this._replicatorJoinEmitted = new Set();
 		this._replicatorsReconciled = false;
 		this._liveness = this.createReplicatorLivenessMonitor();
+		this._v2Receive = this.createReplicationInfoV2ReceiveCoordinator();
 		this._v2Send = this.createReplicationInfoV2SendCoordinator();
 		this._announcements = this.createReplicationAnnouncementCoordinator();
 		this.pendingMaturity = new Map();
@@ -4053,9 +4177,22 @@ export class SharedLog<
 				transportSession !== undefined &&
 				timestamp !== undefined &&
 				previous?.epoch === openingSession &&
+				previous.timestamp !== undefined &&
+				previous.transportSession !== transportSession &&
+				timestamp <= previous.timestamp
+			) {
+				return false;
+			}
+			if (
+				transportSession !== undefined &&
+				timestamp !== undefined &&
+				previous?.epoch === openingSession &&
 				previous.transportSession === transportSession
 			) {
-				if (previous.timestamp !== undefined && timestamp < previous.timestamp) {
+				if (
+					previous.timestamp !== undefined &&
+					timestamp < previous.timestamp
+				) {
 					return false;
 				}
 				this._openingSyncCapabilitiesByPeer.set(peerHash, {
@@ -4085,6 +4222,7 @@ export class SharedLog<
 			this._peerSyncCapabilitySessions.delete(peerHash);
 			this._peerSyncCapabilityTimestamps.delete(peerHash);
 			this._v2Send.advancePeerCapability(peerHash);
+			this._v2Receive.revokePeerCapability(peerHash);
 			return true;
 		}
 
@@ -4092,22 +4230,23 @@ export class SharedLog<
 		const previousTimestamp = this._peerSyncCapabilityTimestamps.get(peerHash);
 		const sameTransportSession = previousSession === transportSession;
 		if (
-			sameTransportSession &&
 			previousTimestamp !== undefined &&
-			timestamp < previousTimestamp
+			((sameTransportSession && timestamp < previousTimestamp) ||
+				(!sameTransportSession && timestamp <= previousTimestamp))
 		) {
 			return false;
 		}
-		const previousCapabilities =
-			this._peerSyncCapabilities.get(peerHash) ?? 0;
+		const previousCapabilities = this._peerSyncCapabilities.get(peerHash) ?? 0;
 		const nextCapabilities = sameTransportSession
 			? previousCapabilities | capabilities
 			: capabilities;
+		const senderGrantCapabilityMask =
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+			SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY;
 		const generationAdvanced =
 			!sameTransportSession ||
-			previousTimestamp === undefined ||
-			timestamp > previousTimestamp ||
-			nextCapabilities !== previousCapabilities;
+			(previousCapabilities & senderGrantCapabilityMask) !==
+				(nextCapabilities & senderGrantCapabilityMask);
 		this._peerSyncCapabilities.set(peerHash, nextCapabilities);
 		this._peerSyncCapabilitySessions.set(peerHash, transportSession);
 		this._peerSyncCapabilityTimestamps.set(
@@ -4122,6 +4261,32 @@ export class SharedLog<
 			this._v2Send.advancePeerCapability(peerHash);
 		}
 		return true;
+	}
+
+	private promoteReplicationInfoV2ReceiveCapability(
+		target: PublicSignKey,
+		peerSession: PeerSession,
+	): boolean {
+		const peerHash = target.hashcode();
+		const senderTransportSession =
+			this._peerSyncCapabilitySessions.get(peerHash);
+		const capabilityTimestamp =
+			this._peerSyncCapabilityTimestamps.get(peerHash);
+		if (
+			senderTransportSession === undefined ||
+			capabilityTimestamp === undefined
+		) {
+			return false;
+		}
+		return this._v2Receive.observeCapability({
+			peerHash,
+			target,
+			peerSession,
+			receiveEpoch: this._peerSessions.receiveEpoch(peerHash),
+			capabilities: this._peerSyncCapabilities.get(peerHash) ?? 0,
+			senderTransportSession,
+			capabilityTimestamp,
+		});
 	}
 
 	/**
@@ -5001,7 +5166,8 @@ export class SharedLog<
 
 	private isReceiveOwnershipSnapshotStable(revision: number): boolean {
 		return (
-			(this._instanceLifecycle?._receiveOwnershipMutationAdmissions ?? 0) === 0 &&
+			(this._instanceLifecycle?._receiveOwnershipMutationAdmissions ?? 0) ===
+				0 &&
 			(this._instanceLifecycle?._receiveOwnershipRevision ?? 0) === revision
 		);
 	}
@@ -5249,7 +5415,8 @@ export class SharedLog<
 		pending: PendingIHave<T>,
 		entry: Entry<T>,
 	): void {
-		const replicationLifecycleController = this._instanceLifecycle?.membershipLifecycleController;
+		const replicationLifecycleController =
+			this._instanceLifecycle?.membershipLifecycleController;
 		if (!this.isReplicationLifecycleActive(replicationLifecycleController)) {
 			if (this._pendingIHave.get(entry.hash) === pending) {
 				pending.clear();
@@ -6157,6 +6324,7 @@ export class SharedLog<
 		};
 		let removed = false;
 		let removalCallCompleted = false;
+		let replicationInfoRecoveryEpochAdvanced = false;
 
 		// Replication-info updates already serialize per peer. Put the hash-wide
 		// removal on the same queue so a newer reset cannot be deleted underneath
@@ -6246,6 +6414,13 @@ export class SharedLog<
 								checkedPruneCoordinator,
 							);
 						}
+						if (!isMe) {
+							// This is the last synchronous current-generation boundary
+							// before destructive work. Fence parked receives now because
+							// the coherent delete can durably mutate and then fail or poison.
+							this.advanceReplicationInfoRecoveryEpoch(keyHash);
+							replicationInfoRecoveryEpochAdvanced = true;
+						}
 						const deletion = await this.deleteReplicationRangesCoherently(
 							deleted,
 							keyHash,
@@ -6269,7 +6444,6 @@ export class SharedLog<
 					}
 					return;
 				}
-
 				if (options?.noEvent !== true && deleted.length > 0) {
 					const publicKey = toLocalPublicSignKey(key);
 					if (publicKey) {
@@ -6305,11 +6479,6 @@ export class SharedLog<
 				await cleanupDisconnectedPeer();
 
 				if (!isMe) {
-					// Replication-info handlers release their receive lease before joining
-					// this lane. Fence every handler queued behind this successful removal,
-					// regardless of whether it came from liveness, startup pruning, or an
-					// unsubscribe transition.
-					this.advanceReplicationInfoRecoveryEpoch(keyHash);
 					this.rebalanceParticipationDebounced?.call();
 				}
 				removed = true;
@@ -6347,6 +6516,24 @@ export class SharedLog<
 			removalCallCompleted = true;
 		} finally {
 			releaseReceiveCleanupGate?.();
+			if (
+				replicationInfoRecoveryEpochAdvanced &&
+				ownsReplicationOwnershipLifecycle() &&
+				ownsReplicationLifecycle() &&
+				ownsSubscriptionEpoch()
+			) {
+				// The first recovery arm ran while receive admission was fenced.
+				// Re-arm after releasing the cleanup gate so a still-open peer can
+				// deliver the authoritative Full that completes recovery.
+				const peerSession = this._peerSessions.current(keyHash);
+				if (peerSession?.phase === "open") {
+					this._v2Receive.advanceRecovery({
+						peerHash: keyHash,
+						peerSession,
+						receiveEpoch: this._peerSessions.receiveEpoch(keyHash),
+					});
+				}
+			}
 			if (isSpeculativePeerRemoval) {
 				const cancelledByFreshActivity =
 					removalCallCompleted &&
@@ -6422,6 +6609,7 @@ export class SharedLog<
 		options?: {
 			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
 			shouldRemove?: () => boolean;
+			onDurableRemoveCommitted?: () => boolean | void;
 		},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<boolean> {
@@ -6440,6 +6628,7 @@ export class SharedLog<
 		options?: {
 			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
 			shouldRemove?: () => boolean;
+			onDurableRemoveCommitted?: () => boolean | void;
 		},
 	): Promise<boolean> {
 		if (ranges.length === 0) {
@@ -6496,6 +6685,13 @@ export class SharedLog<
 			ownerHash,
 		);
 		ranges = deletion.removed;
+		if (
+			(options?.shouldRemove && !options.shouldRemove()) ||
+			options?.onDurableRemoveCommitted?.() === false
+		) {
+			await deletion.rollback();
+			return false;
+		}
 		options?.onRemoved?.(ranges);
 
 		if (ranges.length > 0) {
@@ -6581,6 +6777,7 @@ export class SharedLog<
 			timestamp?: number;
 			allowLegacyOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			onDurableApplyCommitted?: () => boolean | void;
 			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -6622,6 +6819,7 @@ export class SharedLog<
 			rebalance,
 			allowLegacyOrderedReplacementPairs,
 			onConfirmedDurableStateChanged,
+			onDurableApplyCommitted,
 			shouldApply,
 		}: {
 			reset?: boolean;
@@ -6630,6 +6828,7 @@ export class SharedLog<
 			timestamp?: number;
 			allowLegacyOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			onDurableApplyCommitted?: () => boolean | void;
 			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -6644,6 +6843,12 @@ export class SharedLog<
 		if (shouldApply && !shouldApply()) {
 			return [];
 		}
+		const applySuperseded = Symbol("replication-range-apply-superseded");
+		const throwIfApplySuperseded = () => {
+			if (shouldApply && !shouldApply()) {
+				throw applySuperseded;
+			}
+		};
 		const fromHash = from.hashcode();
 		const incomingRangesById = new Map<
 			string,
@@ -6733,6 +6938,7 @@ export class SharedLog<
 		let isStoppedReplicating = false;
 		let wasReplicatorBeforeDestructiveReset = false;
 		let resetFailureLeaveEmitted = false;
+		let resetDeletionRollback: (() => Promise<void>) | undefined;
 		const publishConfirmedResetStop = (ownerHasRanges: boolean) => {
 			if (ownerHasRanges || resetFailureLeaveEmitted) {
 				return;
@@ -6785,12 +6991,18 @@ export class SharedLog<
 			} else {
 				wasReplicatorBeforeDestructiveReset =
 					this.uniqueReplicators.has(fromHash);
+				throwIfApplySuperseded();
 				const deletion = await this.deleteReplicationRangesCoherently(
 					deleted,
 					fromHash,
 					{ preserveOwnerMembership: ranges.length > 0 },
 				);
 				deleted = deletion.removed;
+				resetDeletionRollback = deletion.rollback;
+				if (shouldApply && !shouldApply()) {
+					await deletion.rollback();
+					return [];
+				}
 
 				diffs = [
 					...deleted.map((x) => {
@@ -6986,18 +7198,26 @@ export class SharedLog<
 		};
 
 		try {
+			throwIfApplySuperseded();
 			for (const diff of diffs) {
 				if (diff.type !== "added") {
 					continue;
 				}
+				throwIfApplySuperseded();
 				appliedPositiveRanges.push(diff);
 				await this.replicationIndex.put(diff.range);
 				this.putNativeReplicationRange(diff.range);
+				throwIfApplySuperseded();
 			}
 			if (reset && diffs.length > 0) {
 				await this.updateOldestTimestampFromIndex();
+				throwIfApplySuperseded();
+			}
+			if (onDurableApplyCommitted?.() === false) {
+				throw applySuperseded;
 			}
 		} catch (error) {
+			const superseded = error === applySuperseded;
 			let outcomeError = error;
 			if (appliedPositiveRanges.length > 0) {
 				try {
@@ -7005,6 +7225,19 @@ export class SharedLog<
 				} catch (rollbackError) {
 					outcomeError = poisonFromPositiveRollback(rollbackError, error);
 				}
+			}
+			if (superseded) {
+				if (resetDeletionRollback) {
+					try {
+						await resetDeletionRollback();
+					} catch (rollbackError) {
+						outcomeError = rollbackError;
+					}
+				}
+				if (outcomeError === applySuperseded) {
+					return [];
+				}
+				throw outcomeError;
 			}
 			if (reset) {
 				const negativeDiffs = diffs.filter((diff) => diff.type !== "added");
@@ -8612,7 +8845,8 @@ export class SharedLog<
 					}
 				};
 
-				const residentEntriesByHash = this._coordinates._residentEntryCoordinatesByHash;
+				const residentEntriesByHash =
+					this._coordinates._residentEntryCoordinatesByHash;
 				if (
 					(this._nativeBackbone ?? this._nativeSharedLogState) &&
 					residentEntriesByHash &&
@@ -8924,7 +9158,8 @@ export class SharedLog<
 		const localLeaderHashes = new Set<string>();
 		const unresolvedHashes = new Set(hashes);
 		const nativePlanner = this._nativeBackbone ?? this._nativeRangePlanner;
-		const nativeEntryMetadata = this._coordinates.getNativeLogEntryMetadataBatch(hashes);
+		const nativeEntryMetadata =
+			this._coordinates.getNativeLogEntryMetadataBatch(hashes);
 
 		if (nativePlanner && !this.hasCustomFindLeaders() && nativeEntryMetadata) {
 			const nativeItems: Array<{
@@ -10425,7 +10660,8 @@ export class SharedLog<
 			) {
 				try {
 					this.restoreNativeBackboneDocument(nativeDocumentRollback);
-					const flushed = this._coordinates.flushNativeBackboneCoordinateJournal();
+					const flushed =
+						this._coordinates.flushNativeBackboneCoordinateJournal();
 					if (isPromiseLike(flushed)) {
 						await flushed;
 					}
@@ -10515,11 +10751,12 @@ export class SharedLog<
 								prepared.trimmedEntries as Array<{ hash?: string }> | undefined
 							)?.flatMap((entry) => (entry.hash ? [entry.hash] : [])) ??
 							[];
-						const coordinateRollback = this._coordinates.snapshotResidentCoordinateEntries([
-							...(preparedHash ? [preparedHash] : []),
-							...preparedNext,
-							...nativeTrimmedHashes,
-						]);
+						const coordinateRollback =
+							this._coordinates.snapshotResidentCoordinateEntries([
+								...(preparedHash ? [preparedHash] : []),
+								...preparedNext,
+								...nativeTrimmedHashes,
+							]);
 						lowerPublicationRollback = {
 							committedHashes: preparedHash ? [preparedHash] : [],
 							trimmedEntries: prepared.trimmedEntries,
@@ -10735,7 +10972,8 @@ export class SharedLog<
 					for (const document of lowerPublicationRollback?.documents ?? []) {
 						this.restoreNativeBackboneDocument(document);
 					}
-					const flushed = this._coordinates.flushNativeBackboneCoordinateJournal();
+					const flushed =
+						this._coordinates.flushNativeBackboneCoordinateJournal();
 					if (isPromiseLike(flushed)) {
 						await flushed;
 					}
@@ -10830,7 +11068,10 @@ export class SharedLog<
 			ownershipLifecycleController,
 		);
 		const backbone = this._nativeBackbone;
-		if (!backbone || !this._coordinates.canUseNativeBackboneResidentCoordinateState()) {
+		if (
+			!backbone ||
+			!this._coordinates.canUseNativeBackboneResidentCoordinateState()
+		) {
 			return undefined;
 		}
 		if (
@@ -11035,11 +11276,12 @@ export class SharedLog<
 					const committedHash =
 						backboneAppend.entry.cid ?? backboneAppend.entry.hash;
 					const committedNext = backboneAppend.entry.next ?? next;
-					nativeCoordinateRollback = this._coordinates.snapshotResidentCoordinateEntries([
-						...(committedHash ? [committedHash] : []),
-						...committedNext,
-						...nativeTrimmedHashes,
-					]);
+					nativeCoordinateRollback =
+						this._coordinates.snapshotResidentCoordinateEntries([
+							...(committedHash ? [committedHash] : []),
+							...committedNext,
+							...nativeTrimmedHashes,
+						]);
 					await this.setNativeStrictDurableTransactionOperation(
 						nativeStrictTransaction,
 						committedHash ? [committedHash] : [],
@@ -11350,7 +11592,8 @@ export class SharedLog<
 						if (nativeDocumentRollback) {
 							try {
 								this.restoreNativeBackboneDocument(nativeDocumentRollback);
-								const flushed = this._coordinates.flushNativeBackboneCoordinateJournal();
+								const flushed =
+									this._coordinates.flushNativeBackboneCoordinateJournal();
 								if (isPromiseLike(flushed)) {
 									await flushed;
 								}
@@ -11382,15 +11625,17 @@ export class SharedLog<
 							coordinateIndex.putSharedLogCoordinateFieldsEncodedAndDeleteHashesNoReturn ||
 							coordinateIndex.putSharedLogCoordinateFieldsAndDeleteHashesNoReturn;
 						const persisted = hasNativeCoordinatePut
-							? this._coordinates.persistBackboneCoordinateFieldsNativeTransaction({
-									coordinateIndex,
-									fields: coordinateFields,
-									hash: prepared.appendFacts.hash,
-									deleteHashes: [],
-									coordinates: backboneAppend.coordinate
-										.coordinates as NumberFromType<R>[],
-									skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
-								})
+							? this._coordinates.persistBackboneCoordinateFieldsNativeTransaction(
+									{
+										coordinateIndex,
+										fields: coordinateFields,
+										hash: prepared.appendFacts.hash,
+										deleteHashes: [],
+										coordinates: backboneAppend.coordinate
+											.coordinates as NumberFromType<R>[],
+										skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
+									},
+								)
 							: this._coordinates.persistPreparedCoordinate({
 									prepared: getPreparedCoordinate(),
 									hash: prepared.appendFacts.hash,
@@ -11444,9 +11689,10 @@ export class SharedLog<
 					if (!backboneAppend.isLeader && !delayAdaptiveRebalance) {
 						const leaders = backboneAppend.leaders;
 						if (leaders) {
-							const pruneEntry = this._coordinates.materializePreparedCoordinateEntry(
-								getPreparedCoordinate(),
-							);
+							const pruneEntry =
+								this._coordinates.materializePreparedCoordinateEntry(
+									getPreparedCoordinate(),
+								);
 							this.pruneDebouncedFnAddIfNotKeeping({
 								key: pruneEntry.hash,
 								value: { entry: pruneEntry, leaders },
@@ -12117,16 +12363,17 @@ export class SharedLog<
 						),
 					);
 					const nativeTrimmedHashes = [...nativeTrimmedHashSet];
-					batchCoordinateRollback = this._coordinates.snapshotResidentCoordinateEntries(
-						committedAppends.flatMap((append) => [
-							...((append.entry.cid ?? append.entry.hash)
-								? [append.entry.cid ?? append.entry.hash!]
-								: []),
-							...append.entry.next,
-							...(append.trimmedHashes ??
-								append.trimmed.map((entry) => entry.hash)),
-						]),
-					);
+					batchCoordinateRollback =
+						this._coordinates.snapshotResidentCoordinateEntries(
+							committedAppends.flatMap((append) => [
+								...((append.entry.cid ?? append.entry.hash)
+									? [append.entry.cid ?? append.entry.hash!]
+									: []),
+								...append.entry.next,
+								...(append.trimmedHashes ??
+									append.trimmed.map((entry) => entry.hash)),
+							]),
+						);
 					await this.setNativeStrictDurableTransactionOperation(
 						nativeStrictTransaction,
 						committedCids,
@@ -12378,7 +12625,8 @@ export class SharedLog<
 				for (const document of batchDocumentRollbacks) {
 					this.restoreNativeBackboneDocument(document);
 				}
-				const flushed = this._coordinates.flushNativeBackboneCoordinateJournal();
+				const flushed =
+					this._coordinates.flushNativeBackboneCoordinateJournal();
 				if (isPromiseLike(flushed)) {
 					await flushed;
 				}
@@ -12458,20 +12706,21 @@ export class SharedLog<
 					coordinateFields,
 					plannedCoordinateDeleteHashes,
 				});
-				const persisted = this._coordinates.persistBackboneCoordinateFieldsNativeTransaction(
-					{
-						coordinateIndex: this.entryCoordinatesIndex as PutAndDeleteIndex<
-							EntryReplicated<R>
-						>,
-						fields: coordinateFields,
-						hash: facts.hash,
-						deleteHashes: [],
-						coordinates: backboneAppend.coordinate
-							.coordinates as NumberFromType<R>[],
-						skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
-					},
-					ownershipLifecycleController,
-				);
+				const persisted =
+					this._coordinates.persistBackboneCoordinateFieldsNativeTransaction(
+						{
+							coordinateIndex: this.entryCoordinatesIndex as PutAndDeleteIndex<
+								EntryReplicated<R>
+							>,
+							fields: coordinateFields,
+							hash: facts.hash,
+							deleteHashes: [],
+							coordinates: backboneAppend.coordinate
+								.coordinates as NumberFromType<R>[],
+							skipGenericTransientCoordinateIndex: runtimeOnlyCoordinates,
+						},
+						ownershipLifecycleController,
+					);
 				if (isPromiseLike(persisted)) {
 					await persisted;
 					this.throwIfReplicationOwnershipLifecycleInactive(
@@ -13982,6 +14231,8 @@ export class SharedLog<
 		this._lastLocalAppendAt = 0;
 		this._announcements ??= this.createReplicationAnnouncementCoordinator();
 		this._announcements.resetForOpen();
+		this._v2Receive ??= this.createReplicationInfoV2ReceiveCoordinator();
+		this._v2Receive.resetForOpen();
 		this._v2Send ??= this.createReplicationInfoV2SendCoordinator();
 		this._v2Send.resetForOpen();
 		const adaptiveReplicateOptions =
@@ -14725,8 +14976,11 @@ export class SharedLog<
 			// tombstone was written. Complete that erase before the adapter can expose
 			// any stale coordinate or document state to this backbone.
 			await this._coordinates._nativeBackboneCoordinatePersistence.resumeDrop?.();
-			await this._coordinates._nativeBackboneCoordinatePersistence.hydrate(backbone);
-			this._coordinates._nativeBackboneCoordinateJournalLastFlushMs = Date.now();
+			await this._coordinates._nativeBackboneCoordinatePersistence.hydrate(
+				backbone,
+			);
+			this._coordinates._nativeBackboneCoordinateJournalLastFlushMs =
+				Date.now();
 			this.hydrateNativeCoordinateStateFromBackbone(backbone);
 			return;
 		}
@@ -14766,7 +15020,9 @@ export class SharedLog<
 		if (!this._nativeBackbone) {
 			return;
 		}
-		const hashes = new Set(this._coordinates._residentEntryCoordinatesByHash?.keys() ?? []);
+		const hashes = new Set(
+			this._coordinates._residentEntryCoordinatesByHash?.keys() ?? [],
+		);
 		const iterator = this.entryCoordinatesIndex.iterate({});
 		try {
 			for (;;) {
@@ -14836,7 +15092,10 @@ export class SharedLog<
 				coordinate.requestedReplicas,
 				sharedFields.hashNumber,
 			);
-			this._coordinates._residentEntryCoordinatesByHash.set(sharedFields.hash, sharedFields);
+			this._coordinates._residentEntryCoordinatesByHash.set(
+				sharedFields.hash,
+				sharedFields,
+			);
 			for (const value of sharedFields.coordinates) {
 				this.coordinateToHash.add(value, sharedFields.hash);
 			}
@@ -14995,7 +15254,8 @@ export class SharedLog<
 				this._coordinates._nativeBackboneCoordinatePersistence
 			) {
 				if (
-					this._coordinates._nativeBackboneCoordinatePersistence.durableBarrier !== true ||
+					this._coordinates._nativeBackboneCoordinatePersistence
+						.durableBarrier !== true ||
 					typeof this._nativeBackboneCoordinatePersistenceStore
 						?.durableBarrier !== "function"
 				) {
@@ -15006,11 +15266,12 @@ export class SharedLog<
 			}
 			if (
 				this._coordinates._nativeBackboneCoordinatePersistence &&
-				(this._coordinates._nativeBackboneCoordinatePersistence.compactMaxJournalBytes !=
-					null ||
-					this._coordinates._nativeBackboneCoordinatePersistence.compactMaxJournalRecords !=
-						null) &&
-				this._coordinates._nativeBackboneCoordinatePersistence.crashSafeCompaction !== true
+				(this._coordinates._nativeBackboneCoordinatePersistence
+					.compactMaxJournalBytes != null ||
+					this._coordinates._nativeBackboneCoordinatePersistence
+						.compactMaxJournalRecords != null) &&
+				this._coordinates._nativeBackboneCoordinatePersistence
+					.crashSafeCompaction !== true
 			) {
 				// Durable custom adapters must explicitly advertise an atomic generation
 				// protocol before SharedLog permits automatic WAL compaction.
@@ -15236,7 +15497,8 @@ export class SharedLog<
 	async afterOpen(): Promise<void> {
 		await super.afterOpen();
 		const existingSubscribersPromise = this._getTopicSubscribers(this.topic);
-		const replicationLifecycleController = this._instanceLifecycle?.membershipLifecycleController;
+		const replicationLifecycleController =
+			this._instanceLifecycle?.membershipLifecycleController;
 
 		// We do this here, because these calls requires this.closed == false
 		void this.pruneOfflineReplicators()
@@ -15277,7 +15539,8 @@ export class SharedLog<
 	async pruneOfflineReplicators() {
 		// Go through all segments and wait for replicators to become reachable;
 		// otherwise prune them away from the local membership view.
-		const replicationLifecycleController = this._instanceLifecycle?.membershipLifecycleController;
+		const replicationLifecycleController =
+			this._instanceLifecycle?.membershipLifecycleController;
 		try {
 			if (
 				!replicationLifecycleController ||
@@ -15472,13 +15735,19 @@ export class SharedLog<
 		peerHash: string,
 		ownershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	) {
+		const peerSession = this._peerSessions.current(peerHash);
+		const preserveV2Session =
+			peerSession?.phase === "open" && peerSession.isActive();
 		this.cancelReplicationInfoRequests(peerHash);
 		this._liveness._replicatorLivenessFailures.delete(peerHash);
 		this._liveness._replicatorLastActivityAt.delete(peerHash);
-		this._peerSyncCapabilities.delete(peerHash);
-		this._peerSyncCapabilitySessions.delete(peerHash);
-		this._peerSyncCapabilityTimestamps.delete(peerHash);
-		this._v2Send.clearPeer(peerHash);
+		if (!preserveV2Session) {
+			this._peerSyncCapabilities.delete(peerHash);
+			this._peerSyncCapabilitySessions.delete(peerHash);
+			this._peerSyncCapabilityTimestamps.delete(peerHash);
+			this._v2Receive.clearPeer(peerHash);
+			this._v2Send.clearPeer(peerHash);
+		}
 		this.cleanupPendingIHavePeer(peerHash);
 		this.cleanupCheckedPrunePeer(
 			peerHash,
@@ -15502,8 +15771,16 @@ export class SharedLog<
 		// when they eventually reach the apply lane. Reset the sender's
 		// ordering watermark with the local epoch so a later arrival can be
 		// accepted without comparing its clock to this receiver's clock.
-		this._peerSessions.advanceReceiveEpoch(peerHash);
+		const receiveEpoch = this._peerSessions.advanceReceiveEpoch(peerHash);
 		this.latestReplicationInfoMessage.delete(peerHash);
+		const peerSession = this._peerSessions.current(peerHash);
+		if (peerSession?.phase === "open") {
+			this._v2Receive.advanceRecovery({
+				peerHash,
+				peerSession,
+				receiveEpoch,
+			});
+		}
 	}
 
 	private async resolveCandidatePeersForHash(
@@ -15784,7 +16061,9 @@ export class SharedLog<
 				deferredCoordinateDeleteHashes,
 			);
 		} else {
-			this._coordinates.forgetCoordinateStateForHashes(deferredCoordinateDeleteHashes);
+			this._coordinates.forgetCoordinateStateForHashes(
+				deferredCoordinateDeleteHashes,
+			);
 		}
 		return deferredCoordinateDeleteHashes;
 	}
@@ -15832,7 +16111,9 @@ export class SharedLog<
 				deferredCoordinateDeleteHashes,
 			);
 		} else {
-			this._coordinates.forgetCoordinateStateForHashes(deferredCoordinateDeleteHashes);
+			this._coordinates.forgetCoordinateStateForHashes(
+				deferredCoordinateDeleteHashes,
+			);
 		}
 		return deferredCoordinateDeleteHashes;
 	}
@@ -16395,7 +16676,9 @@ export class SharedLog<
 				this._wireSyncSession = undefined;
 			}
 		});
-		await capture(() => this._coordinates.closeNativeBackboneCoordinatePersistence());
+		await capture(() =>
+			this._coordinates.closeNativeBackboneCoordinatePersistence(),
+		);
 		await capture(() => this.syncronizer?.close());
 
 		captureSync(() => {
@@ -16490,6 +16773,7 @@ export class SharedLog<
 			this._peerSyncCapabilities?.clear();
 			this._peerSyncCapabilitySessions?.clear();
 			this._peerSyncCapabilityTimestamps?.clear();
+			this._v2Receive?.clearForClose();
 			this._v2Send?.clearForClose();
 			this._liveRawGossipBatches?.clear();
 			this._nativeSharedLogState?.clearGidPeers();
@@ -16563,6 +16847,7 @@ export class SharedLog<
 		this.preventParentAttachments();
 		this.stopRepairLifecycle();
 		this._instanceLifecycle?.beginTerminal("close");
+		this._v2Receive?.clearForClose();
 		const replicationRangeTerminalFence =
 			this.acquireReplicationRangeMutationTerminalFence();
 		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();
@@ -16625,10 +16910,12 @@ export class SharedLog<
 				try {
 					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
 					await Promise.all([
-						this.rpc.send(reset, {
-							priority: CONVERGENCE_MESSAGE_PRIORITY,
-							signal: abort.signal,
-						}).catch(() => {}),
+						this.rpc
+							.send(reset, {
+								priority: CONVERGENCE_MESSAGE_PRIORITY,
+								signal: abort.signal,
+							})
+							.catch(() => {}),
 						this._v2Send.sendTerminalReset(abort.signal),
 					]);
 				} finally {
@@ -16688,7 +16975,8 @@ export class SharedLog<
 		}
 		this.throwIfCheckedPruneRemoveBlocksLocalOperation("drop");
 		this.ensureNativeDurabilityRuntimeState();
-		const nativePersistence = this._coordinates._nativeBackboneCoordinatePersistence;
+		const nativePersistence =
+			this._coordinates._nativeBackboneCoordinatePersistence;
 		if (
 			nativePersistence &&
 			(typeof nativePersistence.drop !== "function" ||
@@ -16706,6 +16994,7 @@ export class SharedLog<
 		this.preventParentAttachments();
 		this.stopRepairLifecycle();
 		this._instanceLifecycle?.beginTerminal("drop");
+		this._v2Receive?.clearForClose();
 		const replicationRangeTerminalFence =
 			this.acquireReplicationRangeMutationTerminalFence();
 		const pruneRemoveTerminalFence = this.acquirePruneRemoveTerminalFence();
@@ -16751,10 +17040,12 @@ export class SharedLog<
 				try {
 					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
 					await Promise.all([
-						this.rpc.send(reset, {
-							priority: CONVERGENCE_MESSAGE_PRIORITY,
-							signal: abort.signal,
-						}).catch(() => {}),
+						this.rpc
+							.send(reset, {
+								priority: CONVERGENCE_MESSAGE_PRIORITY,
+								signal: abort.signal,
+							})
+							.catch(() => {}),
 						this._v2Send.sendTerminalReset(abort.signal),
 					]);
 				} finally {
@@ -17273,13 +17564,6 @@ export class SharedLog<
 		msg: TransportMessage,
 		context: RequestContext,
 	): Promise<void> {
-		// Decode-first only: capability advertisement is not permission to use
-		// V2. Drop every unsolicited V2 envelope before even entering the shared
-		// receive envelope, so durable poison checks, leases, liveness, ordering
-		// watermarks, replication ranges and cleanup side effects cannot observe it.
-		if (isReplicationInfoV2Message(msg)) {
-			return;
-		}
 		const stashBackedRawMessage = isStashBackedRawExchangeHeadsMessage(msg)
 			? msg
 			: undefined;
@@ -17332,19 +17616,28 @@ export class SharedLog<
 			}
 			if (
 				msg instanceof AllReplicatingSegmentsMessage ||
-				msg instanceof AddedReplicationSegmentMessage
+				msg instanceof AddedReplicationSegmentMessage ||
+				msg instanceof FullReplicationInfoV2Message ||
+				msg instanceof AddedReplicationInfoV2Message
 			) {
 				// Bound decoded untrusted vectors before per-peer/global mutation
 				// queues, trusted-replicator authorization, or liveness side effects.
 				this.validateReplicationRangeAnnouncement(msg.segments);
-			} else if (msg instanceof StoppedReplicating) {
+			} else if (
+				msg instanceof StoppedReplicating ||
+				msg instanceof StoppedReplicationInfoV2Message
+			) {
 				// Bound the raw decoded vector before deduplication can hide the
 				// allocation cost, and before liveness or apply-queue side effects.
 				this.validateStoppedReplicationAnnouncement(msg.segmentIds);
 			}
 			if (
 				!context.from.equals(this.node.identity.publicKey) &&
-				!(msg instanceof RequestReplicationInfoV2Message)
+				!(msg instanceof RequestReplicationInfoV2Message) &&
+				!isReplicationInfoV2Message(msg) &&
+				!(msg instanceof AllReplicatingSegmentsMessage) &&
+				!(msg instanceof AddedReplicationSegmentMessage) &&
+				!(msg instanceof StoppedReplicating)
 			) {
 				this._liveness.markReplicatorActivity(receiveFromHash);
 			}
@@ -18390,11 +18683,14 @@ export class SharedLog<
 						);
 					}
 					const reusableCoordinatePlans =
-						this._coordinates.createReusableReceiveCoordinatePlans(receiveGroups, {
-							decodedReplicaCounts: receiveReplicaCounts,
-							allowRoleAgeZeroPlans:
-								immediateReplicatingLeaderPlans !== undefined,
-						}) as Map<string, ReusableReceiveCoordinatePlan<R>>;
+						this._coordinates.createReusableReceiveCoordinatePlans(
+							receiveGroups,
+							{
+								decodedReplicaCounts: receiveReplicaCounts,
+								allowRoleAgeZeroPlans:
+									immediateReplicatingLeaderPlans !== undefined,
+							},
+						) as Map<string, ReusableReceiveCoordinatePlan<R>>;
 					if (syncProfile) {
 						emitSyncProfileDuration(syncProfile, joinPlanStartedAt, {
 							name: "sharedLog.receive.joinPlan",
@@ -18789,9 +19085,7 @@ export class SharedLog<
 						}
 						const checkedPruneStartedAt = syncProfileStart(syncProfile);
 						const ownershipChangedDuringReceive =
-							!this.isReceiveOwnershipSnapshotStable(
-								receiveOwnershipRevision,
-							);
+							!this.isReceiveOwnershipSnapshotStable(receiveOwnershipRevision);
 						if (ownershipChangedDuringReceive) {
 							const freshAuditRevision =
 								this._instanceLifecycle?._receiveOwnershipRevision ?? 0;
@@ -18949,6 +19243,7 @@ export class SharedLog<
 					fromHash: receiveFromHash,
 					session: receiveSession,
 					lifecycleController: receiveReplicationLifecycleController,
+					ownershipLifecycleController: receiveOwnershipLifecycleController,
 					receiveEpoch: receiveReplicationInfoReceiveEpoch,
 					syncProfile,
 					lease: peerReceiveLease,
@@ -18972,6 +19267,12 @@ export class SharedLog<
 					this.markEntriesKnownByPeer(msg.hashes, context.from.hashcode());
 					this.clearRepairFrontierHashes(context.from.hashcode(), msg.hashes);
 					return;
+				} else if (isReplicationInfoV2Message(msg)) {
+					await this.handleReplicationInfoV2Announcement(
+						msg,
+						laneRequestContext,
+						lane,
+					);
 				} else if (msg instanceof SyncCapabilitiesMessage) {
 					if (!context.from.equals(this.node.identity.publicKey)) {
 						const capabilityTransportSession = context.message?.header?.session;
@@ -18993,13 +19294,19 @@ export class SharedLog<
 								timestamp: capabilityTimestamp,
 								openingSession: receiveSession!,
 							});
-						} else {
+						} else if (
 							this.observePeerSyncCapabilities({
 								peerHash: receiveFromHash,
 								capabilities: msg.capabilities,
 								transportSession: capabilityTransportSession,
 								timestamp: capabilityTimestamp,
-							});
+							}) &&
+							receiveSession?.phase === "open"
+						) {
+							this.promoteReplicationInfoV2ReceiveCapability(
+								context.from,
+								receiveSession,
+							);
 						}
 					}
 					return;
@@ -19021,6 +19328,8 @@ export class SharedLog<
 							from: context.from,
 							peerSession: receiveSession,
 							receiverTransportSession: context.message.header.session,
+							capabilityTimestamp:
+								this._peerSyncCapabilityTimestamps.get(receiveFromHash)!,
 							requestTimestamp: context.message.header.timestamp,
 						})
 					) {
@@ -19164,9 +19473,7 @@ export class SharedLog<
 			msg.requests,
 		);
 		if (
-			!this.isReplicationLifecycleActive(
-				receiveReplicationLifecycleController,
-			)
+			!this.isReplicationLifecycleActive(receiveReplicationLifecycleController)
 		) {
 			return;
 		}
@@ -19225,9 +19532,7 @@ export class SharedLog<
 			let entry: Entry<T> | undefined;
 			try {
 				if (await this.log.blocks.has(request.hash)) {
-					entry = (await this.log.get(request.hash)) as
-						| Entry<T>
-						| undefined;
+					entry = (await this.log.get(request.hash)) as Entry<T> | undefined;
 				}
 			} catch {
 				// The normal entry-admission hook will retry this path.
@@ -19268,16 +19573,11 @@ export class SharedLog<
 		}
 		const responseTasks: Promise<void>[] = [];
 		for (const request of msg.requests) {
-			const pendingDelete = this._checkedPrune.getPendingDelete(
-				request.hash,
-			);
+			const pendingDelete = this._checkedPrune.getPendingDelete(request.hash);
 			if (pendingDelete) {
 				responseTasks.push(
 					Promise.resolve(
-						pendingDelete.resolve(
-							context.from.hashcode(),
-							request.requestId,
-						),
+						pendingDelete.resolve(context.from.hashcode(), request.requestId),
 					),
 				);
 			}
@@ -19397,6 +19697,191 @@ export class SharedLog<
 		}
 	}
 
+	private async handleReplicationInfoV2Announcement(
+		msg: ReplicationInfoV2Message,
+		context: ReceiveRequestContext,
+		lane: ReceiveLaneContext,
+	): Promise<void> {
+		const from = context.from;
+		const fromHash = lane.fromHash;
+		const receiveSession = lane.session;
+		if (
+			from.equals(this.node.identity.publicKey) ||
+			receiveSession === null ||
+			receiveSession.phase !== "open"
+		) {
+			return;
+		}
+
+		// Authenticate and reserve before the per-peer lane. One reservation per
+		// peer bounds decoded-frame retention while another mutation is parked.
+		const receiveState = this._v2Receive._receiveStates.get(fromHash);
+		if (
+			!receiveState ||
+			receiveState.peerSession !== receiveSession ||
+			receiveState.senderTransportSession !== context.message.header.session
+		) {
+			return;
+		}
+		const admission = this._v2Receive.reserve(msg, {
+			from,
+			peerSession: receiveSession,
+			receiveEpoch: lane.receiveEpoch,
+			senderTransportSession: context.message.header.session,
+			transportTimestamp: context.message.header.timestamp,
+		});
+		if (!admission) {
+			return;
+		}
+
+		lane.lease.release();
+		try {
+			await this.withReplicationInfoApplyQueue(fromHash, async () => {
+				const hostGate = () =>
+					this._instanceLifecycle!.isMembershipActiveFor(
+						lane.lifecycleController,
+					) &&
+					this.isRepairLifecycleActive(lane.ownershipLifecycleController) &&
+					this._peerSessions.isCurrent(fromHash, receiveSession) &&
+					receiveSession.phase === "open" &&
+					this._peerSessions.isReceiveEpochCurrent(
+						fromHash,
+						lane.receiveEpoch,
+					) &&
+					!this._peerSessions.isReplicationInfoBlocked(fromHash) &&
+					this._peerSessions.isReceiveCleanupGateOpen(fromHash);
+				if (!hostGate()) {
+					return;
+				}
+				const exactGate = () =>
+					hostGate() && this._v2Receive.isAdmissionCurrent(admission);
+				let durableCommitted = false;
+
+				try {
+					if (
+						msg instanceof FullReplicationInfoV2Message ||
+						msg instanceof AddedReplicationInfoV2Message
+					) {
+						let mutationGateChecked = false;
+						let mutationGateAdmitted = false;
+						const result = await this.addReplicationRange(
+							msg.segments.map((segment) =>
+								segment.toReplicationRangeIndexable(from),
+							),
+							from,
+							{
+								reset: msg instanceof FullReplicationInfoV2Message,
+								checkDuplicates: true,
+								timestamp: Number(context.message.header.timestamp),
+								allowLegacyOrderedReplacementPairs:
+									msg instanceof AddedReplicationInfoV2Message,
+								shouldApply: () => {
+									mutationGateChecked = true;
+									mutationGateAdmitted = exactGate();
+									return mutationGateAdmitted;
+								},
+								onDurableApplyCommitted: () => {
+									if (!exactGate() || !this._v2Receive.commit(admission)) {
+										return false;
+									}
+									durableCommitted = true;
+									return true;
+								},
+							},
+							lane.ownershipLifecycleController,
+						);
+						if (
+							result === undefined ||
+							!mutationGateChecked ||
+							!mutationGateAdmitted ||
+							!durableCommitted ||
+							!exactGate()
+						) {
+							return;
+						}
+					} else {
+						if (!exactGate()) {
+							return;
+						}
+						const rangesToRemove =
+							await this.resolveReplicationRangesFromIdsAndKey(
+								msg.segmentIds,
+								from,
+							);
+						if (!exactGate()) {
+							return;
+						}
+						let mutationGateAdmitted = true;
+						const removedRanges: ReplicationRangeIndexable<R>[] = [];
+						const removed = await this.removeReplicationRanges(
+							rangesToRemove,
+							from,
+							{
+								shouldRemove: () => {
+									mutationGateAdmitted = exactGate();
+									return mutationGateAdmitted;
+								},
+								onDurableRemoveCommitted: () => {
+									if (!exactGate() || !this._v2Receive.commit(admission)) {
+										return false;
+									}
+									durableCommitted = true;
+									return true;
+								},
+								onRemoved: (ranges) => removedRanges.push(...ranges),
+							},
+							lane.ownershipLifecycleController,
+						);
+						if (!durableCommitted) {
+							if (
+								!mutationGateAdmitted ||
+								!exactGate() ||
+								removed ||
+								!this._v2Receive.commit(admission)
+							) {
+								return;
+							}
+							durableCommitted = true;
+						}
+						if (
+							this._instanceLifecycle!.isMembershipActiveFor(
+								lane.lifecycleController,
+							) &&
+							this.isRepairLifecycleActive(lane.ownershipLifecycleController)
+						) {
+							const timestamp = BigInt(Date.now());
+							for (const range of removedRanges) {
+								this.replicationChangeDebounceFn.add({
+									range,
+									type: "removed",
+									timestamp,
+								});
+							}
+						}
+					}
+				} catch (error) {
+					this._v2Receive.requireFullAfterFailure(admission);
+					throw error;
+				}
+
+				if (!durableCommitted) {
+					if (!exactGate() || !this._v2Receive.commit(admission)) {
+						return;
+					}
+				}
+				if (!hostGate()) {
+					return;
+				}
+				this._liveness.markReplicatorActivity(fromHash);
+				if (msg instanceof FullReplicationInfoV2Message) {
+					this.cancelReplicationInfoRequests(fromHash);
+				}
+			});
+		} finally {
+			this._v2Receive.release(admission);
+		}
+	}
+
 	private async handleReplicationInfoAnnouncement(
 		msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
 		context: ReceiveRequestContext,
@@ -19420,6 +19905,19 @@ export class SharedLog<
 		// (and downstream `waitForReplicator()` timeouts) under timing-sensitive joins.
 		const from = context.from!;
 		const fromHash = from.hashcode();
+		if (this._v2Receive.isLegacyCutover(receiveSession)) {
+			if (receiveSession) {
+				this._v2Receive.noteLegacyAnnouncement({
+					peerHash: fromHash,
+					peerSession: receiveSession,
+					receiveEpoch: receiveReplicationInfoReceiveEpoch,
+					senderTransportSession: context.message.header.session,
+					transportTimestamp: context.message.header.timestamp,
+					message: msg,
+				});
+			}
+			return;
+		}
 		// Pre-lane gate: lifecycle -> receive-epoch -> blocked, exactly the
 		// legacy order. isMembershipActiveFor is the unit-pinned fold of
 		// isReplicationLifecycleActive; isReceiveEpochCurrent is the
@@ -19458,6 +19956,17 @@ export class SharedLog<
 				) {
 					return;
 				}
+				if (receiveSession && this._v2Receive.isLegacyCutover(receiveSession)) {
+					this._v2Receive.noteLegacyAnnouncement({
+						peerHash: fromHash,
+						peerSession: receiveSession,
+						receiveEpoch: receiveReplicationInfoReceiveEpoch,
+						senderTransportSession: context.message.header.session,
+						transportTimestamp: context.message.header.timestamp,
+						message: msg,
+					});
+					return;
+				}
 
 				// Process in-order to avoid races where repeated reset messages arrive
 				// concurrently and trigger spurious "added" diffs / rebalancing.
@@ -19467,14 +19976,13 @@ export class SharedLog<
 				}
 
 				this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-				this._liveness._replicatorLivenessFailures.delete(fromHash);
 
 				if (this.closed) {
 					return;
 				}
 
 				const reset = msg instanceof AllReplicatingSegmentsMessage;
-				await this.addReplicationRange(
+				const result = await this.addReplicationRange(
 					replicationInfoMessage.segments.map((x) =>
 						x.toReplicationRangeIndexable(from),
 					),
@@ -19487,6 +19995,10 @@ export class SharedLog<
 							msg instanceof AddedReplicationSegmentMessage,
 					},
 				);
+				if (result === undefined) {
+					return;
+				}
+				this._liveness.markReplicatorActivity(fromHash);
 
 				// If the peer reports any replication segments, stop re-requesting.
 				// (Empty reports can be transient during startup.)
@@ -19522,6 +20034,19 @@ export class SharedLog<
 			return;
 		}
 		const fromHash = from.hashcode();
+		if (this._v2Receive.isLegacyCutover(receiveSession)) {
+			if (receiveSession) {
+				this._v2Receive.noteLegacyAnnouncement({
+					peerHash: fromHash,
+					peerSession: receiveSession,
+					receiveEpoch: receiveReplicationInfoReceiveEpoch,
+					senderTransportSession: context.message.header.session,
+					transportTimestamp: context.message.header.timestamp,
+					message: msg,
+				});
+			}
+			return;
+		}
 		// Same pre-lane gate shape as Added/All above (and the same
 		// intentional absence of a subscription-epoch term).
 		if (
@@ -19552,22 +20077,34 @@ export class SharedLog<
 			) {
 				return;
 			}
+			if (receiveSession && this._v2Receive.isLegacyCutover(receiveSession)) {
+				this._v2Receive.noteLegacyAnnouncement({
+					peerHash: fromHash,
+					peerSession: receiveSession,
+					receiveEpoch: receiveReplicationInfoReceiveEpoch,
+					senderTransportSession: context.message.header.session,
+					transportTimestamp: context.message.header.timestamp,
+					message: msg,
+				});
+				return;
+			}
 
-			const previousTimestamp =
-				this.latestReplicationInfoMessage.get(fromHash);
+			const previousTimestamp = this.latestReplicationInfoMessage.get(fromHash);
 			if (previousTimestamp && previousTimestamp > messageTimestamp) {
 				return;
 			}
 			this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-			this._liveness._replicatorLivenessFailures.delete(fromHash);
 			if (this.closed) {
 				return;
 			}
 
-			const rangesToRemove =
-				await this.resolveReplicationRangesFromIdsAndKey(segmentIds, from);
+			const rangesToRemove = await this.resolveReplicationRangesFromIdsAndKey(
+				segmentIds,
+				from,
+			);
 
 			await this.removeReplicationRanges(rangesToRemove, from);
+			this._liveness.markReplicatorActivity(fromHash);
 			const timestamp = BigInt(+new Date());
 			for (const range of rangesToRemove) {
 				this.replicationChangeDebounceFn.add({
@@ -20369,10 +20906,9 @@ export class SharedLog<
 		entry: ShallowOrFullEntry<any> | EntryReplicated<R> | NumberFromType<R>,
 		minReplicas: number,
 	): Promise<NumberFromType<R>[]> {
-		return this._coordinates.createCoordinates(
-			entry,
-			minReplicas,
-		) as Promise<NumberFromType<R>[]>;
+		return this._coordinates.createCoordinates(entry, minReplicas) as Promise<
+			NumberFromType<R>[]
+		>;
 	}
 
 	async getDefaultMinRoleAge(): Promise<number> {
@@ -20736,8 +21272,9 @@ export class SharedLog<
 						this.createNativeLeaderOptions(context, firstItem.options),
 					);
 				const plans: EntryLeaderPlan<R>[] = [];
-				const persistItems: Parameters<typeof this._coordinates.persistCoordinatesBatch>[0] =
-					[];
+				const persistItems: Parameters<
+					typeof this._coordinates.persistCoordinatesBatch
+				>[0] = [];
 				for (let i = 0; i < itemArray.length; i++) {
 					const item = itemArray[i]!;
 					const nativePlan = nativePlans[i]!;
@@ -20799,8 +21336,9 @@ export class SharedLog<
 			);
 			const selfHash = this.node.identity.publicKey.hashcode();
 			const plans: EntryLeaderPlan<R>[] = [];
-			const persistItems: Parameters<typeof this._coordinates.persistCoordinatesBatch>[0] =
-				[];
+			const persistItems: Parameters<
+				typeof this._coordinates.persistCoordinatesBatch
+			>[0] = [];
 			for (let i = 0; i < itemArray.length; i++) {
 				const item = itemArray[i]!;
 				const nativePlan = nativePlans[i]!;
@@ -22411,6 +22949,8 @@ export class SharedLog<
 		ownerHash: string,
 		options?: { preserveOwnerMembership?: boolean },
 	): Promise<ReplicationRangeDeletionOutcome<R>> {
+		const wasReplicator = this.uniqueReplicators.has(ownerHash);
+		const joinWasEmitted = this._replicatorJoinEmitted.has(ownerHash);
 		if (ranges.length === 0) {
 			const ownerHasRanges =
 				(await this.replicationIndex.count({ query: { hash: ownerHash } })) > 0;
@@ -22422,14 +22962,24 @@ export class SharedLog<
 				removed: [],
 				retained: [],
 				ownerHasRanges,
+				rollback: async () => {
+					if (wasReplicator) {
+						this.uniqueReplicators.add(ownerHash);
+					} else {
+						this.uniqueReplicators.delete(ownerHash);
+					}
+					if (joinWasEmitted) {
+						this._replicatorJoinEmitted.add(ownerHash);
+					} else {
+						this._replicatorJoinEmitted.delete(ownerHash);
+					}
+				},
 			};
 		}
 
 		const uniqueRanges = [
 			...new Map(ranges.map((range) => [range.idString, range])).values(),
 		];
-		const wasReplicator = this.uniqueReplicators.has(ownerHash);
-		const joinWasEmitted = this._replicatorJoinEmitted.has(ownerHash);
 		type Snapshot = {
 			range: ReplicationRangeIndexable<R>;
 			pending?: PendingMaturityRecord<R>;
@@ -22663,10 +23213,80 @@ export class SharedLog<
 			);
 			this.poisonReplicationOwnership(outcomeError);
 		}
+		let rollbackStarted = false;
+		const rollback = async () => {
+			if (rollbackStarted) {
+				return;
+			}
+			rollbackStarted = true;
+			const rollbackErrors: unknown[] = [];
+			const removedIds = new Set(removed.map((range) => range.idString));
+			for (const snapshot of snapshots) {
+				if (!removedIds.has(snapshot.range.idString)) {
+					continue;
+				}
+				try {
+					await this.replicationIndex.put(snapshot.range);
+					this.putNativeReplicationRange(snapshot.range);
+				} catch (error) {
+					rollbackErrors.push(error);
+				}
+			}
+			for (const snapshot of snapshots) {
+				if (
+					!removedIds.has(snapshot.range.idString) ||
+					!snapshot.pending ||
+					this.pendingMaturity.get(ownerHash)?.has(snapshot.range.idString)
+				) {
+					continue;
+				}
+				try {
+					this.schedulePendingMaturity(
+						snapshot.pending.range,
+						snapshot.pending.from,
+						{
+							rebalance: snapshot.pending.rebalance,
+							waitMs: Math.max(0, snapshot.pending.expiresAt - Date.now()),
+						},
+						snapshot.pending.ownershipLifecycleController,
+					);
+				} catch (error) {
+					rollbackErrors.push(error);
+				}
+			}
+			try {
+				if (wasReplicator) {
+					this.uniqueReplicators.add(ownerHash);
+				} else {
+					this.uniqueReplicators.delete(ownerHash);
+				}
+				if (joinWasEmitted) {
+					this._replicatorJoinEmitted.add(ownerHash);
+				} else {
+					this._replicatorJoinEmitted.delete(ownerHash);
+				}
+			} catch (error) {
+				rollbackErrors.push(error);
+			}
+			try {
+				await this.updateOldestTimestampFromIndex();
+			} catch (error) {
+				rollbackErrors.push(error);
+			}
+			if (rollbackErrors.length > 0) {
+				const failure = new AggregateError(
+					rollbackErrors,
+					"Replication-range deletion rollback failed",
+				);
+				this.poisonReplicationOwnership(failure);
+				throw failure;
+			}
+		};
 		return {
 			removed,
 			retained,
 			ownerHasRanges,
+			rollback,
 			error: outcomeError,
 		};
 	}
@@ -22682,7 +23302,8 @@ export class SharedLog<
 
 	private scheduleReplicationInfoRequests(
 		peer: PublicSignKey,
-		replicationLifecycleController = this._instanceLifecycle?.membershipLifecycleController,
+		replicationLifecycleController = this._instanceLifecycle
+			?.membershipLifecycleController,
 	) {
 		if (
 			!replicationLifecycleController ||
@@ -22764,7 +23385,8 @@ export class SharedLog<
 		if (!topics.includes(this.topic)) {
 			return;
 		}
-		const replicationLifecycleController = this._instanceLifecycle?.membershipLifecycleController;
+		const replicationLifecycleController =
+			this._instanceLifecycle?.membershipLifecycleController;
 		if (
 			!replicationLifecycleController ||
 			!this.isReplicationLifecycleActive(replicationLifecycleController)
@@ -22775,10 +23397,7 @@ export class SharedLog<
 		const peerHash = publicKey.hashcode();
 		const expectedSubscriptionEpoch =
 			subscriptionEpoch ??
-			this._peerSessions.rotate(
-				peerHash,
-				subscribed ? "opening" : "departing",
-			);
+			this._peerSessions.rotate(peerHash, subscribed ? "opening" : "departing");
 		const ownsSubscriptionEpoch = () =>
 			this._peerSessions.isCurrent(peerHash, expectedSubscriptionEpoch);
 		if (!ownsSubscriptionEpoch()) {
@@ -22787,6 +23406,7 @@ export class SharedLog<
 		// A destination stream is scoped to exactly one topic-subscription
 		// session. Abort the predecessor synchronously before either barrier can
 		// yield; a late queue completion must never enter the new session.
+		this._v2Receive.clearPeer(peerHash);
 		this._v2Send.clearPeer(peerHash);
 		this._peerSyncCapabilitySessions.delete(peerHash);
 		this._peerSyncCapabilityTimestamps.delete(peerHash);
@@ -22923,33 +23543,30 @@ export class SharedLog<
 		this._liveness._replicatorLivenessFailures.delete(peerHash);
 		this._liveness.markReplicatorActivity(peerHash);
 		this._peerSessions.markOpen(peerHash, expectedSubscriptionEpoch);
+		this.promoteReplicationInfoV2ReceiveCapability(
+			publicKey,
+			expectedSubscriptionEpoch,
+		);
 
-		// Decode support and receiver-led negotiation readiness are separate bits.
-		// This node never initiates a request in this rollout; normal replication
-		// announcements remain legacy unless a peer explicitly grants one signed,
-		// session-bound V2 destination stream.
-		const receiveCapabilities =
-			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
-			SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
-			(this._logProperties?.sync?.rawExchangeHeads === true
-				? SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
-				: 0);
-		this.rpc
-			.send(
-				new SyncCapabilitiesMessage({
-					capabilities: receiveCapabilities,
-				}),
-				{
-					mode: new SilentDelivery({ redundancy: 1, to: [publicKey] }),
-					signal: replicationLifecycleController.signal,
-				},
-			)
-			.catch((error) =>
+		// Decode, sender and authenticated apply readiness are separate bits. Start
+		// the ACKed receiver-led negotiation before the legacy snapshot, but do not
+		// hold mixed-version replication discovery behind that round trip. Attach
+		// the rejection handler now because a lifecycle fence below may return before
+		// awaiting the advert. RequestV2 is armed only after both sends settle.
+		const receiveEpoch = this._peerSessions.receiveEpoch(peerHash);
+		const localCapabilityAdvertisement =
+			this.advertiseReplicationInfoV2ReceiveCapability({
+				target: publicKey,
+				peerSession: expectedSubscriptionEpoch,
+				receiveEpoch,
+				signal: replicationLifecycleController.signal,
+			}).catch((error) => {
 				this.handleReplicationLifecycleSendError(
 					error,
 					replicationLifecycleController,
-				),
-			);
+				);
+				return undefined;
+			});
 
 		let replicationSegments: ReplicationRangeIndexable<R>[];
 		try {
@@ -23019,9 +23636,9 @@ export class SharedLog<
 			}
 		}
 
-		// Request the remote peer's replication info. This makes joins resilient to
-		// timing-sensitive delivery/order issues where we may miss their initial
-		// replication announcement.
+		// Keep legacy request-based discovery independent of the capability ACK too.
+		// This makes mixed-version joins resilient to timing-sensitive delivery/order
+		// issues where we may miss the remote peer's initial announcement.
 		if (
 			this.isReplicationLifecycleActive(replicationLifecycleController) &&
 			ownsSubscriptionEpoch()
@@ -23030,6 +23647,16 @@ export class SharedLog<
 				publicKey,
 				replicationLifecycleController,
 			);
+		}
+
+		const localCapabilityReady = await localCapabilityAdvertisement;
+		if (localCapabilityReady) {
+			this._v2Receive.markLocalCapabilityReady({
+				peerHash,
+				peerSession: expectedSubscriptionEpoch,
+				receiveEpoch,
+				...localCapabilityReady,
+			});
 		}
 	}
 
@@ -24153,7 +24780,10 @@ export class SharedLog<
 						if (oldPeersSet) {
 							for (const oldPeer of oldPeersSet) {
 								if (!currentPeers.has(oldPeer)) {
-									this._checkedPrune.removeRequestSent(entryReplicated.hash, oldPeer);
+									this._checkedPrune.removeRequestSent(
+										entryReplicated.hash,
+										oldPeer,
+									);
 								}
 							}
 						}
@@ -24242,7 +24872,10 @@ export class SharedLog<
 					if (oldPeersSet) {
 						for (const oldPeer of oldPeersSet) {
 							if (!currentPeers.has(oldPeer)) {
-								this._checkedPrune.removeRequestSent(entryReplicated.hash, oldPeer);
+								this._checkedPrune.removeRequestSent(
+									entryReplicated.hash,
+									oldPeer,
+								);
 							}
 						}
 					}
@@ -24422,10 +25055,7 @@ export class SharedLog<
 		}
 
 		const fromHash = evt.detail.from.hashcode();
-		const subscriptionEpoch = this._peerSessions.rotate(
-			fromHash,
-			"departing",
-		);
+		const subscriptionEpoch = this._peerSessions.rotate(fromHash, "departing");
 		this._peerSessions.blockReplicationInfo(fromHash);
 		this._recentRepairDispatch.delete(fromHash);
 

--- a/packages/programs/data/shared-log/src/replication-info-v2-binding.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-binding.ts
@@ -1,0 +1,44 @@
+import { serialize } from "@dao-xyz/borsh";
+import { type PublicSignKey, sha256Sync } from "@peerbit/crypto";
+import { concat, fromString } from "uint8arrays";
+
+const RECEIVER_BINDING_DOMAIN = fromString(
+	"peerbit/shared-log/replication-info-v2/receiver-binding/v1",
+);
+
+const lengthPrefixed = (bytes: Uint8Array): Uint8Array => {
+	const length = new Uint8Array(4);
+	new DataView(length.buffer).setUint32(0, bytes.byteLength, true);
+	return concat([length, bytes]);
+};
+
+const u64LittleEndian = (value: bigint): Uint8Array => {
+	const bytes = new Uint8Array(8);
+	new DataView(bytes.buffer).setBigUint64(0, value, true);
+	return bytes;
+};
+
+/**
+ * Derive the token echoed by V2 data frames. Delivery recipients are unsigned,
+ * so the receiver's nonce alone is not a destination binding. Folding both
+ * authenticated identities and signed transport sessions into the 32-byte
+ * field prevents a copied request nonce from creating an interchangeable
+ * stream for another receiver.
+ */
+export const deriveReplicationInfoV2ReceiverBinding = (properties: {
+	receiverChallenge: Uint8Array;
+	receiver: PublicSignKey;
+	receiverTransportSession: bigint;
+	sender: PublicSignKey;
+	senderTransportSession: bigint;
+}): Uint8Array =>
+	sha256Sync(
+		concat([
+			lengthPrefixed(RECEIVER_BINDING_DOMAIN),
+			lengthPrefixed(properties.receiverChallenge),
+			lengthPrefixed(serialize(properties.receiver)),
+			u64LittleEndian(properties.receiverTransportSession),
+			lengthPrefixed(serialize(properties.sender)),
+			u64LittleEndian(properties.senderTransportSession),
+		]),
+	);

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -1,0 +1,1045 @@
+import { serialize } from "@dao-xyz/borsh";
+import { type PublicSignKey, randomBytes, sha256Sync } from "@peerbit/crypto";
+import {
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+} from "./exchange-heads.js";
+import { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
+import {
+	AddedReplicationInfoV2Message,
+	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
+	type ReplicationInfoV2Message,
+	RequestReplicationInfoV2Message,
+	StoppedReplicating,
+	StoppedReplicationInfoV2Message,
+} from "./replication.js";
+
+const REQUIRED_SENDER_CAPABILITIES =
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND;
+
+const DEFAULT_REQUEST_RETRY_MS = 1_000;
+const DEFAULT_MAX_REQUEST_RETRY_MS = 30_000;
+const DEFAULT_REQUEST_MAX_ATTEMPTS = 7;
+const DEFAULT_LEGACY_FALLBACK_DELAY_MS = 5_000;
+const MAX_U64 = (1n << 64n) - 1n;
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+	if (left.byteLength !== right.byteLength) {
+		return false;
+	}
+	for (let index = 0; index < left.byteLength; index++) {
+		if (left[index] !== right[index]) {
+			return false;
+		}
+	}
+	return true;
+};
+
+type LegacyReplicationInfoMessage =
+	| AllReplicatingSegmentsMessage
+	| AddedReplicationSegmentMessage
+	| StoppedReplicating;
+
+const replicationInfoPayloadFingerprint = (
+	message: ReplicationInfoV2Message | LegacyReplicationInfoMessage,
+): Uint8Array => {
+	const canonical =
+		message instanceof FullReplicationInfoV2Message
+			? new AllReplicatingSegmentsMessage({ segments: message.segments })
+			: message instanceof AddedReplicationInfoV2Message
+				? new AddedReplicationSegmentMessage({ segments: message.segments })
+				: message instanceof StoppedReplicationInfoV2Message
+					? new StoppedReplicating({ segmentIds: message.segmentIds })
+					: message;
+	return sha256Sync(serialize(canonical));
+};
+
+export type ReplicationInfoV2ReceivePhase =
+	| "awaiting-full"
+	| "active"
+	| "resync";
+
+type LocalCapabilityReady = {
+	peerHash: string;
+	receiverTransportSession: bigint;
+	/**
+	 * The local capability envelope and the later RequestV2 envelope use the
+	 * same millisecond clock. The sender deliberately requires the request to
+	 * be strictly newer, so never construct it in this captured millisecond.
+	 */
+	requestNotBeforeMs: number;
+};
+
+export type ReplicationInfoV2LocalCapabilityRefresh = {
+	receiverTransportSession: bigint;
+	requestNotBeforeMs: number;
+};
+
+export type ReplicationInfoV2ReceiveState = {
+	peerHash: string;
+	target: PublicSignKey;
+	peerSession: object;
+	receiveEpoch: object | null;
+	capabilities: number;
+	capabilityTimestamp: bigint;
+	senderTransportSession: bigint;
+	receiverTransportSession?: bigint;
+	receiverRequestChallenge: Uint8Array;
+	receiverBinding?: Uint8Array;
+	senderEpoch?: Uint8Array;
+	lastSequence?: bigint;
+	phase: ReplicationInfoV2ReceivePhase;
+	version: number;
+	controller: AbortController;
+	requestTimer?: ReturnType<typeof setTimeout>;
+	requestInFlight?: Promise<void>;
+	requestAttempts: number;
+	requestsSinceCapabilityRefresh: number;
+	requestParked: boolean;
+	capabilityRefreshRequired: boolean;
+	legacyFallbackTimer?: ReturnType<typeof setTimeout>;
+	legacyFallbackFingerprint?: Uint8Array;
+	legacyFallbackTimestamp?: bigint;
+	legacyFallbackAmbiguous: boolean;
+	lastCommittedTransportTimestamp?: bigint;
+	recentCommittedPayloads: Array<{
+		fingerprint: Uint8Array;
+		transportTimestamp: bigint;
+	}>;
+	lastLegacyObservationTimestamp?: bigint;
+	lastLegacyObservationFingerprint?: Uint8Array;
+	lastLegacyObservationAmbiguous: boolean;
+	reservedAdmission?: ReplicationInfoV2ReceiveAdmission;
+};
+
+export type ReplicationInfoV2ReceiveAdmission = {
+	state: ReplicationInfoV2ReceiveState;
+	version: number;
+	receiveEpoch: object | null;
+	message: ReplicationInfoV2Message;
+	kind: "full" | "added" | "stopped";
+	payloadFingerprint: Uint8Array;
+	transportTimestamp: bigint;
+	committed: boolean;
+	resyncAfterRelease?: boolean;
+};
+
+export type ReplicationInfoV2ReceiveDeps = {
+	getSelfKey: () => PublicSignKey;
+	getReceiverTransportSession: () => bigint;
+	isClosed: () => boolean;
+	isPeerStateCurrent: (
+		peerHash: string,
+		peerSession: object,
+		receiveEpoch: object | null,
+	) => boolean;
+	isSenderTransportSessionCurrent: (
+		peerHash: string,
+		senderTransportSession: bigint,
+	) => boolean;
+	sendRequest: (
+		request: RequestReplicationInfoV2Message,
+		target: PublicSignKey,
+		signal: AbortSignal,
+	) => Promise<void>;
+	refreshLocalCapability: (properties: {
+		peerHash: string;
+		target: PublicSignKey;
+		peerSession: object;
+		receiveEpoch: object | null;
+		signal: AbortSignal;
+	}) => Promise<ReplicationInfoV2LocalCapabilityRefresh | undefined>;
+	onRequestError?: (error: unknown) => void;
+	now?: () => number;
+	requestRetryMs?: number;
+	maxRequestRetryMs?: number;
+	requestMaxAttempts?: number;
+	legacyFallbackDelayMs?: number;
+};
+
+/**
+ * Authenticated receive grants and sender-authoritative ordering for
+ * replication-info V2. State is bounded to one entry per subscribed peer and
+ * is always scoped to the exact PeerSession object.
+ */
+export class ReplicationInfoV2ReceiveCoordinator {
+	_receiveStates!: Map<string, ReplicationInfoV2ReceiveState>;
+	_cutoverPeerSessions!: WeakSet<object>;
+	_localCapabilityReadyBySession!: WeakMap<object, LocalCapabilityReady>;
+	_reservedAdmissionsByPeer!: Map<string, ReplicationInfoV2ReceiveAdmission>;
+
+	private readonly now: () => number;
+	private readonly requestRetryMs: number;
+	private readonly maxRequestRetryMs: number;
+	private readonly requestMaxAttempts: number;
+	private readonly legacyFallbackDelayMs: number;
+
+	constructor(private readonly deps: ReplicationInfoV2ReceiveDeps) {
+		this.now = deps.now ?? Date.now;
+		this.requestRetryMs = Math.max(
+			1,
+			deps.requestRetryMs ?? DEFAULT_REQUEST_RETRY_MS,
+		);
+		this.maxRequestRetryMs = Math.max(
+			this.requestRetryMs,
+			deps.maxRequestRetryMs ?? DEFAULT_MAX_REQUEST_RETRY_MS,
+		);
+		this.requestMaxAttempts = Math.max(
+			1,
+			Math.floor(deps.requestMaxAttempts ?? DEFAULT_REQUEST_MAX_ATTEMPTS),
+		);
+		this.legacyFallbackDelayMs = Math.max(
+			this.requestRetryMs,
+			deps.legacyFallbackDelayMs ?? DEFAULT_LEGACY_FALLBACK_DELAY_MS,
+		);
+		this._receiveStates = new Map();
+		this._cutoverPeerSessions = new WeakSet();
+		this._localCapabilityReadyBySession = new WeakMap();
+		this._reservedAdmissionsByPeer = new Map();
+	}
+
+	resetForOpen(): void {
+		this.clearForClose();
+		this._receiveStates = new Map();
+		this._cutoverPeerSessions = new WeakSet();
+		this._localCapabilityReadyBySession = new WeakMap();
+		this._reservedAdmissionsByPeer = new Map();
+	}
+
+	clearForClose(): void {
+		for (const state of this._receiveStates?.values() ?? []) {
+			this.clearState(state);
+		}
+		this._receiveStates?.clear();
+		this._cutoverPeerSessions = new WeakSet();
+		this._localCapabilityReadyBySession = new WeakMap();
+	}
+
+	clearPeer(peerHash: string, expectedSession?: object): void {
+		const state = this._receiveStates.get(peerHash);
+		if (state && (!expectedSession || state.peerSession === expectedSession)) {
+			this.clearState(state);
+			this._localCapabilityReadyBySession.delete(state.peerSession);
+			this._cutoverPeerSessions.delete(state.peerSession);
+		}
+		if (expectedSession) {
+			this._localCapabilityReadyBySession.delete(expectedSession);
+			this._cutoverPeerSessions.delete(expectedSession);
+		}
+	}
+
+	/** Revoke an unauthenticated or downgraded capability generation. */
+	revokePeerCapability(peerHash: string, reopenLegacy = true): void {
+		const state = this._receiveStates.get(peerHash);
+		if (!state) {
+			return;
+		}
+		this.clearState(state);
+		if (reopenLegacy) {
+			this._cutoverPeerSessions.delete(state.peerSession);
+		}
+	}
+
+	private clearState(state: ReplicationInfoV2ReceiveState): void {
+		if (state.requestTimer) {
+			clearTimeout(state.requestTimer);
+			state.requestTimer = undefined;
+		}
+		if (state.legacyFallbackTimer) {
+			clearTimeout(state.legacyFallbackTimer);
+			state.legacyFallbackTimer = undefined;
+		}
+		state.controller.abort();
+		state.version++;
+		if (this._receiveStates.get(state.peerHash) === state) {
+			this._receiveStates.delete(state.peerHash);
+		}
+	}
+
+	/** Record success of this session's ACKed local APPLY advertisement. */
+	markLocalCapabilityReady(properties: {
+		peerHash: string;
+		peerSession: object;
+		receiveEpoch: object | null;
+		receiverTransportSession: bigint;
+		requestNotBeforeMs: number;
+	}): boolean {
+		const { peerHash, peerSession, receiverTransportSession } = properties;
+		const state = this._receiveStates.get(peerHash);
+		if (
+			this.deps.isClosed() ||
+			!this.deps.isPeerStateCurrent(
+				peerHash,
+				peerSession,
+				properties.receiveEpoch,
+			) ||
+			this.deps.getReceiverTransportSession() !== receiverTransportSession
+		) {
+			return false;
+		}
+
+		const ready: LocalCapabilityReady = {
+			peerHash,
+			receiverTransportSession,
+			requestNotBeforeMs: properties.requestNotBeforeMs,
+		};
+		this._localCapabilityReadyBySession.set(peerSession, ready);
+		if (
+			state?.peerSession === peerSession &&
+			state.receiveEpoch === properties.receiveEpoch
+		) {
+			if (
+				state.receiverTransportSession !== undefined &&
+				state.receiverTransportSession !== receiverTransportSession
+			) {
+				this.clearState(state);
+				return false;
+			}
+			this.bindLocalCapability(state, ready);
+			state.requestAttempts = 0;
+			state.requestsSinceCapabilityRefresh = 0;
+			state.requestParked = false;
+			this.armRequest(state, 0);
+		}
+		return true;
+	}
+
+	/**
+	 * Promote one signed capability generation after the opening barrier has
+	 * committed. Repeated same-session advertisements refresh freshness only;
+	 * they never reset sequence state.
+	 */
+	observeCapability(properties: {
+		peerHash: string;
+		target: PublicSignKey;
+		peerSession: object;
+		receiveEpoch: object | null;
+		capabilities: number;
+		senderTransportSession: bigint;
+		capabilityTimestamp: bigint;
+	}): boolean {
+		const {
+			peerHash,
+			target,
+			peerSession,
+			receiveEpoch,
+			capabilities,
+			senderTransportSession,
+			capabilityTimestamp,
+		} = properties;
+		if (
+			target.equals(this.deps.getSelfKey()) ||
+			this.deps.isClosed() ||
+			!this.deps.isPeerStateCurrent(peerHash, peerSession, receiveEpoch)
+		) {
+			return false;
+		}
+
+		const senderReady =
+			(capabilities & REQUIRED_SENDER_CAPABILITIES) ===
+			REQUIRED_SENDER_CAPABILITIES;
+		let state = this._receiveStates.get(peerHash);
+		if (
+			state &&
+			(state.peerSession !== peerSession ||
+				state.senderTransportSession !== senderTransportSession ||
+				!state.target.equals(target))
+		) {
+			const preserveCutover = state.peerSession === peerSession && senderReady;
+			this.clearState(state);
+			if (!preserveCutover) {
+				this._cutoverPeerSessions.delete(state.peerSession);
+			}
+			state = undefined;
+		}
+		if (!senderReady) {
+			if (state) {
+				this.clearState(state);
+				this._cutoverPeerSessions.delete(peerSession);
+			}
+			return false;
+		}
+
+		if (state) {
+			if (capabilityTimestamp < state.capabilityTimestamp) {
+				return false;
+			}
+			const previousCapabilities = state.capabilities;
+			const previousTimestamp = state.capabilityTimestamp;
+			const receiveEpochChanged = state.receiveEpoch !== receiveEpoch;
+			const addsCapabilities = (capabilities & ~previousCapabilities) !== 0;
+			if (
+				capabilityTimestamp === previousTimestamp &&
+				!addsCapabilities &&
+				!receiveEpochChanged
+			) {
+				return true;
+			}
+			state.capabilities |= capabilities;
+			state.capabilityTimestamp = capabilityTimestamp;
+			if (receiveEpochChanged) {
+				state.receiveEpoch = receiveEpoch;
+				this.transitionToResync(state, {
+					force: true,
+					refreshCapability: true,
+				});
+			}
+			const ready = this._localCapabilityReadyBySession.get(peerSession);
+			if (ready?.peerHash === peerHash && state.receiverBinding === undefined) {
+				this.bindLocalCapability(state, ready);
+			}
+			if (state.phase !== "active") {
+				state.requestAttempts = 0;
+				state.requestParked = false;
+				this.armRequest(state, 0);
+			}
+			return true;
+		}
+
+		const retainedCutover = this._cutoverPeerSessions.has(peerSession);
+		state = {
+			peerHash,
+			target,
+			peerSession,
+			receiveEpoch,
+			capabilities,
+			capabilityTimestamp,
+			senderTransportSession,
+			receiverRequestChallenge: randomBytes(32),
+			phase: retainedCutover ? "resync" : "awaiting-full",
+			version: 0,
+			controller: new AbortController(),
+			requestAttempts: 0,
+			requestsSinceCapabilityRefresh: 0,
+			requestParked: false,
+			capabilityRefreshRequired: retainedCutover,
+			legacyFallbackAmbiguous: false,
+			recentCommittedPayloads: [],
+			lastLegacyObservationAmbiguous: false,
+		};
+		this._receiveStates.set(peerHash, state);
+		const ready = this._localCapabilityReadyBySession.get(peerSession);
+		if (ready?.peerHash === peerHash) {
+			this.bindLocalCapability(state, ready);
+			this.armRequest(state, 0);
+		}
+		return true;
+	}
+
+	private bindLocalCapability(
+		state: ReplicationInfoV2ReceiveState,
+		ready: LocalCapabilityReady,
+	): void {
+		state.receiverTransportSession = ready.receiverTransportSession;
+		state.receiverBinding = deriveReplicationInfoV2ReceiverBinding({
+			receiverChallenge: state.receiverRequestChallenge,
+			receiver: this.deps.getSelfKey(),
+			receiverTransportSession: ready.receiverTransportSession,
+			sender: state.target,
+			senderTransportSession: state.senderTransportSession,
+		});
+	}
+
+	/** Require a fresh capability-bound grant and authoritative Full. */
+	advanceRecovery(properties: {
+		peerHash: string;
+		peerSession: object;
+		receiveEpoch: object | null;
+	}): boolean {
+		const state = this._receiveStates.get(properties.peerHash);
+		if (!state || state.peerSession !== properties.peerSession) {
+			return false;
+		}
+		state.receiveEpoch = properties.receiveEpoch;
+		this.transitionToResync(state, {
+			force: true,
+			refreshCapability: true,
+		});
+		return true;
+	}
+
+	private transitionToResync(
+		state: ReplicationInfoV2ReceiveState,
+		options?: { force?: boolean; refreshCapability?: boolean },
+	): void {
+		const shouldRestart =
+			state.phase !== "resync" ||
+			options?.force === true ||
+			state.requestParked;
+		if (state.phase !== "resync" || options?.force === true) {
+			state.phase = "resync";
+			state.version++;
+		}
+		if (options?.refreshCapability) {
+			state.capabilityRefreshRequired = true;
+		}
+		if (shouldRestart) {
+			state.requestAttempts = 0;
+			state.requestParked = false;
+			this.armRequest(state, 0);
+		}
+	}
+
+	isLegacyCutover(peerSession: object | null): boolean {
+		return peerSession !== null && this._cutoverPeerSessions.has(peerSession);
+	}
+
+	prepare(
+		message: ReplicationInfoV2Message,
+		properties: {
+			from: PublicSignKey;
+			peerSession: object;
+			receiveEpoch: object | null;
+			senderTransportSession: bigint;
+			transportTimestamp: bigint;
+		},
+	): ReplicationInfoV2ReceiveAdmission | undefined {
+		const peerHash = properties.from.hashcode();
+		const state = this._receiveStates.get(peerHash);
+		if (
+			!state ||
+			state.peerSession !== properties.peerSession ||
+			state.receiveEpoch !== properties.receiveEpoch ||
+			state.senderTransportSession !== properties.senderTransportSession ||
+			!state.target.equals(properties.from) ||
+			!state.receiverBinding ||
+			!bytesEqual(message.receiverChallenge, state.receiverBinding) ||
+			message.sequence <= 0n ||
+			!this.isStateCurrent(state)
+		) {
+			return undefined;
+		}
+
+		const kind =
+			message instanceof FullReplicationInfoV2Message
+				? "full"
+				: message instanceof AddedReplicationInfoV2Message
+					? "added"
+					: message instanceof StoppedReplicationInfoV2Message
+						? "stopped"
+						: undefined;
+		if (!kind) {
+			return undefined;
+		}
+
+		if (state.senderEpoch === undefined) {
+			if (kind !== "full") {
+				return undefined;
+			}
+		} else if (!bytesEqual(message.senderEpoch, state.senderEpoch)) {
+			return undefined;
+		}
+
+		const lastSequence = state.lastSequence;
+		if (kind === "full") {
+			if (lastSequence !== undefined && message.sequence <= lastSequence) {
+				return undefined;
+			}
+		} else {
+			if (
+				state.phase !== "active" ||
+				lastSequence === undefined ||
+				message.sequence !== lastSequence + 1n
+			) {
+				if (
+					state.phase === "active" &&
+					lastSequence !== undefined &&
+					message.sequence > lastSequence + 1n
+				) {
+					this.transitionToResync(state);
+				}
+				return undefined;
+			}
+		}
+
+		return {
+			state,
+			version: state.version,
+			receiveEpoch: state.receiveEpoch,
+			message,
+			kind,
+			payloadFingerprint: replicationInfoPayloadFingerprint(message),
+			transportTimestamp: properties.transportTimestamp,
+			committed: false,
+		};
+	}
+
+	/** Reserve at most one decoded V2 frame per peer ahead of the apply lane. */
+	reserve(
+		message: ReplicationInfoV2Message,
+		properties: {
+			from: PublicSignKey;
+			peerSession: object;
+			receiveEpoch: object | null;
+			senderTransportSession: bigint;
+			transportTimestamp: bigint;
+		},
+	): ReplicationInfoV2ReceiveAdmission | undefined {
+		const peerHash = properties.from.hashcode();
+		const reserved = this._reservedAdmissionsByPeer.get(peerHash);
+		if (reserved) {
+			const state = reserved.state;
+			const currentState = this._receiveStates.get(peerHash);
+			const knownMessage =
+				message instanceof FullReplicationInfoV2Message ||
+				message instanceof AddedReplicationInfoV2Message ||
+				message instanceof StoppedReplicationInfoV2Message;
+			if (
+				knownMessage &&
+				this._receiveStates.get(peerHash) === state &&
+				state.peerSession === properties.peerSession &&
+				state.receiveEpoch === properties.receiveEpoch &&
+				state.senderTransportSession === properties.senderTransportSession &&
+				state.target.equals(properties.from) &&
+				state.receiverBinding !== undefined &&
+				bytesEqual(message.receiverChallenge, state.receiverBinding) &&
+				bytesEqual(message.senderEpoch, reserved.message.senderEpoch) &&
+				message.sequence > reserved.message.sequence &&
+				this.isStateCurrent(state)
+			) {
+				// Transport ACKs precede application. Do not invalidate the frame
+				// already applying, and do not retain an unbounded successor queue.
+				// Commit the reservation, then request one authoritative Full.
+				reserved.resyncAfterRelease = true;
+			} else if (
+				knownMessage &&
+				currentState !== undefined &&
+				currentState !== state &&
+				this.prepare(message, properties)?.state === currentState
+			) {
+				// A previous generation can still be parked in the host apply lane.
+				// Transport already ACKed this current-generation frame, so wake the
+				// current state once the peer-global reservation is finally released.
+				reserved.resyncAfterRelease = true;
+			}
+			return undefined;
+		}
+		const admission = this.prepare(message, properties);
+		if (!admission) {
+			return undefined;
+		}
+		const { state } = admission;
+		this._reservedAdmissionsByPeer.set(peerHash, admission);
+		state.reservedAdmission = admission;
+		return admission;
+	}
+
+	release(admission: ReplicationInfoV2ReceiveAdmission): void {
+		const { state } = admission;
+		if (this._reservedAdmissionsByPeer.get(state.peerHash) !== admission) {
+			return;
+		}
+		this._reservedAdmissionsByPeer.delete(state.peerHash);
+		if (state.reservedAdmission === admission) {
+			state.reservedAdmission = undefined;
+		}
+		const currentState = this._receiveStates.get(state.peerHash);
+		if (
+			currentState &&
+			this.isStateCurrent(currentState) &&
+			(admission.resyncAfterRelease ||
+				(currentState !== state && currentState.phase !== "active"))
+		) {
+			this.transitionToResync(currentState, { force: true });
+		}
+	}
+
+	/**
+	 * B9 can lose its sender grant while keeping the topic session open. Its
+	 * unmatched legacy sidecar is the compatibility signal to re-handshake; a
+	 * matching V2 payload before or after the legacy copy suppresses the timer.
+	 */
+	noteLegacyAnnouncement(properties: {
+		peerHash: string;
+		peerSession: object;
+		receiveEpoch: object | null;
+		senderTransportSession: bigint;
+		transportTimestamp: bigint;
+		message: LegacyReplicationInfoMessage;
+	}): boolean {
+		const state = this._receiveStates.get(properties.peerHash);
+		if (
+			!state ||
+			state.peerSession !== properties.peerSession ||
+			state.receiveEpoch !== properties.receiveEpoch ||
+			state.senderTransportSession !== properties.senderTransportSession ||
+			!this._cutoverPeerSessions.has(properties.peerSession) ||
+			!this.isStateCurrent(state)
+		) {
+			return false;
+		}
+		const fingerprint = replicationInfoPayloadFingerprint(properties.message);
+		if (
+			state.lastCommittedTransportTimestamp !== undefined &&
+			properties.transportTimestamp < state.lastCommittedTransportTimestamp
+		) {
+			return true;
+		}
+		if (
+			state.recentCommittedPayloads.some(
+				(committed) =>
+					properties.transportTimestamp <= committed.transportTimestamp &&
+					bytesEqual(committed.fingerprint, fingerprint),
+			)
+		) {
+			return true;
+		}
+		if (state.lastLegacyObservationTimestamp !== undefined) {
+			if (
+				properties.transportTimestamp < state.lastLegacyObservationTimestamp
+			) {
+				return true;
+			}
+			if (
+				properties.transportTimestamp === state.lastLegacyObservationTimestamp
+			) {
+				if (
+					state.lastLegacyObservationAmbiguous ||
+					(state.lastLegacyObservationFingerprint !== undefined &&
+						bytesEqual(state.lastLegacyObservationFingerprint, fingerprint))
+				) {
+					return true;
+				}
+				state.lastLegacyObservationAmbiguous = true;
+			} else {
+				state.lastLegacyObservationTimestamp = properties.transportTimestamp;
+				state.lastLegacyObservationFingerprint = fingerprint.slice();
+				state.lastLegacyObservationAmbiguous = false;
+			}
+		} else {
+			state.lastLegacyObservationTimestamp = properties.transportTimestamp;
+			state.lastLegacyObservationFingerprint = fingerprint.slice();
+			state.lastLegacyObservationAmbiguous = false;
+		}
+		const reserved = this._reservedAdmissionsByPeer.get(properties.peerHash);
+		if (
+			reserved?.state === state &&
+			!bytesEqual(reserved.payloadFingerprint, fingerprint)
+		) {
+			// A legacy sidecar observed while a different V2 payload is applying
+			// cannot be erased by that commit. The transport has already ACKed the
+			// sidecar, so require one authoritative successor after release.
+			reserved.resyncAfterRelease = true;
+		}
+		if (!state.legacyFallbackFingerprint) {
+			state.legacyFallbackFingerprint = fingerprint;
+			state.legacyFallbackTimestamp = properties.transportTimestamp;
+			state.legacyFallbackAmbiguous = false;
+		} else {
+			if (!bytesEqual(state.legacyFallbackFingerprint, fingerprint)) {
+				state.legacyFallbackAmbiguous = true;
+			}
+			if (
+				state.legacyFallbackTimestamp === undefined ||
+				properties.transportTimestamp > state.legacyFallbackTimestamp
+			) {
+				state.legacyFallbackTimestamp = properties.transportTimestamp;
+			}
+		}
+		if (state.phase !== "active") {
+			if (state.requestParked) {
+				this.transitionToResync(state, {
+					force: true,
+					refreshCapability: true,
+				});
+			}
+			return true;
+		}
+		if (state.legacyFallbackTimer) {
+			return true;
+		}
+		state.legacyFallbackTimer = setTimeout(() => {
+			state.legacyFallbackTimer = undefined;
+			if (this.isStateCurrent(state) && state.phase === "active") {
+				this.transitionToResync(state, {
+					force: true,
+					refreshCapability: true,
+				});
+			}
+		}, this.legacyFallbackDelayMs);
+		state.legacyFallbackTimer.unref?.();
+		return true;
+	}
+
+	private clearLegacyFallback(state: ReplicationInfoV2ReceiveState): void {
+		if (state.legacyFallbackTimer) {
+			clearTimeout(state.legacyFallbackTimer);
+			state.legacyFallbackTimer = undefined;
+		}
+		state.legacyFallbackFingerprint = undefined;
+		state.legacyFallbackTimestamp = undefined;
+		state.legacyFallbackAmbiguous = false;
+	}
+
+	isAdmissionCurrent(admission: ReplicationInfoV2ReceiveAdmission): boolean {
+		const { state } = admission;
+		return (
+			state.version === admission.version &&
+			state.receiveEpoch === admission.receiveEpoch &&
+			this.isStateCurrent(state)
+		);
+	}
+
+	commit(admission: ReplicationInfoV2ReceiveAdmission): boolean {
+		if (admission.committed) {
+			return this.isAdmissionCurrent(admission);
+		}
+		if (!this.isAdmissionCurrent(admission)) {
+			this.release(admission);
+			return false;
+		}
+		const { state, message } = admission;
+		if (admission.kind === "full") {
+			if (state.senderEpoch === undefined) {
+				state.senderEpoch = message.senderEpoch.slice();
+				this._cutoverPeerSessions.add(state.peerSession);
+			} else if (!bytesEqual(state.senderEpoch, message.senderEpoch)) {
+				this.release(admission);
+				return false;
+			}
+		} else if (
+			state.senderEpoch === undefined ||
+			!bytesEqual(state.senderEpoch, message.senderEpoch)
+		) {
+			this.release(admission);
+			return false;
+		}
+		state.lastSequence = message.sequence;
+		state.phase = "active";
+		state.requestAttempts = 0;
+		state.requestsSinceCapabilityRefresh = 0;
+		state.requestParked = false;
+		state.capabilityRefreshRequired = false;
+		state.lastCommittedTransportTimestamp = admission.transportTimestamp;
+		state.recentCommittedPayloads.push({
+			fingerprint: admission.payloadFingerprint.slice(),
+			transportTimestamp: admission.transportTimestamp,
+		});
+		if (state.recentCommittedPayloads.length > 8) {
+			state.recentCommittedPayloads.shift();
+		}
+		if (
+			(state.legacyFallbackTimestamp !== undefined &&
+				admission.transportTimestamp > state.legacyFallbackTimestamp) ||
+			(!state.legacyFallbackAmbiguous &&
+				state.legacyFallbackFingerprint !== undefined &&
+				bytesEqual(
+					state.legacyFallbackFingerprint,
+					admission.payloadFingerprint,
+				))
+		) {
+			this.clearLegacyFallback(state);
+		}
+		if (state.requestTimer) {
+			clearTimeout(state.requestTimer);
+			state.requestTimer = undefined;
+		}
+		state.version++;
+		admission.version = state.version;
+		admission.receiveEpoch = state.receiveEpoch;
+		admission.committed = true;
+		this.release(admission);
+		return true;
+	}
+
+	requireFullAfterFailure(
+		admission: ReplicationInfoV2ReceiveAdmission,
+	): boolean {
+		if (!this.isAdmissionCurrent(admission)) {
+			this.release(admission);
+			return false;
+		}
+		this.release(admission);
+		this.transitionToResync(admission.state, { force: true });
+		return true;
+	}
+
+	private isStateCurrent(state: ReplicationInfoV2ReceiveState): boolean {
+		return (
+			this._receiveStates.get(state.peerHash) === state &&
+			!state.controller.signal.aborted &&
+			!this.deps.isClosed() &&
+			state.receiverTransportSession !== undefined &&
+			this.deps.getReceiverTransportSession() ===
+				state.receiverTransportSession &&
+			this.deps.isSenderTransportSessionCurrent(
+				state.peerHash,
+				state.senderTransportSession,
+			) &&
+			this.deps.isPeerStateCurrent(
+				state.peerHash,
+				state.peerSession,
+				state.receiveEpoch,
+			)
+		);
+	}
+
+	private armRequest(
+		state: ReplicationInfoV2ReceiveState,
+		delayMs: number,
+	): void {
+		if (state.requestTimer) {
+			clearTimeout(state.requestTimer);
+		}
+		if (
+			this._receiveStates.get(state.peerHash) !== state ||
+			state.controller.signal.aborted ||
+			this.deps.isClosed() ||
+			(this._reservedAdmissionsByPeer.has(state.peerHash) &&
+				this._reservedAdmissionsByPeer.get(state.peerHash)?.state !== state) ||
+			state.receiverBinding === undefined ||
+			state.phase === "active" ||
+			state.requestParked ||
+			state.lastSequence === MAX_U64
+		) {
+			state.requestTimer = undefined;
+			return;
+		}
+		state.requestTimer = setTimeout(
+			() => {
+				state.requestTimer = undefined;
+				void this.runRequest(state);
+			},
+			Math.max(0, delayMs),
+		);
+		state.requestTimer.unref?.();
+	}
+
+	private requestRetryDelay(state: ReplicationInfoV2ReceiveState): number {
+		const exponent = Math.max(0, state.requestAttempts - 1);
+		return Math.min(
+			this.maxRequestRetryMs,
+			this.requestRetryMs * 2 ** Math.min(exponent, 20),
+		);
+	}
+
+	private async refreshGrant(
+		state: ReplicationInfoV2ReceiveState,
+	): Promise<boolean> {
+		const refreshed = await this.deps.refreshLocalCapability({
+			peerHash: state.peerHash,
+			target: state.target,
+			peerSession: state.peerSession,
+			receiveEpoch: state.receiveEpoch,
+			signal: state.controller.signal,
+		});
+		if (
+			!refreshed ||
+			!this.isStateCurrent(state) ||
+			this.deps.getReceiverTransportSession() !==
+				refreshed.receiverTransportSession
+		) {
+			return false;
+		}
+
+		const ready: LocalCapabilityReady = {
+			peerHash: state.peerHash,
+			receiverTransportSession: refreshed.receiverTransportSession,
+			requestNotBeforeMs: refreshed.requestNotBeforeMs,
+		};
+		this._localCapabilityReadyBySession.set(state.peerSession, ready);
+		state.receiverRequestChallenge = randomBytes(32);
+		state.senderEpoch = undefined;
+		state.lastSequence = undefined;
+		state.phase = "resync";
+		state.capabilityRefreshRequired = false;
+		state.requestsSinceCapabilityRefresh = 0;
+		state.version++;
+		this.bindLocalCapability(state, ready);
+		return true;
+	}
+
+	private async runRequest(
+		state: ReplicationInfoV2ReceiveState,
+	): Promise<void> {
+		if (state.requestInFlight) {
+			return;
+		}
+		if (!this.isStateCurrent(state)) {
+			return;
+		}
+		if (
+			state.phase === "active" ||
+			state.requestParked ||
+			state.lastSequence === MAX_U64
+		) {
+			return;
+		}
+		if (state.requestAttempts >= this.requestMaxAttempts) {
+			state.requestParked = true;
+			return;
+		}
+
+		let operation: Promise<void>;
+		operation = (async () => {
+			if (state.capabilityRefreshRequired) {
+				state.requestAttempts++;
+				if (!(await this.refreshGrant(state))) {
+					return;
+				}
+			}
+			if (!this.isStateCurrent(state)) {
+				return;
+			}
+			const ready = this._localCapabilityReadyBySession.get(state.peerSession);
+			if (
+				!ready ||
+				ready.peerHash !== state.peerHash ||
+				ready.receiverTransportSession !== state.receiverTransportSession
+			) {
+				return;
+			}
+			const now = this.now();
+			if (now <= ready.requestNotBeforeMs) {
+				this.armRequest(state, ready.requestNotBeforeMs - now + 1);
+				return;
+			}
+			if (state.requestAttempts >= this.requestMaxAttempts) {
+				state.requestParked = true;
+				return;
+			}
+			state.requestAttempts++;
+			state.requestsSinceCapabilityRefresh++;
+			const request = new RequestReplicationInfoV2Message({
+				receiverChallenge: state.receiverRequestChallenge.slice(),
+				intendedSender: state.target,
+				senderSession: state.senderTransportSession,
+			});
+			await this.deps.sendRequest(
+				request,
+				state.target,
+				state.controller.signal,
+			);
+		})()
+			.catch((error) => {
+				if (!state.controller.signal.aborted && !this.deps.isClosed()) {
+					this.deps.onRequestError?.(error);
+				}
+			})
+			.finally(() => {
+				if (state.requestInFlight === operation) {
+					state.requestInFlight = undefined;
+				}
+				if (
+					this._receiveStates.get(state.peerHash) === state &&
+					!state.controller.signal.aborted &&
+					!state.requestTimer &&
+					state.phase !== "active"
+				) {
+					if (state.requestsSinceCapabilityRefresh >= 3) {
+						state.capabilityRefreshRequired = true;
+					}
+					if (state.requestAttempts >= this.requestMaxAttempts) {
+						state.requestParked = true;
+					} else {
+						this.armRequest(state, this.requestRetryDelay(state));
+					}
+				}
+			});
+		state.requestInFlight = operation;
+		await operation;
+	}
+}

--- a/packages/programs/data/shared-log/src/replication-info-v2-send.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-send.ts
@@ -1,5 +1,4 @@
-import { serialize } from "@dao-xyz/borsh";
-import { type PublicSignKey, randomBytes, sha256Sync } from "@peerbit/crypto";
+import { type PublicSignKey, randomBytes } from "@peerbit/crypto";
 import { logger as loggerFn } from "@peerbit/logger";
 import type { RPC } from "@peerbit/rpc";
 import {
@@ -8,7 +7,7 @@ import {
 } from "@peerbit/stream-interface";
 import type { TransportMessage } from "./message.js";
 import type { ReplicationRangeIndexable } from "./ranges.js";
-import { concat, fromString } from "uint8arrays";
+import { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
 import {
 	AddedReplicationInfoV2Message,
 	AddedReplicationSegmentMessage,
@@ -22,46 +21,8 @@ import {
 const logger = loggerFn("peerbit:shared-log:replication-info-v2-send");
 
 const MAX_U64 = (1n << 64n) - 1n;
-const RECEIVER_BINDING_DOMAIN = fromString(
-	"peerbit/shared-log/replication-info-v2/receiver-binding/v1",
-);
 
-const lengthPrefixed = (bytes: Uint8Array): Uint8Array => {
-	const length = new Uint8Array(4);
-	new DataView(length.buffer).setUint32(0, bytes.byteLength, true);
-	return concat([length, bytes]);
-};
-
-const u64LittleEndian = (value: bigint): Uint8Array => {
-	const bytes = new Uint8Array(8);
-	new DataView(bytes.buffer).setBigUint64(0, value, true);
-	return bytes;
-};
-
-/**
- * Derive the token echoed by V2 data frames. Delivery recipients are unsigned,
- * so the receiver's nonce alone is not a destination binding. Folding both
- * authenticated identities and signed transport sessions into the 32-byte
- * field prevents a copied request nonce from creating an interchangeable
- * stream for another receiver.
- */
-export const deriveReplicationInfoV2ReceiverBinding = (properties: {
-	receiverChallenge: Uint8Array;
-	receiver: PublicSignKey;
-	receiverTransportSession: bigint;
-	sender: PublicSignKey;
-	senderTransportSession: bigint;
-}): Uint8Array =>
-	sha256Sync(
-		concat([
-			lengthPrefixed(RECEIVER_BINDING_DOMAIN),
-			lengthPrefixed(properties.receiverChallenge),
-			lengthPrefixed(serialize(properties.receiver)),
-			u64LittleEndian(properties.receiverTransportSession),
-			lengthPrefixed(serialize(properties.sender)),
-			u64LittleEndian(properties.senderTransportSession),
-		]),
-	);
+export { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
 
 export type LegacyReplicationInfoMessage =
 	| AllReplicatingSegmentsMessage
@@ -78,6 +39,7 @@ export type ReplicationInfoV2SendState = {
 	peerSession: object;
 	receiverTransportSession: bigint;
 	senderTransportSession: bigint;
+	capabilityTimestamp: bigint;
 	lastRequestTimestamp: bigint;
 	receiverRequestChallenge: Uint8Array;
 	receiverChallenge: Uint8Array;
@@ -218,8 +180,8 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 	/**
 	 * Accept a signed receiver request. An exact newer retry asks for another
 	 * full snapshot without resetting the epoch/sequence. A different challenge
-	 * cannot replace the first binding within one PeerSession; this prevents a
-	 * signed request flood from spawning unbounded orphan snapshot reads.
+	 * can replace the binding only after a strictly newer signed capability;
+	 * retiring work is drained before the replacement can start.
 	 */
 	acceptRequest(
 		request: RequestReplicationInfoV2Message,
@@ -227,6 +189,7 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 			from: PublicSignKey;
 			peerSession: object;
 			receiverTransportSession: bigint;
+			capabilityTimestamp: bigint;
 			requestTimestamp: bigint;
 		},
 	): boolean {
@@ -275,12 +238,20 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 					return false;
 				}
 				previous.lastRequestTimestamp = properties.requestTimestamp;
+				previous.capabilityTimestamp = properties.capabilityTimestamp;
 				previous.suspended = false;
 				this.enqueueState(previous, { kind: "snapshot" });
 				return true;
 			}
 
-			return false;
+			if (properties.capabilityTimestamp <= previous.capabilityTimestamp) {
+				return false;
+			}
+			this.clearState(previous);
+			previous = undefined;
+			if (this._retiringWorkersByPeer.has(peerHash)) {
+				return false;
+			}
 		}
 
 		const ownershipLifecycleController =
@@ -291,6 +262,7 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 			peerSession: properties.peerSession,
 			receiverTransportSession: properties.receiverTransportSession,
 			senderTransportSession,
+			capabilityTimestamp: properties.capabilityTimestamp,
 			lastRequestTimestamp: properties.requestTimestamp,
 			receiverRequestChallenge: request.receiverChallenge.slice(),
 			receiverChallenge: deriveReplicationInfoV2ReceiverBinding({

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -96,12 +96,12 @@ describe("lifecycle", () => {
 					new Error("forced ownership poison"),
 				);
 				await db.close();
-				expect(sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target")).to.equal(
-					runningState,
-				);
+				expect(
+					sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target"),
+				).to.equal(runningState);
 				await session.peers[0].open(db);
-				expect(sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target")).to.be
-					.undefined;
+				expect(sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target"))
+					.to.be.undefined;
 
 				sharedLog.dispatchMaybeMissingEntries(
 					"target",
@@ -118,9 +118,9 @@ describe("lifecycle", () => {
 				const reopenedState =
 					sharedLog.joinWarmup._joinWarmupSendStateByTarget.get("target");
 				expect(reopenedState.session).to.not.equal(oldGeneration);
-				expect(sharedLog.joinWarmup._warmupSessionsByTarget.get("target")).to.equal(
-					reopenedState.session,
-				);
+				expect(
+					sharedLog.joinWarmup._warmupSessionsByTarget.get("target"),
+				).to.equal(reopenedState.session);
 				expect(maxActiveSimpleSends).to.equal(2);
 
 				expect(releaseOldSimple).to.be.a("function");
@@ -236,7 +236,9 @@ describe("lifecycle", () => {
 				releaseLookup();
 				await terminating;
 
-				expect(lookup.calledOnce).to.be.true;
+				// A capability round-trip can keep an earlier duplicate subscription
+				// callback admitted. Terminal drain must settle every admitted lookup.
+				expect(lookup.called).to.be.true;
 				expect(retire.calledOnce).to.be.true;
 				expect(
 					sent.filter(
@@ -278,25 +280,30 @@ describe("lifecycle", () => {
 						new Map([["late-entry", { hash: "late-entry" }]]),
 						false,
 					);
-					expect(sharedLog.joinWarmup._warmupSessionsByTarget.get(target)).to.equal(
-						generation,
-					);
-					expect(sharedLog.joinWarmup._joinWarmupRetryTimersByTarget.has(target)).to.be
-						.false;
-					expect(sharedLog.joinWarmup._joinWarmupScheduledRetriesByTarget.has(target)).to
-						.be.false;
-				});
-			const drainReceiveHandlers = sinon
-				.stub(sharedLog, "drainReceiveHandlers")
-				.callsFake(async () => {
 					expect(
-						sharedLog.joinWarmup._warmupSessionsByTarget.has(target),
-					).to.be.false;
+						sharedLog.joinWarmup._warmupSessionsByTarget.get(target),
+					).to.equal(generation);
 					expect(
 						sharedLog.joinWarmup._joinWarmupRetryTimersByTarget.has(target),
 					).to.be.false;
 					expect(
-						sharedLog.joinWarmup._joinWarmupScheduledRetriesByTarget.has(target),
+						sharedLog.joinWarmup._joinWarmupScheduledRetriesByTarget.has(
+							target,
+						),
+					).to.be.false;
+				});
+			const drainReceiveHandlers = sinon
+				.stub(sharedLog, "drainReceiveHandlers")
+				.callsFake(async () => {
+					expect(sharedLog.joinWarmup._warmupSessionsByTarget.has(target)).to.be
+						.false;
+					expect(
+						sharedLog.joinWarmup._joinWarmupRetryTimersByTarget.has(target),
+					).to.be.false;
+					expect(
+						sharedLog.joinWarmup._joinWarmupScheduledRetriesByTarget.has(
+							target,
+						),
 					).to.be.false;
 				});
 
@@ -452,8 +459,9 @@ describe("lifecycle", () => {
 		const synchronizerGate = new Promise<void>((resolve) => {
 			releaseSynchronizer = resolve;
 		});
-		const originalSynchronizerOnMessage =
-			sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+		const originalSynchronizerOnMessage = sharedLog.syncronizer.onMessage.bind(
+			sharedLog.syncronizer,
+		);
 		const synchronizer = sinon
 			.stub(sharedLog.syncronizer, "onMessage")
 			.callsFake(async (message: unknown, context: unknown) => {
@@ -485,8 +493,8 @@ describe("lifecycle", () => {
 			closing = db.close().then(() => {
 				closeSettled = true;
 			});
-			await waitForResolved(() =>
-				expect(sharedLog.acceptsParentAttachments).to.be.false,
+			await waitForResolved(
+				() => expect(sharedLog.acceptsParentAttachments).to.be.false,
 			);
 			await delay(20);
 			expect(closeSettled).to.be.false;

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -186,6 +186,142 @@ describe("receive admission replication-info recovery epoch", () => {
 		}
 	});
 
+	it("fences a parked handler when coherent deletion throws after durable commit", async () => {
+		const session = await TestSession.connected(2);
+		const handlerParked = pDefer<void>();
+		const releaseHandler = pDefer<void>();
+		try {
+			const store = new EventStore<string, any>();
+			const target = await session.peers[0].open(store, {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			await session.peers[1].open(store.clone(), {
+				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+			});
+			const sharedLog = target.log as any;
+			const sourceKey = session.peers[1].identity.publicKey;
+			const sourceHash = sourceKey.hashcode();
+			let remoteRange: any;
+			await waitForResolved(async () => {
+				const ranges = await target.log.replicationIndex
+					.iterate({ query: { hash: sourceHash } })
+					.all();
+				expect(ranges).to.have.length.greaterThan(0);
+				remoteRange = ranges[0].value;
+			});
+
+			const scheduleRequests = sinon
+				.stub(sharedLog, "scheduleReplicationInfoRequests")
+				.callsFake(() => {});
+			const recoveryCalls: Array<{
+				gateOpen: boolean;
+				receiveEpoch: object | null;
+			}> = [];
+			const v2Recovery = sinon
+				.stub(sharedLog._v2Receive, "advanceRecovery")
+				.callsFake((...args: unknown[]) => {
+					const properties = args[0] as { receiveEpoch: object | null };
+					recoveryCalls.push({
+						gateOpen:
+							sharedLog._peerSessions.isReceiveCleanupGateOpen(sourceHash),
+						receiveEpoch: properties.receiveEpoch,
+					});
+					return true;
+				});
+			const delayedMessage = new AddedReplicationSegmentMessage({
+				segments: [remoteRange.toReplicationRange()],
+			});
+			let armed = false;
+			const originalSynchronizerOnMessage =
+				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
+			const synchronizer = sinon
+				.stub(sharedLog.syncronizer, "onMessage")
+				.callsFake(async (message: unknown, context: unknown) => {
+					if (message === delayedMessage) {
+						armed = true;
+						return false;
+					}
+					return originalSynchronizerOnMessage(message, context);
+				});
+			const originalApplyQueue =
+				sharedLog.withReplicationInfoApplyQueue.bind(sharedLog);
+			const applyQueue = sinon
+				.stub(sharedLog, "withReplicationInfoApplyQueue")
+				.callsFake(async (...args: unknown[]) => {
+					const [peerHash, fn] = args as [string, () => Promise<void>];
+					if (armed && peerHash === sourceHash) {
+						armed = false;
+						handlerParked.resolve();
+						await releaseHandler.promise;
+					}
+					return originalApplyQueue(peerHash, fn);
+				});
+			const originalDelete =
+				sharedLog.deleteReplicationRangesCoherently.bind(sharedLog);
+			const postCommitFailure = new Error("post-commit deletion failure");
+			const coherentDelete = sinon
+				.stub(sharedLog, "deleteReplicationRangesCoherently")
+				.callsFake(async (...args: unknown[]) => {
+					await originalDelete(...args);
+					throw postCommitFailure;
+				});
+
+			try {
+				const receive = target.log.onMessage(delayedMessage, {
+					from: sourceKey,
+					message: { header: { timestamp: BigInt(Date.now()) } },
+				} as any);
+				await handlerParked.promise;
+				const receiveEpochBefore =
+					sharedLog._peerSessions.receiveEpoch(sourceHash);
+
+				let removalError: unknown;
+				try {
+					await sharedLog.removeReplicator(sourceKey, { noEvent: true });
+				} catch (error) {
+					removalError = error;
+				}
+				expect(removalError).to.equal(postCommitFailure);
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(sharedLog._peerSessions.receiveEpoch(sourceHash)).to.not.equal(
+					receiveEpochBefore,
+				);
+				expect(recoveryCalls).to.have.length(2);
+				expect(recoveryCalls.map((call) => call.gateOpen)).to.deep.equal([
+					false,
+					true,
+				]);
+				expect(recoveryCalls[0].receiveEpoch).to.equal(
+					recoveryCalls[1].receiveEpoch,
+				);
+
+				releaseHandler.resolve();
+				await receive;
+				expect(
+					await target.log.replicationIndex.count({
+						query: { hash: sourceHash },
+					}),
+				).to.equal(0);
+				expect(sharedLog.latestReplicationInfoMessage.has(sourceHash)).to.be
+					.false;
+			} finally {
+				releaseHandler.resolve();
+				coherentDelete.restore();
+				applyQueue.restore();
+				synchronizer.restore();
+				v2Recovery.restore();
+				scheduleRequests.restore();
+			}
+		} finally {
+			releaseHandler.resolve();
+			await session.stop();
+		}
+	});
+
 	it("keeps a pre-close recovery-epoch capture stale after reopen", async () => {
 		const session = await TestSession.disconnected(1);
 		try {
@@ -323,9 +459,10 @@ describe("receive admission opening-barrier windows", () => {
 					.then(() => {
 						subscriptionSettled = true;
 					});
-				await waitForResolved(() =>
-					expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
-						.true,
+				await waitForResolved(
+					() =>
+						expect(sharedLog._receiveHandlerDrainByPeer.has(sourceHash)).to.be
+							.true,
 				);
 				// Window-open probe (stage-3 home: the barrier flags its session).
 				const barrierSession = sharedLog._peerSessions.current(sourceHash);
@@ -552,6 +689,11 @@ describe("receive admission control-plane lease one-shot", () => {
 			const scheduleRequests = sinon
 				.stub(sharedLog, "scheduleReplicationInfoRequests")
 				.callsFake(() => {});
+			// This assertion targets the legacy handler's lease/apply-lane boundary;
+			// keep the independently negotiated V2 cutover from bypassing that path.
+			const forceLegacyReceivePath = sinon
+				.stub(sharedLog._v2Receive, "isLegacyCutover")
+				.returns(false);
 			try {
 				// Hold a second lease in the same bucket: a lost mid-branch release
 				// would keep the bucket at 2, and any extra release (e.g. a finally
@@ -629,12 +771,14 @@ describe("receive admission control-plane lease one-shot", () => {
 					).to.equal(1),
 				);
 				extraRelease();
-				await waitForResolved(() =>
-					expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
-						.false,
+				await waitForResolved(
+					() =>
+						expect(sharedLog._activeReceiveHandlersByPeer.has(sourceHash)).to.be
+							.false,
 				);
 			} finally {
 				scheduleRequests.restore();
+				forceLegacyReceivePath.restore();
 			}
 		} finally {
 			releaseLane.resolve();

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -270,7 +270,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		).to.equal("00000a0f000000");
 	});
 
-	it("drops unsolicited V2 before receive state or side effects", async () => {
+	it("drops unsolicited V2 before state or mutation side effects", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: false, timeUntilRoleMaturity: 0 },
@@ -278,9 +278,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		const log = db.log as any;
 		const remote = session.peers[1].identity.publicKey;
 		const remoteHash = remote.hashcode();
-		const durablePoison = sinon.spy(log, "throwIfNativeDurableCommitFailed");
-		const lease = sinon.spy(log, "acquirePeerReceiveLease");
-		const ownership = sinon.spy(log, "captureReplicationOwnershipLifecycle");
 		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
 		const add = sinon.spy(log, "addReplicationRange");
 		const remove = sinon.spy(log, "removeReplicationRanges");
@@ -294,9 +291,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				} as any);
 			}
 
-			expect(durablePoison.notCalled).to.be.true;
-			expect(lease.notCalled).to.be.true;
-			expect(ownership.notCalled).to.be.true;
 			expect(activity.notCalled).to.be.true;
 			expect(add.notCalled).to.be.true;
 			expect(remove.notCalled).to.be.true;
@@ -307,9 +301,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				await db.log.replicationIndex.count({ query: { hash: remoteHash } }),
 			).to.equal(0);
 		} finally {
-			durablePoison.restore();
-			lease.restore();
-			ownership.restore();
 			activity.restore();
 			add.restore();
 			remove.restore();
@@ -317,7 +308,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises sender readiness while ordinary replication sends stay legacy", async () => {
+	it("advertises sender and receiver readiness while legacy remains primary", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -347,18 +338,17 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE);
 			expect(
-				capability!.capabilities &
-					SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND);
 			expect(
-				capability!.capabilities &
-					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
-			).to.equal(0);
+				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY);
 			expect(
 				capability!.capabilities &
 					~(
 						SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
 						SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
+						SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY |
 						SYNC_CAPABILITY_RAW_EXCHANGE_HEADS
 					),
 			).to.equal(0);
@@ -382,7 +372,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises sender readiness before replication snapshot retrieval", async () => {
+	it("advertises V2 readiness before replication snapshot retrieval", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -415,16 +405,94 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE);
 			expect(
-				capability!.capabilities &
-					SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND);
 			expect(
-				capability!.capabilities &
-					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
-			).to.equal(0);
+				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY);
 		} finally {
 			send.restore();
 			snapshot.restore();
+		}
+	});
+
+	it("does not hold the legacy snapshot behind the V2 capability acknowledgement", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: true, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		let releaseCapabilityAcknowledgement!: () => void;
+		const capabilityAcknowledgement = new Promise<void>((resolve) => {
+			releaseCapabilityAcknowledgement = resolve;
+		});
+		let markLegacySnapshotSent!: () => void;
+		const legacySnapshotSent = new Promise<void>((resolve) => {
+			markLegacySnapshotSent = resolve;
+		});
+		const sent: unknown[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				sent.push(message);
+				if (message instanceof SyncCapabilitiesMessage) {
+					await capabilityAcknowledgement;
+				}
+				if (message instanceof AllReplicatingSegmentsMessage) {
+					markLegacySnapshotSent();
+				}
+				return [] as any;
+			});
+		const markReady = sinon.spy(log._v2Receive, "markLocalCapabilityReady");
+		const requests = sinon
+			.stub(log, "scheduleReplicationInfoRequests")
+			.callsFake(() => {});
+		let subscription: Promise<void> | undefined;
+		let subscriptionSettled = false;
+		let legacySnapshotTimeout: ReturnType<typeof setTimeout> | undefined;
+
+		try {
+			subscription = log
+				._onSubscription({
+					detail: { from: remote, topics: [db.log.topic] },
+				})
+				.then(() => {
+					subscriptionSettled = true;
+				});
+			await Promise.race([
+				legacySnapshotSent,
+				new Promise<never>((_, reject) => {
+					legacySnapshotTimeout = setTimeout(
+						() => reject(new Error("legacy snapshot send was blocked")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(legacySnapshotTimeout);
+			legacySnapshotTimeout = undefined;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(sent[0]).to.be.instanceOf(SyncCapabilitiesMessage);
+			expect(
+				sent.some(
+					(message) => message instanceof AllReplicatingSegmentsMessage,
+				),
+			).to.be.true;
+			expect(subscriptionSettled).to.be.false;
+			expect(markReady.called).to.be.false;
+			expect(requests.calledOnce).to.be.true;
+
+			releaseCapabilityAcknowledgement();
+			await subscription;
+			expect(markReady.calledOnce).to.be.true;
+		} finally {
+			clearTimeout(legacySnapshotTimeout);
+			releaseCapabilityAcknowledgement();
+			await subscription?.catch(() => {});
+			send.restore();
+			markReady.restore();
+			requests.restore();
 		}
 	});
 });

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -1,0 +1,1904 @@
+import { Ed25519PublicKey } from "@peerbit/crypto";
+import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import pDefer from "p-defer";
+import sinon from "sinon";
+import {
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
+	SyncCapabilitiesMessage,
+} from "../src/exchange-heads.js";
+import {
+	ReplicationIntent,
+	ReplicationRangeMessageU64,
+} from "../src/ranges.js";
+import { deriveReplicationInfoV2ReceiverBinding } from "../src/replication-info-v2-binding.js";
+import { ReplicationInfoV2ReceiveCoordinator } from "../src/replication-info-v2-receive.js";
+import { ReplicationInfoV2SendCoordinator } from "../src/replication-info-v2-send.js";
+import {
+	AddedReplicationInfoV2Message,
+	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
+	StoppedReplicationInfoV2Message,
+} from "../src/replication.js";
+import { EventStore } from "./utils/stores/index.js";
+
+const key = (value: number) =>
+	new Ed25519PublicKey({ publicKey: new Uint8Array(32).fill(value) });
+
+const bytes = (value: number) => new Uint8Array(32).fill(value);
+const senderCapabilities =
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND;
+
+describe("receive admission replication-info V2 receiver state", () => {
+	const self = key(1);
+	const sender = key(2);
+	const peerHash = sender.hashcode();
+	const senderTransportSession = 0x20000000000001n;
+	const receiverTransportSession = 0x20000000000002n;
+
+	let closed: boolean;
+	let currentSession: object;
+	let currentReceiveEpoch: object;
+	let currentSenderTransportSession: bigint;
+	let sendRequest: sinon.SinonStub;
+	let refreshLocalCapability: sinon.SinonStub;
+	let coordinator: ReplicationInfoV2ReceiveCoordinator;
+
+	const createCoordinator = (options?: {
+		requestRetryMs?: number;
+		maxRequestRetryMs?: number;
+		requestMaxAttempts?: number;
+		legacyFallbackDelayMs?: number;
+	}) =>
+		new ReplicationInfoV2ReceiveCoordinator({
+			getSelfKey: () => self,
+			getReceiverTransportSession: () => receiverTransportSession,
+			isClosed: () => closed,
+			isPeerStateCurrent: (_peerHash, peerSession, receiveEpoch) =>
+				peerSession === currentSession && receiveEpoch === currentReceiveEpoch,
+			isSenderTransportSessionCurrent: (_peerHash, transportSession) =>
+				transportSession === currentSenderTransportSession,
+			sendRequest,
+			refreshLocalCapability,
+			requestRetryMs: options?.requestRetryMs ?? 5,
+			maxRequestRetryMs: options?.maxRequestRetryMs ?? 20,
+			requestMaxAttempts: options?.requestMaxAttempts ?? 7,
+			legacyFallbackDelayMs: options?.legacyFallbackDelayMs ?? 10,
+		});
+
+	const markLocalReady = (requestNotBeforeMs = Date.now()) =>
+		coordinator.markLocalCapabilityReady({
+			peerHash,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			receiverTransportSession,
+			requestNotBeforeMs,
+		});
+
+	const observeSender = (
+		capabilityTimestamp = 1n,
+		transportSession = senderTransportSession,
+	) =>
+		coordinator.observeCapability({
+			peerHash,
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			capabilities: senderCapabilities,
+			senderTransportSession: transportSession,
+			capabilityTimestamp,
+		});
+
+	const prepare = (
+		message:
+			| FullReplicationInfoV2Message
+			| AddedReplicationInfoV2Message
+			| StoppedReplicationInfoV2Message,
+		transportTimestamp = 1n,
+	) =>
+		coordinator.prepare(message, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp,
+		});
+
+	beforeEach(() => {
+		closed = false;
+		currentSession = {};
+		currentReceiveEpoch = {};
+		currentSenderTransportSession = senderTransportSession;
+		sendRequest = sinon.stub().resolves();
+		refreshLocalCapability = sinon.stub().callsFake(async () => ({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		}));
+		coordinator = createCoordinator();
+	});
+
+	afterEach(() => {
+		coordinator.clearForClose();
+		sinon.restore();
+	});
+
+	it("waits for ACKed local readiness and retries the exact challenge", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({ requestRetryMs: 5 });
+
+		expect(observeSender()).to.be.true;
+		await clock.tickAsync(100);
+		expect(sendRequest.notCalled).to.be.true;
+
+		expect(markLocalReady(1_100)).to.be.true;
+		await clock.tickAsync(1);
+		expect(sendRequest.calledOnce).to.be.true;
+		const first = sendRequest.firstCall.args[0];
+		expect(first.intendedSender.equals(sender)).to.be.true;
+		expect(first.senderSession).to.equal(senderTransportSession);
+
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect([...state.receiverBinding!]).to.deep.equal([
+			...deriveReplicationInfoV2ReceiverBinding({
+				receiverChallenge: state.receiverRequestChallenge,
+				receiver: self,
+				receiverTransportSession,
+				sender,
+				senderTransportSession,
+			}),
+		]);
+
+		await clock.tickAsync(5);
+		expect(sendRequest.callCount).to.equal(2);
+		const retried = sendRequest.secondCall.args[0];
+		expect([...retried.receiverChallenge]).to.deep.equal([
+			...first.receiverChallenge,
+		]);
+	});
+
+	it("orders Full, Added and recovery Full independently of transport time", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(3);
+
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		const fullAdmission = prepare(full);
+		expect(fullAdmission).to.exist;
+		expect(coordinator.commit(fullAdmission!)).to.be.true;
+		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+
+		const added = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const addedAdmission = prepare(added);
+		expect(addedAdmission).to.exist;
+		expect(coordinator.commit(addedAdmission!)).to.be.true;
+
+		expect(prepare(added)).to.be.undefined;
+		const gap = new StoppedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 4n,
+			segmentIds: [],
+		});
+		expect(prepare(gap)).to.be.undefined;
+		expect(state.phase).to.equal("resync");
+		expect(state.lastSequence).to.equal(2n);
+
+		const repaired = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 5n,
+			segments: [],
+		});
+		const repairedAdmission = prepare(repaired);
+		expect(repairedAdmission).to.exist;
+		expect(coordinator.commit(repairedAdmission!)).to.be.true;
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(5n);
+
+		const wrongEpoch = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(4),
+			sequence: 6n,
+			segments: [],
+		});
+		expect(prepare(wrongEpoch)).to.be.undefined;
+		expect(state.lastSequence).to.equal(5n);
+	});
+
+	it("fences a parked delta across same-session recovery without reopening legacy", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(5);
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+
+		const delta = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const parked = prepare(delta)!;
+		const rawChallenge = state.receiverRequestChallenge.slice();
+		const binding = state.receiverBinding!.slice();
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+
+		expect(coordinator.commit(parked)).to.be.false;
+		expect(state.phase).to.equal("resync");
+		expect([...state.receiverRequestChallenge]).to.deep.equal([
+			...rawChallenge,
+		]);
+		expect([...state.receiverBinding!]).to.deep.equal([...binding]);
+		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(
+			coordinator.prepare(delta, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 1n,
+			}),
+		).to.be.undefined;
+
+		const repaired = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 3n,
+			segments: [],
+		});
+		const admission = coordinator.prepare(repaired, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 1n,
+		});
+		expect(admission).to.exist;
+		expect(coordinator.commit(admission!)).to.be.true;
+	});
+
+	it("makes exact capability replays side-effect free", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender(10n)).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(6),
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+		const challenge = state.receiverRequestChallenge.slice();
+
+		expect(observeSender(11n)).to.be.true;
+		expect(coordinator._receiveStates.get(peerHash)).to.equal(state);
+		expect(state.lastSequence).to.equal(1n);
+		expect(state.phase).to.equal("active");
+		expect([...state.receiverRequestChallenge]).to.deep.equal([...challenge]);
+		sendRequest.resetHistory();
+		await clock.tickAsync(100);
+		expect(sendRequest.notCalled).to.be.true;
+		expect(state.requestTimer).to.be.undefined;
+		expect(observeSender(9n)).to.be.false;
+	});
+
+	it("revokes an old grant when a newer transport drops sender readiness", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender(10n)).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(11),
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+
+		const newerTransport = senderTransportSession + 1n;
+		currentSenderTransportSession = newerTransport;
+		expect(
+			coordinator.observeCapability({
+				peerHash,
+				target: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+				senderTransportSession: newerTransport,
+				capabilityTimestamp: 20n,
+			}),
+		).to.be.false;
+		expect(state.controller.signal.aborted).to.be.true;
+		expect(coordinator._receiveStates.has(peerHash)).to.be.false;
+		expect(coordinator.isLegacyCutover(currentSession)).to.be.false;
+		expect(prepare(full)).to.be.undefined;
+	});
+
+	it("rejects every mismatched binding, session, epoch and sequence tuple", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(12);
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+
+		const wrongBinding = new AddedReplicationInfoV2Message({
+			receiverChallenge: bytes(99),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const wrongSenderEpoch = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(98),
+			sequence: 2n,
+			segments: [],
+		});
+		const zero = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 0n,
+			segments: [],
+		});
+		expect(prepare(wrongBinding)).to.be.undefined;
+		expect(prepare(wrongSenderEpoch)).to.be.undefined;
+		expect(prepare(zero)).to.be.undefined;
+		expect(prepare(full)).to.be.undefined;
+		expect(
+			coordinator.prepare(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 2n,
+					segments: [],
+				}),
+				{
+					from: sender,
+					peerSession: {},
+					receiveEpoch: currentReceiveEpoch,
+					senderTransportSession,
+					transportTimestamp: 1n,
+				},
+			),
+		).to.be.undefined;
+		expect(
+			coordinator.prepare(full, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: {},
+				senderTransportSession,
+				transportTimestamp: 1n,
+			}),
+		).to.be.undefined;
+		expect(
+			coordinator.prepare(full, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession: senderTransportSession + 1n,
+				transportTimestamp: 1n,
+			}),
+		).to.be.undefined;
+	});
+
+	it("defers one bounded resync when a successor overlaps an active reservation", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(13);
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+		const next = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const reserved = coordinator.reserve(next, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		for (let index = 0; index < 100; index++) {
+			expect(
+				coordinator.reserve(next, {
+					from: sender,
+					peerSession: currentSession,
+					receiveEpoch: currentReceiveEpoch,
+					senderTransportSession,
+					transportTimestamp: 2n,
+				}),
+			).to.be.undefined;
+		}
+		expect(state.reservedAdmission).to.equal(reserved);
+
+		const successor = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 3n,
+			segments: [],
+		});
+		expect(
+			coordinator.reserve(successor, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 3n,
+			}),
+		).to.be.undefined;
+		expect(state.phase).to.equal("active");
+		expect(state.reservedAdmission).to.equal(reserved);
+		expect(reserved.resyncAfterRelease).to.be.true;
+		expect(state.requestTimer).to.be.undefined;
+		expect(coordinator.commit(reserved)).to.be.true;
+		expect(state.lastSequence).to.equal(2n);
+		expect(state.phase).to.equal("resync");
+		expect(state.requestTimer).to.exist;
+		expect(state.reservedAdmission).to.be.undefined;
+	});
+
+	it("recovers a successor that overlaps the first authoritative Full", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(14);
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		const reserved = coordinator.reserve(full, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 1n,
+		})!;
+		const successor = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		expect(
+			coordinator.reserve(successor, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 2n,
+			}),
+		).to.be.undefined;
+		expect(state.phase).to.equal("awaiting-full");
+		expect(reserved.resyncAfterRelease).to.be.true;
+		expect(coordinator.commit(reserved)).to.be.true;
+		expect(state.lastSequence).to.equal(1n);
+		expect(state.phase).to.equal("resync");
+		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(state.requestTimer).to.exist;
+	});
+
+	it("pauses a replacement generation behind an old peer reservation", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const oldState = coordinator._receiveStates.get(peerHash)!;
+		const oldEpoch = bytes(15);
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: oldState.receiverBinding!.slice(),
+						senderEpoch: oldEpoch,
+						sequence: 1n,
+						segments: [],
+					}),
+					1n,
+				)!,
+			),
+		).to.be.true;
+		const oldAdmission = coordinator.reserve(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: oldState.receiverBinding!.slice(),
+				senderEpoch: oldEpoch,
+				sequence: 2n,
+				segments: [],
+			}),
+			{
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 2n,
+			},
+		)!;
+
+		sendRequest.resetHistory();
+		const replacementTransportSession = senderTransportSession + 1n;
+		currentSenderTransportSession = replacementTransportSession;
+		expect(observeSender(2n, replacementTransportSession)).to.be.true;
+		const replacement = coordinator._receiveStates.get(peerHash)!;
+		expect(replacement).to.not.equal(oldState);
+		expect(replacement.phase).to.equal("resync");
+		expect(replacement.requestAttempts).to.equal(0);
+		expect(replacement.requestTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(sendRequest.notCalled).to.be.true;
+		expect(replacement.requestAttempts).to.equal(0);
+
+		coordinator.release(oldAdmission);
+		expect(replacement.requestTimer).to.exist;
+		await clock.tickAsync(2);
+		expect(sendRequest.calledOnce).to.be.true;
+		const replacementFull = new FullReplicationInfoV2Message({
+			receiverChallenge: replacement.receiverBinding!.slice(),
+			senderEpoch: bytes(16),
+			sequence: 1n,
+			segments: [],
+		});
+		const replacementAdmission = coordinator.reserve(replacementFull, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession: replacementTransportSession,
+			transportTimestamp: 3n,
+		});
+		expect(replacementAdmission).to.exist;
+		expect(coordinator.commit(replacementAdmission!)).to.be.true;
+		expect(replacement.phase).to.equal("active");
+		expect(replacement.lastSequence).to.equal(1n);
+	});
+
+	it("fences legacy recovery evidence to the exact receive generation", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch: bytes(17),
+						sequence: 1n,
+						segments: [],
+					}),
+					10n,
+				)!,
+			),
+		).to.be.true;
+		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
+		expect(
+			coordinator.noteLegacyAnnouncement({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession: senderTransportSession + 1n,
+				transportTimestamp: 100n,
+				message: legacy,
+			}),
+		).to.be.false;
+		expect(
+			coordinator.noteLegacyAnnouncement({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: {},
+				senderTransportSession,
+				transportTimestamp: 101n,
+				message: legacy,
+			}),
+		).to.be.false;
+		expect(state.phase).to.equal("active");
+		expect(state.legacyFallbackTimer).to.be.undefined;
+	});
+
+	it("lets one fresh legacy observation restart parked recovery only once", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({
+			requestRetryMs: 1,
+			requestMaxAttempts: 1,
+		});
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch: bytes(18),
+						sequence: 1n,
+						segments: [],
+					}),
+					1n,
+				)!,
+			),
+		).to.be.true;
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		await clock.tickAsync(1);
+		expect(state.requestParked).to.be.true;
+
+		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
+		const observeLegacy = (transportTimestamp: bigint) =>
+			coordinator.noteLegacyAnnouncement({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp,
+				message: legacy,
+			});
+		expect(observeLegacy(2n)).to.be.true;
+		expect(state.requestParked).to.be.false;
+		await clock.tickAsync(1);
+		expect(state.requestParked).to.be.true;
+		const refreshesAfterFreshEvidence = refreshLocalCapability.callCount;
+		for (let replay = 0; replay < 100; replay++) {
+			expect(observeLegacy(2n)).to.be.true;
+		}
+		expect(state.requestParked).to.be.true;
+		expect(state.requestTimer).to.be.undefined;
+		expect(refreshLocalCapability.callCount).to.equal(
+			refreshesAfterFreshEvidence,
+		);
+		expect(observeLegacy(3n)).to.be.true;
+		expect(state.requestParked).to.be.false;
+		expect(state.requestTimer).to.exist;
+	});
+
+	it("uses strict transport time and payload evidence for legacy coverage", () => {
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(19);
+		const rangeA = new ReplicationRangeMessageU64({
+			id: bytes(30),
+			offset: 1n,
+			factor: 1n,
+			timestamp: 1n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const rangeB = new ReplicationRangeMessageU64({
+			id: bytes(31),
+			offset: 2n,
+			factor: 1n,
+			timestamp: 2n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 1n,
+						segments: [],
+					}),
+					1n,
+				)!,
+			),
+		).to.be.true;
+		expect(
+			coordinator.commit(
+				prepare(
+					new AddedReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 2n,
+						segments: [rangeA],
+					}),
+					10n,
+				)!,
+			),
+		).to.be.true;
+		expect(
+			coordinator.commit(
+				prepare(
+					new AddedReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 3n,
+						segments: [rangeB],
+					}),
+					20n,
+				)!,
+			),
+		).to.be.true;
+		const note = (
+			message: AddedReplicationSegmentMessage,
+			transportTimestamp: bigint,
+		) =>
+			coordinator.noteLegacyAnnouncement({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp,
+				message,
+			});
+		expect(
+			note(new AddedReplicationSegmentMessage({ segments: [rangeA] }), 10n),
+		).to.be.true;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 4n,
+						segments: [rangeA, rangeB],
+					}),
+					30n,
+				)!,
+			),
+		).to.be.true;
+		expect(
+			note(new AddedReplicationSegmentMessage({ segments: [rangeB] }), 29n),
+		).to.be.true;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+		expect(
+			note(new AddedReplicationSegmentMessage({ segments: [rangeA] }), 30n),
+		).to.be.true;
+		expect(state.legacyFallbackTimer).to.exist;
+
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 5n,
+						segments: [rangeA, rangeB],
+					}),
+					31n,
+				)!,
+			),
+		).to.be.true;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+	});
+
+	it("keeps unmatched legacy fallback armed across unrelated V2 work", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(20);
+		const initial = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(initial)!)).to.be.true;
+		const rangeA = new ReplicationRangeMessageU64({
+			id: bytes(21),
+			offset: 1n,
+			factor: 1n,
+			timestamp: 1n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const rangeB = new ReplicationRangeMessageU64({
+			id: bytes(22),
+			offset: 2n,
+			factor: 1n,
+			timestamp: 2n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		expect(
+			coordinator.noteLegacyAnnouncement({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 2n,
+				message: new AddedReplicationSegmentMessage({ segments: [rangeB] }),
+			}),
+		).to.be.true;
+		const unrelated = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [rangeA],
+		});
+		expect(coordinator.commit(prepare(unrelated)!)).to.be.true;
+		expect(state.legacyFallbackTimer).to.exist;
+		await clock.tickAsync(10);
+		expect(state.phase).to.equal("resync");
+	});
+
+	it("cancels legacy fallback only after a matching commit", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(23);
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 1n,
+						segments: [],
+					}),
+				)!,
+			),
+		).to.be.true;
+		const range = new ReplicationRangeMessageU64({
+			id: bytes(24),
+			offset: 3n,
+			factor: 1n,
+			timestamp: 3n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const legacy = new AddedReplicationSegmentMessage({ segments: [range] });
+		coordinator.noteLegacyAnnouncement({
+			peerHash,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+			message: legacy,
+		});
+		const matching = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [range],
+		});
+		const reserved = coordinator.reserve(matching, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(state.legacyFallbackTimer).to.exist;
+		coordinator.release(reserved);
+		expect(state.legacyFallbackTimer).to.exist;
+		const committed = coordinator.reserve(matching, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(coordinator.commit(committed)).to.be.true;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(state.phase).to.equal("active");
+	});
+
+	it("restarts parked recovery on fresh unmatched legacy evidence", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({
+			requestRetryMs: 2,
+			requestMaxAttempts: 1,
+		});
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(25);
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 1n,
+						segments: [],
+					}),
+				)!,
+			),
+		).to.be.true;
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		await clock.tickAsync(1);
+		expect(state.requestParked).to.be.true;
+		coordinator.noteLegacyAnnouncement({
+			peerHash,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+			message: new AddedReplicationSegmentMessage({ segments: [] }),
+		});
+		expect(state.requestParked).to.be.false;
+		expect(state.capabilityRefreshRequired).to.be.true;
+		expect(state.requestTimer).to.exist;
+	});
+
+	it("backs off to a parked request state and never renews an active stream", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({
+			requestRetryMs: 2,
+			maxRequestRetryMs: 4,
+			requestMaxAttempts: 2,
+		});
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		await clock.tickAsync(10);
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(sendRequest.callCount).to.equal(2);
+		expect(state.requestParked).to.be.true;
+		expect(state.requestTimer).to.be.undefined;
+		await clock.tickAsync(1_000);
+		expect(sendRequest.callCount).to.equal(2);
+
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(14),
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+		await clock.tickAsync(1_000);
+		expect(sendRequest.callCount).to.equal(2);
+	});
+
+	it("treats MAX_U64 as terminal for the current receiver grant", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const terminal = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(15),
+			sequence: (1n << 64n) - 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(terminal)!)).to.be.true;
+		sendRequest.resetHistory();
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		await clock.tickAsync(1_000);
+		expect(sendRequest.notCalled).to.be.true;
+		expect(state.requestTimer).to.be.undefined;
+	});
+
+	it("aborts an in-flight request without re-arming on clear", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		const pending = pDefer<void>();
+		let requestSignal: AbortSignal | undefined;
+		sendRequest = sinon.stub().callsFake((_request, _target, signal) => {
+			requestSignal = signal;
+			return pending.promise;
+		});
+		coordinator = createCoordinator({ requestRetryMs: 2 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		await clock.tickAsync(0);
+		expect(sendRequest.calledOnce).to.be.true;
+		coordinator.clearPeer(peerHash, currentSession);
+		expect(requestSignal?.aborted).to.be.true;
+		pending.resolve();
+		await clock.tickAsync(1_000);
+		expect(sendRequest.calledOnce).to.be.true;
+		expect(coordinator._receiveStates.has(peerHash)).to.be.false;
+	});
+
+	it("re-handshakes after a B9 sender clears its same-session grant", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		const senderPeerSession = {};
+		const ownershipController = new AbortController();
+		let capabilityTimestamp = 1_000n;
+		const delivered: FullReplicationInfoV2Message[] = [];
+		let senderCoordinator: ReplicationInfoV2SendCoordinator<"u32">;
+
+		const senderRpcSend = sinon.stub().callsFake(async (message) => {
+			if (
+				message instanceof FullReplicationInfoV2Message ||
+				message instanceof AddedReplicationInfoV2Message
+			) {
+				if (message instanceof FullReplicationInfoV2Message) {
+					delivered.push(message);
+				}
+				const admission = coordinator.prepare(message, {
+					from: sender,
+					peerSession: currentSession,
+					receiveEpoch: currentReceiveEpoch,
+					senderTransportSession,
+					transportTimestamp: message.sequence,
+				});
+				if (admission) {
+					expect(coordinator.commit(admission)).to.be.true;
+				}
+			}
+			return [];
+		});
+		senderCoordinator = new ReplicationInfoV2SendCoordinator<"u32">({
+			getRpc: () => ({ send: senderRpcSend }) as any,
+			getSelfKey: () => sender,
+			getSenderTransportSession: () => senderTransportSession,
+			getMyReplicationSegments: async () => [],
+			validatePersistedReplicationRangeSnapshot: () => {},
+			isClosed: () => false,
+			isPeerSessionOpen: (_hash, peerSession) =>
+				peerSession === senderPeerSession,
+			captureReplicationOwnershipLifecycle: () => ownershipController,
+			isReplicationOwnershipLifecycleActive: (controller) =>
+				controller === ownershipController && !controller.signal.aborted,
+		});
+
+		sendRequest = sinon.stub().callsFake(async (request) => {
+			expect(
+				senderCoordinator.acceptRequest(request, {
+					from: self,
+					peerSession: senderPeerSession,
+					receiverTransportSession,
+					capabilityTimestamp,
+					requestTimestamp: BigInt(Date.now()),
+				}),
+			).to.be.true;
+		});
+		refreshLocalCapability = sinon.stub().callsFake(async () => {
+			capabilityTimestamp = BigInt(Date.now());
+			// B9 treated every newer capability timestamp as a sender-generation
+			// advance and cleared the per-peer stream immediately.
+			senderCoordinator.advancePeerCapability(self.hashcode());
+			return {
+				receiverTransportSession,
+				requestNotBeforeMs: Date.now(),
+			};
+		});
+		coordinator = createCoordinator({ requestRetryMs: 2 });
+		expect(markLocalReady(1_000)).to.be.true;
+		expect(observeSender(capabilityTimestamp)).to.be.true;
+		await clock.tickAsync(1);
+		await senderCoordinator.drain();
+		expect(coordinator._receiveStates.get(peerHash)?.phase).to.equal("active");
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const oldBinding = state.receiverBinding!.slice();
+		const oldFull = delivered[0];
+
+		senderCoordinator.enqueue(
+			new AddedReplicationSegmentMessage({ segments: [] }),
+		);
+		await senderCoordinator.drain();
+		expect(state.lastSequence).to.equal(2n);
+		senderCoordinator.advancePeerCapability(self.hashcode());
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		await clock.tickAsync(10);
+		await senderCoordinator.drain();
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(1n);
+		expect([...state.receiverBinding!]).not.to.deep.equal([...oldBinding]);
+		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(
+			coordinator.prepare(oldFull, {
+				from: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				senderTransportSession,
+				transportTimestamp: 1n,
+			}),
+		).to.be.undefined;
+		senderCoordinator.clearForClose();
+	});
+});
+
+describe("receive admission replication-info V2 receiver integration", () => {
+	let session: TestSession | undefined;
+
+	afterEach(async () => {
+		sinon.restore();
+		await session?.stop();
+		session = undefined;
+	});
+
+	it("completes an actual signed two-node capability and request handshake", async () => {
+		session = await TestSession.connected(2);
+		const db1 = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const db2 = await EventStore.open<EventStore<string, any>>(
+			db1.address!,
+			session.peers[1],
+			{
+				args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			},
+		);
+		const receiver = db1.log as any;
+		const senderLog = db2.log as any;
+		const senderHash = session.peers[1].identity.publicKey.hashcode();
+		const receiverHash = session.peers[0].identity.publicKey.hashcode();
+
+		await waitForResolved(
+			() => {
+				const receiveState = receiver._v2Receive._receiveStates.get(senderHash);
+				const sendState = senderLog._v2Send._sendStates.get(receiverHash);
+				const capabilityTimestamp =
+					senderLog._peerSyncCapabilityTimestamps.get(receiverHash);
+				expect(receiveState?.phase).to.equal(
+					"active",
+					JSON.stringify({
+						receive: receiveState && {
+							phase: receiveState.phase,
+							attempts: receiveState.requestAttempts,
+							parked: receiveState.requestParked,
+							senderTransportSession:
+								receiveState.senderTransportSession?.toString(),
+						},
+						sender: sendState && {
+							established: sendState.established,
+							lastRequestTimestamp: sendState.lastRequestTimestamp?.toString(),
+						},
+						capabilityTimestamp: capabilityTimestamp?.toString(),
+					}),
+				);
+				expect(receiveState?.lastSequence > 0n).to.be.true;
+				expect(sendState?.established).to.be.true;
+				expect(capabilityTimestamp).to.not.equal(undefined);
+				expect(sendState.lastRequestTimestamp > capabilityTimestamp).to.be.true;
+				expect(
+					receiver._v2Receive.isLegacyCutover(
+						receiver._peerSessions.current(senderHash),
+					),
+				).to.be.true;
+			},
+			{ timeout: 20_000 },
+		);
+	});
+
+	it("rejects transport-generation downgrade replay on the signed host path", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiveEpoch = log._peerSessions.receiveEpoch(remoteHash);
+		const receiverTransportSession = BigInt(log.node.services.pubsub.session);
+		const senderSessionA = 4_001n;
+		const senderSessionB = 4_002n;
+		const context = (transportSession: bigint, timestamp: bigint) =>
+			({
+				from: remote,
+				message: { header: { session: transportSession, timestamp } },
+			}) as any;
+
+		expect(
+			log._v2Receive.markLocalCapabilityReady({
+				peerHash: remoteHash,
+				peerSession,
+				receiveEpoch,
+				receiverTransportSession,
+				requestNotBeforeMs: Date.now(),
+			}),
+		).to.be.true;
+		await log.onMessage(
+			new SyncCapabilitiesMessage({ capabilities: senderCapabilities }),
+			context(senderSessionA, 10n),
+		);
+		const state = log._v2Receive._receiveStates.get(remoteHash)!;
+		clearTimeout(state.requestTimer);
+		state.requestTimer = undefined;
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(16),
+			sequence: 1n,
+			segments: [],
+		});
+		await log.onMessage(full, context(senderSessionA, 11n));
+		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+
+		await log.onMessage(
+			new SyncCapabilitiesMessage({
+				capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+			}),
+			context(senderSessionB, 20n),
+		);
+		expect(state.controller.signal.aborted).to.be.true;
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
+		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.false;
+		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
+			senderSessionB,
+		);
+
+		await log.onMessage(
+			new SyncCapabilitiesMessage({ capabilities: senderCapabilities }),
+			context(senderSessionA, 10n),
+		);
+		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
+			senderSessionB,
+		);
+		await log.onMessage(full, context(senderSessionA, 30n));
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
+	});
+
+	it("commits first-Full cutover before fallible local bookkeeping", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiveEpoch = log._peerSessions.receiveEpoch(remoteHash);
+		const receiverTransportSession = BigInt(log.node.services.pubsub.session);
+		const senderTransportSession = 4_101n;
+		const send = sinon.stub(log.rpc, "send").resolves([] as any);
+		log._peerSyncCapabilities.set(remoteHash, senderCapabilities);
+		log._peerSyncCapabilitySessions.set(remoteHash, senderTransportSession);
+		log._peerSyncCapabilityTimestamps.set(remoteHash, 1n);
+		expect(
+			log._v2Receive.markLocalCapabilityReady({
+				peerHash: remoteHash,
+				peerSession,
+				receiveEpoch,
+				receiverTransportSession,
+				requestNotBeforeMs: 0,
+			}),
+		).to.be.true;
+		expect(
+			log._v2Receive.observeCapability({
+				peerHash: remoteHash,
+				target: remote,
+				peerSession,
+				receiveEpoch,
+				capabilities: senderCapabilities,
+				senderTransportSession,
+				capabilityTimestamp: 1n,
+			}),
+		).to.be.true;
+		const state = log._v2Receive._receiveStates.get(remoteHash)!;
+		clearTimeout(state.requestTimer);
+		state.requestTimer = undefined;
+		const senderEpoch = bytes(18);
+		const range = new ReplicationRangeMessageU64({
+			id: bytes(19),
+			offset: 10n,
+			factor: 10n,
+			timestamp: 10n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const context = {
+			from: remote,
+			message: {
+				header: { session: senderTransportSession, timestamp: 100n },
+			},
+		} as any;
+		const bookkeepingFailure = sinon
+			.stub(log.replicationChangeDebounceFn, "add")
+			.throws(new Error("post-durable bookkeeping failed"));
+		try {
+			await log.onMessage(
+				new FullReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 1n,
+					segments: [range],
+				}),
+				context,
+			);
+		} finally {
+			bookkeepingFailure.restore();
+		}
+
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+		expect(state.lastSequence).to.equal(1n);
+		expect(state.phase).to.equal("resync");
+		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+		await waitForResolved(() => expect(send.called).to.be.true);
+
+		await log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 2n,
+				segments: [range],
+			}),
+			context,
+		);
+		expect(state.lastSequence).to.equal(2n);
+		expect(state.phase).to.equal("active");
+	});
+
+	it("rolls back stale Full and Stopped deletions after transport revocation", async () => {
+		session = await TestSession.disconnected(2);
+		for (const [caseIndex, kind] of ["full", "stopped"].entries()) {
+			const db = await session.peers[0].open(new EventStore(), {
+				args: { replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const log = db.log as any;
+			const remote = session.peers[1].identity.publicKey;
+			const remoteHash = remote.hashcode();
+			const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+			log._peerSessions.unblockReplicationInfo(remoteHash);
+			log._peerSessions.markOpen(remoteHash, peerSession);
+			const receiveEpoch = log._peerSessions.receiveEpoch(remoteHash);
+			const receiverTransportSession = BigInt(log.node.services.pubsub.session);
+			const senderTransportSession = 4_200n + BigInt(caseIndex);
+			log._peerSyncCapabilities.set(remoteHash, senderCapabilities);
+			log._peerSyncCapabilitySessions.set(remoteHash, senderTransportSession);
+			log._peerSyncCapabilityTimestamps.set(remoteHash, 1n);
+			expect(
+				log._v2Receive.markLocalCapabilityReady({
+					peerHash: remoteHash,
+					peerSession,
+					receiveEpoch,
+					receiverTransportSession,
+					requestNotBeforeMs: 0,
+				}),
+			).to.be.true;
+			expect(
+				log._v2Receive.observeCapability({
+					peerHash: remoteHash,
+					target: remote,
+					peerSession,
+					receiveEpoch,
+					capabilities: senderCapabilities,
+					senderTransportSession,
+					capabilityTimestamp: 1n,
+				}),
+			).to.be.true;
+			const state = log._v2Receive._receiveStates.get(remoteHash)!;
+			clearTimeout(state.requestTimer);
+			state.requestTimer = undefined;
+			const senderEpoch = bytes(25 + caseIndex);
+			const range = new ReplicationRangeMessageU64({
+				id: bytes(27 + caseIndex),
+				offset: 10n,
+				factor: 10n,
+				timestamp: 10n,
+				mode: ReplicationIntent.NonStrict,
+			});
+			const context = (transportSession: bigint, timestamp: bigint) =>
+				({
+					from: remote,
+					message: { header: { session: transportSession, timestamp } },
+				}) as any;
+			await log.onMessage(
+				new FullReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 1n,
+					segments: [range],
+				}),
+				context(senderTransportSession, 10n),
+			);
+			expect(
+				await log.replicationIndex.count({ query: { hash: remoteHash } }),
+			).to.equal(1);
+
+			const deleteCommitted = pDefer<void>();
+			const releaseDelete = pDefer<void>();
+			const originalDelete = log.replicationIndex.del.bind(
+				log.replicationIndex,
+			);
+			const durableDelete = sinon
+				.stub(log.replicationIndex, "del")
+				.callsFake(async (...args: unknown[]) => {
+					const result = await originalDelete(...args);
+					deleteCommitted.resolve();
+					await releaseDelete.promise;
+					return result;
+				});
+			const nativeRestore = sinon.spy(log, "putNativeReplicationRange");
+			const activity = sinon.spy(log._liveness, "markReplicatorActivity");
+			let changes = 0;
+			const onChange = () => {
+				changes++;
+			};
+			log.events.addEventListener("replication:change", onChange);
+			const staleMessage =
+				kind === "full"
+					? new FullReplicationInfoV2Message({
+							receiverChallenge: state.receiverBinding!.slice(),
+							senderEpoch,
+							sequence: 2n,
+							segments: [],
+						})
+					: new StoppedReplicationInfoV2Message({
+							receiverChallenge: state.receiverBinding!.slice(),
+							senderEpoch,
+							sequence: 2n,
+							segmentIds: [range.id],
+						});
+			try {
+				const stale = log.onMessage(
+					staleMessage,
+					context(senderTransportSession, 20n),
+				);
+				await deleteCommitted.promise;
+				await log.onMessage(
+					new SyncCapabilitiesMessage({
+						capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+					}),
+					context(senderTransportSession + 100n, 30n),
+				);
+				activity.resetHistory();
+				releaseDelete.resolve();
+				await stale;
+			} finally {
+				releaseDelete.resolve();
+				log.events.removeEventListener("replication:change", onChange);
+				durableDelete.restore();
+			}
+			expect(state.controller.signal.aborted).to.be.true;
+			expect(state.lastSequence).to.equal(1n);
+			expect(
+				await log.replicationIndex.count({ query: { hash: remoteHash } }),
+			).to.equal(1);
+			expect(log.uniqueReplicators.has(remoteHash)).to.be.true;
+			expect(nativeRestore.called).to.be.true;
+			expect(activity.notCalled).to.be.true;
+			expect(changes).to.equal(0);
+		}
+	});
+
+	it("applies sequence order, cuts over legacy and recovers a gap with Full", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const receiveEpoch = log._peerSessions.receiveEpoch(remoteHash);
+		const localTransportSession = BigInt(log.node.services.pubsub.session);
+		const remoteTransportSession = 0x20000000000003n;
+		const send = sinon.stub(log.rpc, "send").resolves([] as any);
+		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
+		log._peerSyncCapabilities.set(remoteHash, senderCapabilities);
+		log._peerSyncCapabilitySessions.set(remoteHash, remoteTransportSession);
+		log._peerSyncCapabilityTimestamps.set(remoteHash, 1n);
+
+		expect(
+			log._v2Receive.markLocalCapabilityReady({
+				peerHash: remoteHash,
+				peerSession,
+				receiveEpoch,
+				receiverTransportSession: localTransportSession,
+				requestNotBeforeMs: Date.now(),
+			}),
+		).to.be.true;
+		expect(
+			log._v2Receive.observeCapability({
+				peerHash: remoteHash,
+				target: remote,
+				peerSession,
+				receiveEpoch,
+				capabilities: senderCapabilities,
+				senderTransportSession: remoteTransportSession,
+				capabilityTimestamp: 1n,
+			}),
+		).to.be.true;
+		const state = log._v2Receive._receiveStates.get(remoteHash)!;
+		clearTimeout(state.requestTimer);
+		state.requestTimer = undefined;
+		const localReady =
+			log._v2Receive._localCapabilityReadyBySession.get(peerSession);
+		localReady.requestNotBeforeMs = 0;
+		const senderEpoch = bytes(7);
+		const rangeA = new ReplicationRangeMessageU64({
+			id: bytes(8),
+			offset: 10n,
+			factor: 10n,
+			timestamp: 10n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const rangeB = new ReplicationRangeMessageU64({
+			id: bytes(9),
+			offset: 30n,
+			factor: 10n,
+			timestamp: 11n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const rangeC = new ReplicationRangeMessageU64({
+			id: bytes(10),
+			offset: 50n,
+			factor: 10n,
+			timestamp: 12n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const context = (timestamp: bigint) =>
+			({
+				from: remote,
+				message: {
+					header: { session: remoteTransportSession, timestamp },
+				},
+			}) as any;
+
+		const releaseCutoverLane = pDefer<void>();
+		let cutoverLaneEntered = false;
+		const cutoverLaneBlocker = log.withReplicationInfoApplyQueue(
+			remoteHash,
+			async () => {
+				cutoverLaneEntered = true;
+				await releaseCutoverLane.promise;
+			},
+		);
+		await waitForResolved(() => expect(cutoverLaneEntered).to.be.true);
+		const initialFull = log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 1n,
+				segments: [rangeA],
+			}),
+			context(100n),
+		);
+		await waitForResolved(() => expect(state.reservedAdmission).to.exist);
+		const originalLegacyHandler =
+			log.handleReplicationInfoAnnouncement.bind(log);
+		const legacyQueued = pDefer<void>();
+		const legacyHandler = sinon
+			.stub(log, "handleReplicationInfoAnnouncement")
+			.callsFake((...args: unknown[]) => {
+				const result = originalLegacyHandler(...args);
+				legacyQueued.resolve();
+				return result;
+			});
+		const legacyAcrossCutover = log.onMessage(
+			new AddedReplicationSegmentMessage({ segments: [rangeB] }),
+			context(150n),
+		);
+		await legacyQueued.promise;
+		legacyHandler.restore();
+		releaseCutoverLane.resolve();
+		await cutoverLaneBlocker;
+		await Promise.all([initialFull, legacyAcrossCutover]);
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(1n);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+		expect(activity.calledOnceWith(remoteHash)).to.be.true;
+		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+		expect(state.legacyFallbackTimer).to.exist;
+		expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
+
+		activity.resetHistory();
+		await log.onMessage(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 2n,
+				segments: [rangeB],
+			}),
+			context(1n),
+		);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(2);
+		expect(activity.calledOnceWith(remoteHash)).to.be.true;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+
+		activity.resetHistory();
+		await log.onMessage(
+			new StoppedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 3n,
+				segmentIds: [bytes(99)],
+			}),
+			context(201n),
+		);
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(3n);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(2);
+
+		await log.onMessage(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 4n,
+				segments: [rangeC],
+			}),
+			context(202n),
+		);
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(4n);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(3);
+
+		activity.resetHistory();
+		await log.onMessage(
+			new AllReplicatingSegmentsMessage({ segments: [] }),
+			context(1_000n),
+		);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(3);
+		expect(activity.notCalled).to.be.true;
+		expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
+
+		activity.resetHistory();
+		await log.onMessage(
+			new StoppedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 6n,
+				segmentIds: [rangeA.id],
+			}),
+			context(0n),
+		);
+		expect(state.phase).to.equal("resync");
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(3);
+		expect(activity.notCalled).to.be.true;
+		await waitForResolved(() => expect(send.calledOnce).to.be.true);
+		expect([...send.firstCall.args[0].receiverChallenge]).to.deep.equal([
+			...state.receiverRequestChallenge,
+		]);
+
+		send.resetHistory();
+		await log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 7n,
+				segments: [rangeB],
+			}),
+			context(0n),
+		);
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(7n);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+
+		activity.resetHistory();
+		await log.onMessage(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 3n,
+				segments: [rangeA],
+			}),
+			context(10_000n),
+		);
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+		expect(activity.notCalled).to.be.true;
+
+		const parkedLane = pDefer<void>();
+		let laneEntered = false;
+		const blocker = log.withReplicationInfoApplyQueue(remoteHash, async () => {
+			laneEntered = true;
+			await parkedLane.promise;
+		});
+		await waitForResolved(() => expect(laneEntered).to.be.true);
+		activity.resetHistory();
+		const parkedDelta = log.onMessage(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 8n,
+				segments: [rangeA],
+			}),
+			context(20_000n),
+		);
+		await Promise.resolve();
+		const challengeBeforeRecovery = state.receiverRequestChallenge.slice();
+		log.advanceReplicationInfoRecoveryEpoch(remoteHash);
+		parkedLane.resolve();
+		await blocker;
+		await parkedDelta;
+
+		expect(state.phase).to.equal("resync");
+		expect(state.lastSequence).to.equal(7n);
+		expect([...state.receiverRequestChallenge]).to.deep.equal([
+			...challengeBeforeRecovery,
+		]);
+		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+		expect(activity.notCalled).to.be.true;
+
+		await log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 9n,
+				segments: [rangeB],
+			}),
+			context(30_000n),
+		);
+		expect(state.phase).to.equal("active");
+
+		const removalDebounce = sinon.spy(log.replicationChangeDebounceFn, "add");
+		const stoppedDeleteCommitted = pDefer<void>();
+		const releaseStoppedDelete = pDefer<void>();
+		const originalDelete = log.replicationIndex.del.bind(log.replicationIndex);
+		const stoppedDelete = sinon
+			.stub(log.replicationIndex, "del")
+			.callsFake(async (...args: unknown[]) => {
+				const result = await originalDelete(...args);
+				stoppedDeleteCommitted.resolve();
+				await releaseStoppedDelete.promise;
+				return result;
+			});
+		let overlappingStopped: Promise<void> | undefined;
+		try {
+			overlappingStopped = log.onMessage(
+				new StoppedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 10n,
+					segmentIds: [rangeB.id],
+				}),
+				context(31_000n),
+			);
+			await stoppedDeleteCommitted.promise;
+			const stoppedAdmission = state.reservedAdmission;
+			expect(stoppedAdmission).to.exist;
+			await log.onMessage(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 11n,
+					segments: [rangeA],
+				}),
+				context(32_000n),
+			);
+			expect(stoppedAdmission.resyncAfterRelease).to.be.true;
+			releaseStoppedDelete.resolve();
+			await overlappingStopped;
+		} finally {
+			releaseStoppedDelete.resolve();
+			await overlappingStopped?.catch(() => {});
+			stoppedDelete.restore();
+		}
+		expect(state.lastSequence).to.equal(10n);
+		expect(state.phase).to.equal("resync");
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(0);
+		const removedChanges = removalDebounce
+			.getCalls()
+			.map((call) => call.args[0])
+			.filter((change) => change.type === "removed");
+		expect(removedChanges).to.have.length(1);
+		expect(removedChanges[0].range.idString).to.equal(
+			rangeB.toReplicationRangeIndexable(remote).idString,
+		);
+		removalDebounce.restore();
+
+		await log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 12n,
+				segments: [rangeB],
+			}),
+			context(33_000n),
+		);
+		expect(state.phase).to.equal("active");
+
+		const putCommitted = pDefer<void>();
+		const releasePut = pDefer<void>();
+		const originalPut = log.replicationIndex.put.bind(log.replicationIndex);
+		const put = sinon
+			.stub(log.replicationIndex, "put")
+			.callsFake(async (range: any) => {
+				const result = await originalPut(range);
+				if (
+					range.idString === rangeA.toReplicationRangeIndexable(remote).idString
+				) {
+					putCommitted.resolve();
+					await releasePut.promise;
+				}
+				return result;
+			});
+		const staleDuringDurablePut = log.onMessage(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 13n,
+				segments: [rangeA],
+			}),
+			context(40_000n),
+		);
+		await putCommitted.promise;
+		await log.onMessage(
+			new SyncCapabilitiesMessage({
+				capabilities: SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
+			}),
+			{
+				from: remote,
+				message: {
+					header: {
+						session: remoteTransportSession + 1n,
+						timestamp: 50_000n,
+					},
+				},
+			} as any,
+		);
+		releasePut.resolve();
+		await staleDuringDurablePut;
+		put.restore();
+		expect(state.controller.signal.aborted).to.be.true;
+		expect(
+			await log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(1);
+	});
+});

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -13,8 +13,8 @@ import {
 } from "../src/exchange-heads.js";
 import {
 	ReplicationInfoV2SendCoordinator,
-	deriveReplicationInfoV2ReceiverBinding,
 	type ReplicationInfoV2SendState,
+	deriveReplicationInfoV2ReceiverBinding,
 } from "../src/replication-info-v2-send.js";
 import {
 	AddedReplicationInfoV2Message,
@@ -63,6 +63,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 			from,
 			peerSession,
 			receiverTransportSession: BigInt(from.publicKey[0]),
+			capabilityTimestamp: 1n,
 			requestTimestamp,
 		});
 
@@ -187,9 +188,8 @@ describe("receive admission replication-info V2 sender streams", () => {
 		const firstState = coordinator._sendStates.get(peerA.hashcode())!;
 
 		for (let index = 0; index < 10_000; index++) {
-			expect(
-				accept(peerA, peerSession, challenge(8), 21n + BigInt(index)),
-			).to.be.false;
+			expect(accept(peerA, peerSession, challenge(8), 21n + BigInt(index))).to
+				.be.false;
 		}
 		expect(getSegments.calledOnce).to.be.true;
 		expect(rpcSend.notCalled).to.be.true;
@@ -225,9 +225,8 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(drainSettled).to.be.false;
 		for (let index = 0; index < 10_000; index++) {
 			coordinator.advancePeerCapability(peerA.hashcode());
-			expect(
-				accept(peerA, peerSession, challenge(19), 31n + BigInt(index)),
-			).to.be.false;
+			expect(accept(peerA, peerSession, challenge(19), 31n + BigInt(index))).to
+				.be.false;
 		}
 		expect(getSegments.calledOnce).to.be.true;
 		expect(rpcSend.notCalled).to.be.true;
@@ -539,10 +538,11 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(activity.notCalled).to.be.true;
 
 		await log.onMessage(request, context(receiverTransportSession, 3n));
-		await waitForResolved(() =>
-			expect(
-				send.calledWith(sinon.match.instanceOf(FullReplicationInfoV2Message)),
-			).to.be.true,
+		await waitForResolved(
+			() =>
+				expect(
+					send.calledWith(sinon.match.instanceOf(FullReplicationInfoV2Message)),
+				).to.be.true,
 		);
 		expect(activity.calledOnceWith(remoteHash)).to.be.true;
 		const state = log._v2Send._sendStates.get(remoteHash);
@@ -604,7 +604,7 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(v2!.sequence).to.equal(2n);
 	});
 
-	it("keeps capabilities monotonic and fences the previous grant generation", async () => {
+	it("uses a newer capability to authorize one bounded challenge rebind", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: false, timeUntilRoleMaturity: 0 },
@@ -638,23 +638,16 @@ describe("receive admission replication-info V2 sender integration", () => {
 				intendedSender: log.node.identity.publicKey,
 				senderSession: BigInt(log.node.services.pubsub.session),
 			});
+		const firstSend = pDefer<void>();
 		let blockFirst = true;
-		const send = sinon
-			.stub(log.rpc, "send")
-			.callsFake(async (_message, options: any) => {
-				if (!blockFirst) {
-					return [] as any;
-				}
-				blockFirst = false;
-				await new Promise<void>((_resolve, reject) => {
-					options.signal.addEventListener(
-						"abort",
-						() => reject(new Error("capability generation advanced")),
-						{ once: true },
-					);
-				});
+		const send = sinon.stub(log.rpc, "send").callsFake(async () => {
+			if (!blockFirst) {
 				return [] as any;
-			});
+			}
+			blockFirst = false;
+			await firstSend.promise;
+			return [] as any;
+		});
 
 		await log.onMessage(request(30), context(11n));
 		await waitForResolved(() => expect(send.calledOnce).to.be.true);
@@ -662,15 +655,15 @@ describe("receive admission replication-info V2 sender integration", () => {
 			new SyncCapabilitiesMessage({ capabilities: 0 }),
 			context(12n),
 		);
-		expect(log._v2Send._sendStates.size).to.equal(0);
+		expect(log._v2Send._sendStates.size).to.equal(1);
 		expect(
 			log._peerSyncCapabilities.get(remoteHash) &
 				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
 		).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY);
 		expect(log._peerSyncCapabilityTimestamps.get(remoteHash)).to.equal(12n);
-		await waitForResolved(() =>
-			expect(log._v2Send._retiringWorkersByPeer.size).to.equal(0),
-		);
+		expect(log._v2Send._retiringWorkersByPeer.size).to.equal(0);
+		firstSend.resolve();
+		await log._v2Send.drain();
 
 		await log.onMessage(request(30), context(11n));
 		expect(send.calledOnce).to.be.true;
@@ -678,8 +671,13 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(send.calledOnce).to.be.true;
 		await log.onMessage(request(31), context(13n));
 		await waitForResolved(() => expect(send.callCount).to.equal(2));
+		await log.onMessage(request(30), context(13n));
+		expect(send.callCount).to.equal(2);
 		await log._v2Send.drain();
 		expect(log._v2Send._sendStates.get(remoteHash)?.established).to.be.true;
+		expect([
+			...log._v2Send._sendStates.get(remoteHash)!.receiverRequestChallenge,
+		]).to.deep.equal([...challenge(31)]);
 	});
 
 	it("keeps opening-barrier capabilities monotonic within a signed session", async () => {

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -807,6 +807,12 @@ describe("waitForReplicator liveness", () => {
 		const resolvePublicKey = sinon
 			.stub(log, "_resolvePublicKeyFromHash")
 			.resolves(undefined);
+		// This test isolates the legacy receive-epoch fence. Once a B10 peer has
+		// committed V2 Full, ignoring later legacy snapshots is correct and V2
+		// recovery owns relearning; that path is covered by the V2 receiver suite.
+		const forceLegacyReceivePath = sinon
+			.stub(log._v2Receive, "isLegacyCutover")
+			.returns(false);
 
 		try {
 			const delayedSnapshotReceive = db0.log.onMessage(delayedSnapshot, {
@@ -871,6 +877,7 @@ describe("waitForReplicator liveness", () => {
 			releaseStoppedSynchronizer.resolve();
 			synchronizer.restore();
 			resolvePublicKey.restore();
+			forceLegacyReceivePath.restore();
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- activate authenticated, receiver-led replication-info V2 negotiation and apply
- bind grants to both peers and transport sessions with sender epoch/sequence ordering
- fence lifecycle, reconnect, overlap, and durable mutation races with bounded recovery
- retain a session-scoped legacy compatibility fallback for mixed B9/B10 rollout

## Validation

- `@peerbit/shared-log` build
- full shared-log Node suite: 2,432 passing, 10 pending
- focused replication-info V2 suite: 52 passing
- receive-admission suite: 94 passing
- events suite: 91 passing

Includes a patch changeset for `@peerbit/shared-log`.
