### PR TITLE
feat(shared-log): make v2 recovery self-healing

### DIFF
--- a/.changeset/v2-independent-recovery.md
+++ b/.changeset/v2-independent-recovery.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Make authenticated replication-info V2 negotiation and destination streams recover independently of legacy sidecars.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -3415,6 +3415,8 @@ export class SharedLog<
 			validatePersistedReplicationRangeSnapshot: (ranges) =>
 				this.validatePersistedReplicationRangeSnapshot(ranges),
 			isClosed: () => this.closed,
+			isPeerSessionCurrent: (peerHash, peerSession) =>
+				this._peerSessions.isCurrent(peerHash, peerSession),
 			isPeerSessionOpen: (peerHash, peerSession) =>
 				this._peerSessions.isCurrent(peerHash, peerSession) &&
 				(peerSession as PeerSession).phase === "open" &&
@@ -3495,6 +3497,12 @@ export class SharedLog<
 					(this.node.services.pubsub as unknown as { session: number }).session,
 				),
 			isClosed: () => this.closed,
+			isPeerSessionCurrent: (peerHash, peerSession) =>
+				this._peerSessions.isCurrent(peerHash, peerSession) &&
+				(peerSession as PeerSession).phase === "open" &&
+				(peerSession as PeerSession).isActive(),
+			isReceiveEpochCurrent: (peerHash, receiveEpoch) =>
+				this._peerSessions.isReceiveEpochCurrent(peerHash, receiveEpoch),
 			isPeerStateCurrent: (peerHash, peerSession, receiveEpoch) =>
 				this._peerSessions.isCurrent(peerHash, peerSession) &&
 				(peerSession as PeerSession).phase === "open" &&
@@ -3532,6 +3540,8 @@ export class SharedLog<
 					}`,
 				);
 			},
+			onLocalCapabilityError: (error) =>
+				this.handleReplicationLifecycleSendError(error),
 		});
 	}
 
@@ -6527,10 +6537,16 @@ export class SharedLog<
 				// deliver the authoritative Full that completes recovery.
 				const peerSession = this._peerSessions.current(keyHash);
 				if (peerSession?.phase === "open") {
+					const receiveEpoch = this._peerSessions.receiveEpoch(keyHash);
 					this._v2Receive.advanceRecovery({
 						peerHash: keyHash,
 						peerSession,
-						receiveEpoch: this._peerSessions.receiveEpoch(keyHash),
+						receiveEpoch,
+					});
+					this._v2Receive.reAdvertiseLocalCapabilityForRecovery({
+						peerHash: keyHash,
+						peerSession,
+						receiveEpoch,
 					});
 				}
 			}
@@ -23548,76 +23564,46 @@ export class SharedLog<
 			expectedSubscriptionEpoch,
 		);
 
-		// Decode, sender and authenticated apply readiness are separate bits. Start
-		// the ACKed receiver-led negotiation before the legacy snapshot, but do not
-		// hold mixed-version replication discovery behind that round trip. Attach
-		// the rejection handler now because a lifecycle fence below may return before
-		// awaiting the advert. RequestV2 is armed only after both sends settle.
+		// Decode, sender and authenticated apply readiness are separate bits. An
+		// ACKed capability advert is the local half of receiver-led negotiation;
+		// readiness is promoted only after the legacy startup path has completed.
+		// This preserves mixed-version discovery without putting capability ACK
+		// latency on the subscription callback's critical path.
 		const receiveEpoch = this._peerSessions.receiveEpoch(peerHash);
 		const localCapabilityAdvertisement =
-			this.advertiseReplicationInfoV2ReceiveCapability({
+			this._v2Receive.advertiseLocalCapability({
 				target: publicKey,
 				peerSession: expectedSubscriptionEpoch,
 				receiveEpoch,
 				signal: replicationLifecycleController.signal,
-			}).catch((error) => {
-				this.handleReplicationLifecycleSendError(
-					error,
-					replicationLifecycleController,
-				);
-				return undefined;
 			});
 
-		let replicationSegments: ReplicationRangeIndexable<R>[];
 		try {
-			replicationSegments = await this.getMyReplicationSegments();
-		} catch (error) {
-			if (
-				!this.isReplicationLifecycleActive(replicationLifecycleController) &&
-				isNotStartedError(error as Error)
-			) {
-				return;
+			let replicationSegments: ReplicationRangeIndexable<R>[];
+			try {
+				replicationSegments = await this.getMyReplicationSegments();
+			} catch (error) {
+				if (
+					!this.isReplicationLifecycleActive(replicationLifecycleController) &&
+					isNotStartedError(error as Error)
+				) {
+					return;
+				}
+				throw error;
 			}
-			throw error;
-		}
-		if (
-			!this.isReplicationLifecycleActive(replicationLifecycleController) ||
-			!ownsSubscriptionEpoch()
-		) {
-			return;
-		}
-		if (replicationSegments.length > 0) {
-			const segments = replicationSegments.map((x) => x.toReplicationRange());
-			this.validatePersistedReplicationRangeSnapshot(segments);
-			await this.rpc
-				.send(
-					new AllReplicatingSegmentsMessage({
-						segments,
-					}),
-					{
-						mode: new AcknowledgeDelivery({ redundancy: 1, to: [publicKey] }),
-						signal: replicationLifecycleController.signal,
-					},
-				)
-				.catch((error) =>
-					this.handleReplicationLifecycleSendError(
-						error,
-						replicationLifecycleController,
-					),
-				);
 			if (
 				!this.isReplicationLifecycleActive(replicationLifecycleController) ||
 				!ownsSubscriptionEpoch()
 			) {
 				return;
 			}
-
-			if (this.v8Behaviour) {
-				// for backwards compatibility
+			if (replicationSegments.length > 0) {
+				const segments = replicationSegments.map((x) => x.toReplicationRange());
+				this.validatePersistedReplicationRangeSnapshot(segments);
 				await this.rpc
 					.send(
-						new ResponseRoleMessage({
-							role: this.getRoleFromReplicationSegments(replicationSegments),
+						new AllReplicatingSegmentsMessage({
+							segments,
 						}),
 						{
 							mode: new AcknowledgeDelivery({
@@ -23633,30 +23619,51 @@ export class SharedLog<
 							replicationLifecycleController,
 						),
 					);
+				if (
+					!this.isReplicationLifecycleActive(replicationLifecycleController) ||
+					!ownsSubscriptionEpoch()
+				) {
+					return;
+				}
+
+				if (this.v8Behaviour) {
+					// for backwards compatibility
+					await this.rpc
+						.send(
+							new ResponseRoleMessage({
+								role: this.getRoleFromReplicationSegments(replicationSegments),
+							}),
+							{
+								mode: new AcknowledgeDelivery({
+									redundancy: 1,
+									to: [publicKey],
+								}),
+								signal: replicationLifecycleController.signal,
+							},
+						)
+						.catch((error) =>
+							this.handleReplicationLifecycleSendError(
+								error,
+								replicationLifecycleController,
+							),
+						);
+				}
 			}
-		}
 
-		// Keep legacy request-based discovery independent of the capability ACK too.
-		// This makes mixed-version joins resilient to timing-sensitive delivery/order
-		// issues where we may miss the remote peer's initial announcement.
-		if (
-			this.isReplicationLifecycleActive(replicationLifecycleController) &&
-			ownsSubscriptionEpoch()
-		) {
-			this.scheduleReplicationInfoRequests(
-				publicKey,
-				replicationLifecycleController,
-			);
-		}
-
-		const localCapabilityReady = await localCapabilityAdvertisement;
-		if (localCapabilityReady) {
-			this._v2Receive.markLocalCapabilityReady({
-				peerHash,
-				peerSession: expectedSubscriptionEpoch,
-				receiveEpoch,
-				...localCapabilityReady,
-			});
+			// Keep legacy request-based discovery independent of the capability ACK.
+			// This makes mixed-version joins resilient to timing-sensitive delivery/order
+			// issues where we may miss the remote peer's initial announcement.
+			if (
+				this.isReplicationLifecycleActive(replicationLifecycleController) &&
+				ownsSubscriptionEpoch()
+			) {
+				this.scheduleReplicationInfoRequests(
+					publicKey,
+					replicationLifecycleController,
+				);
+			}
+		} finally {
+			localCapabilityAdvertisement.releaseLegacyBarrier();
 		}
 	}
 

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -25,6 +25,7 @@ const DEFAULT_MAX_REQUEST_RETRY_MS = 30_000;
 const DEFAULT_REQUEST_MAX_ATTEMPTS = 7;
 const DEFAULT_LEGACY_FALLBACK_DELAY_MS = 5_000;
 const MAX_U64 = (1n << 64n) - 1n;
+const MAX_BACKOFF_EXPONENT = 20;
 
 const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
 	if (left.byteLength !== right.byteLength) {
@@ -64,6 +65,7 @@ export type ReplicationInfoV2ReceivePhase =
 
 type LocalCapabilityReady = {
 	peerHash: string;
+	receiveEpoch: object | null;
 	receiverTransportSession: bigint;
 	/**
 	 * The local capability envelope and the later RequestV2 envelope use the
@@ -71,6 +73,45 @@ type LocalCapabilityReady = {
 	 * be strictly newer, so never construct it in this captured millisecond.
 	 */
 	requestNotBeforeMs: number;
+	advertisement?: ReplicationInfoV2LocalCapabilityAdvertisement;
+};
+
+type LocalCapabilityReadyProperties = {
+	peerHash: string;
+	peerSession: object;
+	receiveEpoch: object | null;
+	receiverTransportSession: bigint;
+	requestNotBeforeMs: number;
+};
+
+export type ReplicationInfoV2LocalCapabilityAdvertisementHandle = {
+	firstAttempt: Promise<void>;
+	releaseLegacyBarrier(): void;
+};
+
+export type ReplicationInfoV2LocalCapabilityContext = {
+	peerHash: string;
+	target: PublicSignKey;
+	lifecycleSignal: AbortSignal;
+	legacyBarrierReleased: boolean;
+};
+
+export type ReplicationInfoV2LocalCapabilityAdvertisement = {
+	peerHash: string;
+	target: PublicSignKey;
+	peerSession: object;
+	receiveEpoch: object | null;
+	lifecycleSignal: AbortSignal;
+	onLifecycleAbort: () => void;
+	controller: AbortController;
+	context: ReplicationInfoV2LocalCapabilityContext;
+	attempts: number;
+	ready: boolean;
+	acknowledgedReady?: LocalCapabilityReady;
+	receiverTransportSession?: bigint;
+	timer?: ReturnType<typeof setTimeout>;
+	inFlight?: Promise<void>;
+	firstAttempt?: Promise<void>;
 };
 
 export type ReplicationInfoV2LocalCapabilityRefresh = {
@@ -131,6 +172,11 @@ export type ReplicationInfoV2ReceiveDeps = {
 	getSelfKey: () => PublicSignKey;
 	getReceiverTransportSession: () => bigint;
 	isClosed: () => boolean;
+	isPeerSessionCurrent: (peerHash: string, peerSession: object) => boolean;
+	isReceiveEpochCurrent: (
+		peerHash: string,
+		receiveEpoch: object | null,
+	) => boolean;
 	isPeerStateCurrent: (
 		peerHash: string,
 		peerSession: object,
@@ -153,6 +199,7 @@ export type ReplicationInfoV2ReceiveDeps = {
 		signal: AbortSignal;
 	}) => Promise<ReplicationInfoV2LocalCapabilityRefresh | undefined>;
 	onRequestError?: (error: unknown) => void;
+	onLocalCapabilityError?: (error: unknown) => void;
 	now?: () => number;
 	requestRetryMs?: number;
 	maxRequestRetryMs?: number;
@@ -169,6 +216,14 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	_receiveStates!: Map<string, ReplicationInfoV2ReceiveState>;
 	_cutoverPeerSessions!: WeakSet<object>;
 	_localCapabilityReadyBySession!: WeakMap<object, LocalCapabilityReady>;
+	_localCapabilityContextBySession!: WeakMap<
+		object,
+		ReplicationInfoV2LocalCapabilityContext
+	>;
+	_localCapabilityAdvertisementsByPeer!: Map<
+		string,
+		ReplicationInfoV2LocalCapabilityAdvertisement
+	>;
 	_reservedAdmissionsByPeer!: Map<string, ReplicationInfoV2ReceiveAdmission>;
 
 	private readonly now: () => number;
@@ -198,6 +253,8 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		this._receiveStates = new Map();
 		this._cutoverPeerSessions = new WeakSet();
 		this._localCapabilityReadyBySession = new WeakMap();
+		this._localCapabilityContextBySession = new WeakMap();
+		this._localCapabilityAdvertisementsByPeer = new Map();
 		this._reservedAdmissionsByPeer = new Map();
 	}
 
@@ -206,27 +263,46 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		this._receiveStates = new Map();
 		this._cutoverPeerSessions = new WeakSet();
 		this._localCapabilityReadyBySession = new WeakMap();
+		this._localCapabilityContextBySession = new WeakMap();
+		this._localCapabilityAdvertisementsByPeer = new Map();
 		this._reservedAdmissionsByPeer = new Map();
 	}
 
 	clearForClose(): void {
+		for (const advertisement of [
+			...(this._localCapabilityAdvertisementsByPeer?.values() ?? []),
+		]) {
+			this.clearLocalCapabilityAdvertisement(advertisement);
+		}
+		this._localCapabilityAdvertisementsByPeer?.clear();
 		for (const state of this._receiveStates?.values() ?? []) {
 			this.clearState(state);
 		}
 		this._receiveStates?.clear();
 		this._cutoverPeerSessions = new WeakSet();
 		this._localCapabilityReadyBySession = new WeakMap();
+		this._localCapabilityContextBySession = new WeakMap();
 	}
 
 	clearPeer(peerHash: string, expectedSession?: object): void {
+		const advertisement =
+			this._localCapabilityAdvertisementsByPeer.get(peerHash);
+		if (
+			advertisement &&
+			(!expectedSession || advertisement.peerSession === expectedSession)
+		) {
+			this.clearLocalCapabilityAdvertisement(advertisement);
+		}
 		const state = this._receiveStates.get(peerHash);
 		if (state && (!expectedSession || state.peerSession === expectedSession)) {
 			this.clearState(state);
 			this._localCapabilityReadyBySession.delete(state.peerSession);
+			this._localCapabilityContextBySession.delete(state.peerSession);
 			this._cutoverPeerSessions.delete(state.peerSession);
 		}
 		if (expectedSession) {
 			this._localCapabilityReadyBySession.delete(expectedSession);
+			this._localCapabilityContextBySession.delete(expectedSession);
 			this._cutoverPeerSessions.delete(expectedSession);
 		}
 	}
@@ -259,14 +335,462 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		}
 	}
 
-	/** Record success of this session's ACKed local APPLY advertisement. */
-	markLocalCapabilityReady(properties: {
+	private clearLocalCapabilityAdvertisement(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+		options?: { preserveContext?: boolean },
+	): void {
+		if (state.timer) {
+			clearTimeout(state.timer);
+			state.timer = undefined;
+		}
+		state.lifecycleSignal.removeEventListener("abort", state.onLifecycleAbort);
+		state.controller.abort();
+		const wasMapped =
+			this._localCapabilityAdvertisementsByPeer.get(state.peerHash) === state;
+		if (wasMapped) {
+			this._localCapabilityAdvertisementsByPeer.delete(state.peerHash);
+		}
+		const ready = this._localCapabilityReadyBySession.get(state.peerSession);
+		if (ready?.advertisement === state) {
+			this._localCapabilityReadyBySession.delete(state.peerSession);
+		}
+		if (
+			wasMapped &&
+			!options?.preserveContext &&
+			this._localCapabilityContextBySession.get(state.peerSession) ===
+				state.context
+		) {
+			this._localCapabilityContextBySession.delete(state.peerSession);
+		}
+	}
+
+	private isLocalCapabilityAdvertisementOwnerCurrent(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): boolean {
+		return (
+			this._localCapabilityAdvertisementsByPeer.get(state.peerHash) === state &&
+			this._localCapabilityContextBySession.get(state.peerSession) ===
+				state.context &&
+			state.context.peerHash === state.peerHash &&
+			state.context.lifecycleSignal === state.lifecycleSignal &&
+			state.context.target.equals(state.target) &&
+			!state.controller.signal.aborted &&
+			!state.lifecycleSignal.aborted &&
+			!this.deps.isClosed() &&
+			this.deps.isPeerSessionCurrent(state.peerHash, state.peerSession) &&
+			(state.receiverTransportSession === undefined ||
+				this.deps.getReceiverTransportSession() ===
+					state.receiverTransportSession)
+		);
+	}
+
+	private isLocalCapabilityAdvertisementGenerationCurrent(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): boolean {
+		return (
+			this.isLocalCapabilityAdvertisementOwnerCurrent(state) &&
+			this.deps.isReceiveEpochCurrent(state.peerHash, state.receiveEpoch)
+		);
+	}
+
+	private isLocalCapabilityAdvertisementReadyOpen(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): boolean {
+		return (
+			this.isLocalCapabilityAdvertisementGenerationCurrent(state) &&
+			this.deps.isPeerStateCurrent(
+				state.peerHash,
+				state.peerSession,
+				state.receiveEpoch,
+			)
+		);
+	}
+
+	private localCapabilityRetryDelay(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): number {
+		const exponent = Math.max(0, state.attempts - 1);
+		return Math.min(
+			this.maxRequestRetryMs,
+			this.requestRetryMs * 2 ** Math.min(exponent, MAX_BACKOFF_EXPONENT),
+		);
+	}
+
+	private armLocalCapabilityAdvertisement(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): void {
+		if (state.timer || state.inFlight || state.ready) {
+			return;
+		}
+		if (state.acknowledgedReady && !state.context.legacyBarrierReleased) {
+			return;
+		}
+		if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+			this.clearLocalCapabilityAdvertisement(state);
+			return;
+		}
+		if (!this.isLocalCapabilityAdvertisementGenerationCurrent(state)) {
+			return;
+		}
+		state.timer = setTimeout(() => {
+			state.timer = undefined;
+			if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+				this.clearLocalCapabilityAdvertisement(state);
+				return;
+			}
+			if (!this.isLocalCapabilityAdvertisementGenerationCurrent(state)) {
+				return;
+			}
+			if (!this.isLocalCapabilityAdvertisementReadyOpen(state)) {
+				this.armLocalCapabilityAdvertisement(state);
+				return;
+			}
+			void this.runLocalCapabilityAdvertisement(state);
+		}, this.localCapabilityRetryDelay(state));
+		state.timer.unref?.();
+	}
+
+	private async runLocalCapabilityAdvertisement(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): Promise<void> {
+		if (state.inFlight) {
+			await state.inFlight;
+			return;
+		}
+		if (state.ready) {
+			return;
+		}
+		if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+			this.clearLocalCapabilityAdvertisement(state);
+			return;
+		}
+		if (!this.isLocalCapabilityAdvertisementGenerationCurrent(state)) {
+			return;
+		}
+		if (state.acknowledgedReady) {
+			if (state.context.legacyBarrierReleased) {
+				this.promoteLocalCapabilityAdvertisement(state);
+			}
+			return;
+		}
+		if (!this.isLocalCapabilityAdvertisementReadyOpen(state)) {
+			this.armLocalCapabilityAdvertisement(state);
+			return;
+		}
+		state.attempts = Math.min(state.attempts + 1, MAX_BACKOFF_EXPONENT + 1);
+		let operation: Promise<void>;
+		operation = (async () => {
+			const refreshed = await this.deps.refreshLocalCapability({
+				peerHash: state.peerHash,
+				target: state.target,
+				peerSession: state.peerSession,
+				receiveEpoch: state.receiveEpoch,
+				signal: AbortSignal.any([
+					state.controller.signal,
+					state.lifecycleSignal,
+				]),
+			});
+			if (
+				!refreshed ||
+				!this.isLocalCapabilityAdvertisementGenerationCurrent(state) ||
+				this.deps.getReceiverTransportSession() !==
+					refreshed.receiverTransportSession
+			) {
+				return;
+			}
+			state.receiverTransportSession = refreshed.receiverTransportSession;
+			state.acknowledgedReady = {
+				peerHash: state.peerHash,
+				receiveEpoch: state.receiveEpoch,
+				receiverTransportSession: refreshed.receiverTransportSession,
+				requestNotBeforeMs: refreshed.requestNotBeforeMs,
+				advertisement: state,
+			};
+			state.attempts = 0;
+			this.promoteLocalCapabilityAdvertisement(state);
+		})()
+			.catch((error) => {
+				if (
+					!state.controller.signal.aborted &&
+					!state.lifecycleSignal.aborted &&
+					!this.deps.isClosed()
+				) {
+					this.deps.onLocalCapabilityError?.(error);
+				}
+			})
+			.finally(() => {
+				if (state.inFlight === operation) {
+					state.inFlight = undefined;
+				}
+				if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+					this.clearLocalCapabilityAdvertisement(state);
+				} else if (
+					this.isLocalCapabilityAdvertisementGenerationCurrent(state) &&
+					!state.ready
+				) {
+					if (!state.acknowledgedReady || state.context.legacyBarrierReleased) {
+						this.armLocalCapabilityAdvertisement(state);
+					}
+				}
+			});
+		state.inFlight = operation;
+		await operation;
+	}
+
+	/**
+	 * Start local authenticated-apply advertisement independently of the legacy
+	 * join path. ACK and legacy publication are a two-phase barrier: the first
+	 * attempt always settles independently, while readiness is promoted only
+	 * after the host releases the legacy barrier. Failed attempts leave one
+	 * exact-session worker retrying with capped exponential backoff.
+	 */
+	advertiseLocalCapability(properties: {
+		target: PublicSignKey;
+		peerSession: object;
+		receiveEpoch: object | null;
+		signal: AbortSignal;
+	}): ReplicationInfoV2LocalCapabilityAdvertisementHandle {
+		const peerHash = properties.target.hashcode();
+		if (
+			properties.signal.aborted ||
+			this.deps.isClosed() ||
+			!this.deps.isPeerSessionCurrent(peerHash, properties.peerSession) ||
+			!this.deps.isReceiveEpochCurrent(peerHash, properties.receiveEpoch)
+		) {
+			return {
+				firstAttempt: Promise.resolve(),
+				releaseLegacyBarrier: () => {},
+			};
+		}
+		let context = this._localCapabilityContextBySession.get(
+			properties.peerSession,
+		);
+		if (
+			context &&
+			(context.peerHash !== peerHash ||
+				!context.target.equals(properties.target) ||
+				context.lifecycleSignal !== properties.signal)
+		) {
+			return {
+				firstAttempt: Promise.resolve(),
+				releaseLegacyBarrier: () => {},
+			};
+		}
+		if (!context) {
+			context = {
+				peerHash,
+				target: properties.target,
+				lifecycleSignal: properties.signal,
+				legacyBarrierReleased: false,
+			};
+			this._localCapabilityContextBySession.set(
+				properties.peerSession,
+				context,
+			);
+		}
+		let state = this._localCapabilityAdvertisementsByPeer.get(peerHash);
+		if (
+			state &&
+			(state.peerSession !== properties.peerSession ||
+				state.context !== context ||
+				state.lifecycleSignal !== properties.signal ||
+				!state.target.equals(properties.target))
+		) {
+			this.clearLocalCapabilityAdvertisement(state);
+			state = undefined;
+		}
+		if (state && state.receiveEpoch !== properties.receiveEpoch) {
+			this.clearLocalCapabilityAdvertisement(state, { preserveContext: true });
+			state = undefined;
+		}
+		if (state && !this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+			this.clearLocalCapabilityAdvertisement(state);
+			state = undefined;
+		}
+		if (
+			this._localCapabilityContextBySession.get(properties.peerSession) !==
+			context
+		) {
+			return {
+				firstAttempt: Promise.resolve(),
+				releaseLegacyBarrier: () => {},
+			};
+		}
+		if (!state) {
+			const controller = new AbortController();
+			const advertisement: ReplicationInfoV2LocalCapabilityAdvertisement = {
+				peerHash,
+				target: properties.target,
+				peerSession: properties.peerSession,
+				receiveEpoch: properties.receiveEpoch,
+				lifecycleSignal: properties.signal,
+				onLifecycleAbort: () => {},
+				controller,
+				context,
+				attempts: 0,
+				ready: false,
+				receiverTransportSession: this.deps.getReceiverTransportSession(),
+			};
+			advertisement.onLifecycleAbort = () =>
+				this.clearLocalCapabilityAdvertisement(advertisement);
+			properties.signal.addEventListener(
+				"abort",
+				advertisement.onLifecycleAbort,
+				{
+					once: true,
+				},
+			);
+			this._localCapabilityAdvertisementsByPeer.set(peerHash, advertisement);
+			state = advertisement;
+		}
+		const firstAttempt =
+			state.firstAttempt ??
+			(state.firstAttempt = this.runLocalCapabilityAdvertisement(state));
+		const advertisement = state;
+		return {
+			firstAttempt,
+			releaseLegacyBarrier: () =>
+				this.releaseLocalCapabilityLegacyBarrier(
+					advertisement.peerSession,
+					context,
+				),
+		};
+	}
+
+	private releaseLocalCapabilityLegacyBarrier(
+		peerSession: object,
+		context: ReplicationInfoV2LocalCapabilityContext,
+	): void {
+		if (context.legacyBarrierReleased) {
+			return;
+		}
+		if (
+			this._localCapabilityContextBySession.get(peerSession) !== context ||
+			context.lifecycleSignal.aborted ||
+			this.deps.isClosed() ||
+			!this.deps.isPeerSessionCurrent(context.peerHash, peerSession)
+		) {
+			return;
+		}
+		context.legacyBarrierReleased = true;
+		const state = this._localCapabilityAdvertisementsByPeer.get(
+			context.peerHash,
+		);
+		if (state?.peerSession === peerSession && state.context === context) {
+			if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
+				this.clearLocalCapabilityAdvertisement(state);
+				return;
+			}
+			this.promoteLocalCapabilityAdvertisement(state);
+		}
+	}
+
+	private promoteLocalCapabilityAdvertisement(
+		state: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): boolean {
+		const ready = state.acknowledgedReady;
+		if (
+			state.ready ||
+			!state.context.legacyBarrierReleased ||
+			!ready ||
+			ready.receiveEpoch !== state.receiveEpoch ||
+			ready.advertisement !== state ||
+			!this.isLocalCapabilityAdvertisementOwnerCurrent(state) ||
+			!this.isLocalCapabilityAdvertisementGenerationCurrent(state) ||
+			this.deps.getReceiverTransportSession() !== ready.receiverTransportSession
+		) {
+			return state.ready;
+		}
+		if (!this.isLocalCapabilityAdvertisementReadyOpen(state)) {
+			this.armLocalCapabilityAdvertisement(state);
+			return false;
+		}
+		if (
+			!this.recordLocalCapabilityReady(
+				{
+					peerHash: state.peerHash,
+					peerSession: state.peerSession,
+					receiveEpoch: state.receiveEpoch,
+					receiverTransportSession: ready.receiverTransportSession,
+					requestNotBeforeMs: ready.requestNotBeforeMs,
+				},
+				state,
+			)
+		) {
+			return false;
+		}
+		state.ready = true;
+		return true;
+	}
+
+	/**
+	 * Re-advertise one exact current recovery epoch from the stable membership
+	 * context captured during opening. The opening handle owns barrier release;
+	 * recovery never bypasses a legacy snapshot or role publication still in
+	 * progress.
+	 */
+	reAdvertiseLocalCapabilityForRecovery(properties: {
 		peerHash: string;
 		peerSession: object;
 		receiveEpoch: object | null;
-		receiverTransportSession: bigint;
-		requestNotBeforeMs: number;
 	}): boolean {
+		const context = this._localCapabilityContextBySession.get(
+			properties.peerSession,
+		);
+		if (
+			!context ||
+			context.peerHash !== properties.peerHash ||
+			context.lifecycleSignal.aborted ||
+			this.deps.isClosed() ||
+			!this.deps.isPeerSessionCurrent(
+				properties.peerHash,
+				properties.peerSession,
+			) ||
+			!this.deps.isReceiveEpochCurrent(
+				properties.peerHash,
+				properties.receiveEpoch,
+			)
+		) {
+			return false;
+		}
+		const state = this._receiveStates.get(properties.peerHash);
+		if (
+			state?.peerSession === properties.peerSession &&
+			state.receiveEpoch === properties.receiveEpoch &&
+			state.receiverBinding !== undefined
+		) {
+			return false;
+		}
+		const ready = this._localCapabilityReadyBySession.get(
+			properties.peerSession,
+		);
+		if (
+			ready?.peerHash === properties.peerHash &&
+			ready.receiveEpoch === properties.receiveEpoch &&
+			ready.receiverTransportSession === this.deps.getReceiverTransportSession()
+		) {
+			return false;
+		}
+		this.advertiseLocalCapability({
+			target: context.target,
+			peerSession: properties.peerSession,
+			receiveEpoch: properties.receiveEpoch,
+			signal: context.lifecycleSignal,
+		});
+		return true;
+	}
+
+	/** Record success of this session's ACKed local APPLY advertisement. */
+	markLocalCapabilityReady(
+		properties: LocalCapabilityReadyProperties,
+	): boolean {
+		return this.recordLocalCapabilityReady(properties);
+	}
+
+	private recordLocalCapabilityReady(
+		properties: LocalCapabilityReadyProperties,
+		advertisement?: ReplicationInfoV2LocalCapabilityAdvertisement,
+	): boolean {
 		const { peerHash, peerSession, receiverTransportSession } = properties;
 		const state = this._receiveStates.get(peerHash);
 		if (
@@ -283,8 +807,10 @@ export class ReplicationInfoV2ReceiveCoordinator {
 
 		const ready: LocalCapabilityReady = {
 			peerHash,
+			receiveEpoch: properties.receiveEpoch,
 			receiverTransportSession,
 			requestNotBeforeMs: properties.requestNotBeforeMs,
+			advertisement,
 		};
 		this._localCapabilityReadyBySession.set(peerSession, ready);
 		if (
@@ -388,7 +914,11 @@ export class ReplicationInfoV2ReceiveCoordinator {
 				});
 			}
 			const ready = this._localCapabilityReadyBySession.get(peerSession);
-			if (ready?.peerHash === peerHash && state.receiverBinding === undefined) {
+			if (
+				ready?.peerHash === peerHash &&
+				ready.receiveEpoch === receiveEpoch &&
+				state.receiverBinding === undefined
+			) {
 				this.bindLocalCapability(state, ready);
 			}
 			if (state.phase !== "active") {
@@ -422,7 +952,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		};
 		this._receiveStates.set(peerHash, state);
 		const ready = this._localCapabilityReadyBySession.get(peerSession);
-		if (ready?.peerHash === peerHash) {
+		if (ready?.peerHash === peerHash && ready.receiveEpoch === receiveEpoch) {
 			this.bindLocalCapability(state, ready);
 			this.armRequest(state, 0);
 		}
@@ -937,6 +1467,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 
 		const ready: LocalCapabilityReady = {
 			peerHash: state.peerHash,
+			receiveEpoch: state.receiveEpoch,
 			receiverTransportSession: refreshed.receiverTransportSession,
 			requestNotBeforeMs: refreshed.requestNotBeforeMs,
 		};
@@ -988,6 +1519,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			if (
 				!ready ||
 				ready.peerHash !== state.peerHash ||
+				ready.receiveEpoch !== state.receiveEpoch ||
 				ready.receiverTransportSession !== state.receiverTransportSession
 			) {
 				return;

--- a/packages/programs/data/shared-log/src/replication-info-v2-send.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-send.ts
@@ -21,6 +21,9 @@ import {
 const logger = loggerFn("peerbit:shared-log:replication-info-v2-send");
 
 const MAX_U64 = (1n << 64n) - 1n;
+const DEFAULT_SEND_RETRY_MS = 1_000;
+const DEFAULT_MAX_SEND_RETRY_MS = 30_000;
+const MAX_BACKOFF_EXPONENT = 20;
 
 export { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
 
@@ -45,10 +48,13 @@ export type ReplicationInfoV2SendState = {
 	receiverChallenge: Uint8Array;
 	senderEpoch: Uint8Array;
 	ownershipLifecycleController: AbortController;
+	ownershipAbortListener: () => void;
 	nextSequence: bigint;
 	established: boolean;
 	suspended: boolean;
 	inFlightSequence?: bigint;
+	retryTimer?: ReturnType<typeof setTimeout>;
+	retryAttempts: number;
 	controller: AbortController;
 	pending?: SendRequest;
 	worker?: Promise<void>;
@@ -63,11 +69,14 @@ export type ReplicationInfoV2SendDeps<R extends "u32" | "u64"> = {
 		ranges: readonly { mode: unknown }[],
 	) => void;
 	isClosed: () => boolean;
+	isPeerSessionCurrent: (peerHash: string, peerSession: object) => boolean;
 	isPeerSessionOpen: (peerHash: string, peerSession: object) => boolean;
 	captureReplicationOwnershipLifecycle: () => AbortController;
 	isReplicationOwnershipLifecycleActive: (
 		controller: AbortController,
 	) => boolean;
+	sendRetryMs?: number;
+	maxSendRetryMs?: number;
 };
 
 const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
@@ -93,7 +102,15 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 	_spentPeerSessions!: WeakSet<object>;
 	_retiringWorkersByPeer!: Map<string, Promise<void>>;
 
+	private readonly sendRetryMs: number;
+	private readonly maxSendRetryMs: number;
+
 	constructor(private readonly deps: ReplicationInfoV2SendDeps<R>) {
+		this.sendRetryMs = Math.max(1, deps.sendRetryMs ?? DEFAULT_SEND_RETRY_MS);
+		this.maxSendRetryMs = Math.max(
+			this.sendRetryMs,
+			deps.maxSendRetryMs ?? DEFAULT_MAX_SEND_RETRY_MS,
+		);
 		this._senderEpoch = randomBytes(32);
 		this._sendStates = new Map();
 		this._spentPeerSessions = new WeakSet();
@@ -131,6 +148,14 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 
 	private clearState(state: ReplicationInfoV2SendState): void {
 		this.trackRetiringWorker(state);
+		if (state.retryTimer) {
+			clearTimeout(state.retryTimer);
+			state.retryTimer = undefined;
+		}
+		state.ownershipLifecycleController.signal.removeEventListener(
+			"abort",
+			state.ownershipAbortListener,
+		);
 		state.controller.abort();
 		if (this._sendStates.get(state.peerHash) === state) {
 			this._sendStates.delete(state.peerHash);
@@ -163,18 +188,65 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 			!this.deps.isClosed() &&
 			!state.controller.signal.aborted &&
 			this._sendStates.get(state.peerHash) === state &&
-			this.deps.isPeerSessionOpen(state.peerHash, state.peerSession) &&
+			this.deps.isPeerSessionCurrent(state.peerHash, state.peerSession) &&
 			this.deps.getSenderTransportSession() === state.senderTransportSession
+		);
+	}
+
+	private isDestinationReady(state: ReplicationInfoV2SendState): boolean {
+		return (
+			this.isDestinationCurrent(state) &&
+			this.deps.isPeerSessionOpen(state.peerHash, state.peerSession)
 		);
 	}
 
 	private isCurrent(state: ReplicationInfoV2SendState): boolean {
 		return (
-			this.isDestinationCurrent(state) &&
+			this.isDestinationReady(state) &&
 			this.deps.isReplicationOwnershipLifecycleActive(
 				state.ownershipLifecycleController,
 			)
 		);
+	}
+
+	private retireSpentState(state: ReplicationInfoV2SendState): void {
+		this._spentPeerSessions.add(state.peerSession);
+		this.clearState(state);
+	}
+
+	/**
+	 * Collapse every interrupted normal-send path to one authoritative snapshot.
+	 * A closed readiness gate is temporary while the exact PeerSession remains
+	 * current, so it parks instead of destroying the receiver binding. Sequence
+	 * exhaustion is terminal even when readiness or ownership changed at the same
+	 * time as an in-flight transport attempt.
+	 */
+	private parkSnapshotForRetry(state: ReplicationInfoV2SendState): void {
+		state.inFlightSequence = undefined;
+		if (state.nextSequence > MAX_U64) {
+			this.retireSpentState(state);
+			return;
+		}
+		if (!this.isDestinationCurrent(state)) {
+			this.clearState(state);
+			return;
+		}
+		if (
+			!this.deps.isReplicationOwnershipLifecycleActive(
+				state.ownershipLifecycleController,
+			)
+		) {
+			if (state.retryTimer) {
+				clearTimeout(state.retryTimer);
+				state.retryTimer = undefined;
+			}
+			state.pending = undefined;
+			return;
+		}
+
+		state.suspended = true;
+		state.pending = { kind: "snapshot" };
+		this.scheduleRetry(state);
 	}
 
 	/**
@@ -207,6 +279,7 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 		if (
 			this._retiringWorkersByPeer.has(peerHash) ||
 			this._spentPeerSessions.has(properties.peerSession) ||
+			!this.deps.isPeerSessionCurrent(peerHash, properties.peerSession) ||
 			!this.deps.isPeerSessionOpen(peerHash, properties.peerSession)
 		) {
 			return false;
@@ -224,6 +297,16 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				return false;
 			}
 		}
+		if (
+			previous &&
+			!this.deps.isReplicationOwnershipLifecycleActive(
+				previous.ownershipLifecycleController,
+			)
+		) {
+			// Ownership teardown retains the binding only so close/drop can send its
+			// terminal empty Full. A later request must not revive normal delivery.
+			return false;
+		}
 		if (previous) {
 			const sameBinding =
 				previous.peerSession === properties.peerSession &&
@@ -239,7 +322,12 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				}
 				previous.lastRequestTimestamp = properties.requestTimestamp;
 				previous.capabilityTimestamp = properties.capabilityTimestamp;
+				if (previous.retryTimer) {
+					clearTimeout(previous.retryTimer);
+					previous.retryTimer = undefined;
+				}
 				previous.suspended = false;
+				previous.pending = { kind: "snapshot" };
 				this.enqueueState(previous, { kind: "snapshot" });
 				return true;
 			}
@@ -256,6 +344,13 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 
 		const ownershipLifecycleController =
 			this.deps.captureReplicationOwnershipLifecycle();
+		if (
+			!this.deps.isReplicationOwnershipLifecycleActive(
+				ownershipLifecycleController,
+			)
+		) {
+			return false;
+		}
 		const state: ReplicationInfoV2SendState = {
 			peerHash,
 			target: properties.from,
@@ -273,12 +368,26 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				senderTransportSession,
 			}),
 			senderEpoch: this._senderEpoch.slice(),
+			ownershipAbortListener: () => {},
 			nextSequence: 1n,
 			established: false,
 			suspended: false,
+			retryAttempts: 0,
 			controller: new AbortController(),
 			ownershipLifecycleController,
 		};
+		state.ownershipAbortListener = () => {
+			if (state.retryTimer) {
+				clearTimeout(state.retryTimer);
+				state.retryTimer = undefined;
+			}
+			state.pending = undefined;
+		};
+		ownershipLifecycleController.signal.addEventListener(
+			"abort",
+			state.ownershipAbortListener,
+			{ once: true },
+		);
 		this._sendStates.set(peerHash, state);
 		this.enqueueState(state, { kind: "snapshot" });
 		return true;
@@ -301,20 +410,15 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 		state: ReplicationInfoV2SendState,
 		request: SendRequest,
 	): void {
-		if (!this.isCurrent(state)) {
-			state.pending = undefined;
-			if (
-				!this.isDestinationCurrent(state) ||
-				this.deps.isReplicationOwnershipLifecycleActive(
-					state.ownershipLifecycleController,
-				)
-			) {
-				this.clearState(state);
-			}
+		if (state.nextSequence > MAX_U64 || !this.isCurrent(state)) {
+			this.parkSnapshotForRetry(state);
 			return;
 		}
 		if (state.suspended) {
-			state.pending = undefined;
+			// Delivery is ambiguous while the backoff is armed. Never retain a
+			// potentially stale delta: one authoritative Full represents every
+			// mutation that arrives before the retry fires.
+			this.parkSnapshotForRetry(state);
 			return;
 		}
 
@@ -324,12 +428,14 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 			worker = Promise.resolve()
 				.then(() => this.runWorker(state))
 				.catch((error) => {
-					const ownershipActive =
+					// Sequence cleanup and exhaustion fencing must happen before any
+					// readiness/ownership classification in the recovery path.
+					this.parkSnapshotForRetry(state);
+					if (
+						this._sendStates.get(state.peerHash) === state &&
 						this.deps.isReplicationOwnershipLifecycleActive(
 							state.ownershipLifecycleController,
-						);
-					if (
-						ownershipActive &&
+						) &&
 						!state.controller.signal.aborted &&
 						!this.deps.isClosed()
 					) {
@@ -339,28 +445,6 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 							(error as Error)?.message ?? String(error),
 						);
 					}
-					state.pending = undefined;
-					const ordinaryFailure =
-						ownershipActive && this.isDestinationCurrent(state);
-					if (ordinaryFailure) {
-						if (state.inFlightSequence !== undefined) {
-							state.inFlightSequence = undefined;
-							if (state.nextSequence > MAX_U64) {
-								this._spentPeerSessions.add(state.peerSession);
-								this.clearState(state);
-								return;
-							}
-						}
-						// A delivery error is ambiguous: the receiver may already have
-						// applied this sequence. Retain the exact grant, stop ordinary
-						// deltas, and require a newer same-challenge request to resume
-						// with an authoritative Full at the next safe sequence.
-						state.suspended = true;
-						return;
-					}
-					if (!this.isDestinationCurrent(state)) {
-						this.clearState(state);
-					}
 				})
 				.finally(() => {
 					if (state.worker === worker) {
@@ -369,7 +453,7 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 						// before this promise reaction clears `worker`. Re-arm that item
 						// here so the one-slot bound cannot become a stranded queue.
 						const pending = state.pending;
-						if (pending && this.isCurrent(state)) {
+						if (pending) {
 							state.pending = undefined;
 							this.enqueueState(state, pending);
 						}
@@ -387,6 +471,51 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 		// One pending item is the hard bound. Once another mutation arrives,
 		// replace the pending delta with a current authoritative snapshot.
 		state.pending = { kind: "snapshot" };
+	}
+
+	private retryDelay(state: ReplicationInfoV2SendState): number {
+		const exponent = Math.max(0, state.retryAttempts - 1);
+		return Math.min(
+			this.maxSendRetryMs,
+			this.sendRetryMs * 2 ** Math.min(exponent, MAX_BACKOFF_EXPONENT),
+		);
+	}
+
+	private scheduleRetry(state: ReplicationInfoV2SendState): void {
+		if (state.retryTimer) {
+			return;
+		}
+		if (state.nextSequence > MAX_U64) {
+			this.retireSpentState(state);
+			return;
+		}
+		if (!this.isDestinationCurrent(state)) {
+			this.clearState(state);
+			return;
+		}
+		if (
+			!this.deps.isReplicationOwnershipLifecycleActive(
+				state.ownershipLifecycleController,
+			)
+		) {
+			state.pending = undefined;
+			return;
+		}
+		state.retryAttempts = Math.min(
+			state.retryAttempts + 1,
+			MAX_BACKOFF_EXPONENT + 1,
+		);
+		state.retryTimer = setTimeout(() => {
+			state.retryTimer = undefined;
+			if (state.nextSequence > MAX_U64 || !this.isCurrent(state)) {
+				this.parkSnapshotForRetry(state);
+				return;
+			}
+			state.suspended = false;
+			state.pending = { kind: "snapshot" };
+			this.enqueueState(state, { kind: "snapshot" });
+		}, this.retryDelay(state));
+		state.retryTimer.unref?.();
 	}
 
 	private async createMessage(
@@ -427,19 +556,19 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 	}
 
 	private async runWorker(state: ReplicationInfoV2SendState): Promise<void> {
-		while (this.isCurrent(state)) {
+		while (true) {
+			if (state.nextSequence > MAX_U64 || !this.isCurrent(state)) {
+				this.parkSnapshotForRetry(state);
+				return;
+			}
 			const request = state.pending;
 			if (!request) {
 				return;
 			}
 			state.pending = undefined;
-			if (state.nextSequence > MAX_U64) {
-				this.clearState(state);
-				return;
-			}
-
 			const message = await this.createMessage(state, request);
-			if (!this.isCurrent(state)) {
+			if (state.nextSequence > MAX_U64 || !this.isCurrent(state)) {
+				this.parkSnapshotForRetry(state);
 				return;
 			}
 			// Consume the sequence before the transport attempt. From this point on
@@ -460,15 +589,12 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				]),
 			});
 			state.inFlightSequence = undefined;
-			if (!this.isCurrent(state)) {
+			if (state.nextSequence > MAX_U64 || !this.isCurrent(state)) {
+				this.parkSnapshotForRetry(state);
 				return;
 			}
+			state.retryAttempts = 0;
 			state.established = true;
-			if (state.nextSequence > MAX_U64) {
-				this._spentPeerSessions.add(state.peerSession);
-				this.clearState(state);
-				return;
-			}
 		}
 	}
 
@@ -490,22 +616,38 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				continue;
 			}
 			state.pending = undefined;
+			const sequence = state.nextSequence;
+			state.nextSequence += 1n;
 			const message = new FullReplicationInfoV2Message({
 				receiverChallenge: state.receiverChallenge.slice(),
 				senderEpoch: state.senderEpoch.slice(),
-				sequence: state.nextSequence,
+				sequence,
 				segments: [],
 			});
-			sends.push(
-				this.deps.getRpc().send(message, {
-					mode: new AcknowledgeDelivery({
-						to: [state.target],
-						redundancy: 1,
-					}),
-					priority: CONVERGENCE_MESSAGE_PRIORITY,
-					signal,
-				}),
-			);
+			if (sequence === MAX_U64) {
+				// Retire the exhausted normal stream before transport invocation. The
+				// terminal attempt remains valid because it carries its caller-owned
+				// signal rather than the state controller that clearState aborts.
+				this.retireSpentState(state);
+			}
+			try {
+				sends.push(
+					Promise.resolve(
+						this.deps.getRpc().send(message, {
+							mode: new AcknowledgeDelivery({
+								to: [state.target],
+								redundancy: 1,
+							}),
+							priority: CONVERGENCE_MESSAGE_PRIORITY,
+							signal,
+						}),
+					),
+				);
+			} catch (error) {
+				// Keep one synchronous transport failure isolated to its destination;
+				// the sequence was already consumed and later peers must still reset.
+				sends.push(Promise.reject(error));
+			}
 		}
 		await Promise.allSettled(sends);
 	}

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -228,6 +228,26 @@ describe("receive admission replication-info recovery epoch", () => {
 					});
 					return true;
 				});
+			const reAdvertisementCalls: Array<{
+				gateOpen: boolean;
+				peerSession: object;
+				receiveEpoch: object | null;
+			}> = [];
+			const v2ReAdvertisement = sinon
+				.stub(sharedLog._v2Receive, "reAdvertiseLocalCapabilityForRecovery")
+				.callsFake((...args: unknown[]) => {
+					const properties = args[0] as {
+						peerSession: object;
+						receiveEpoch: object | null;
+					};
+					reAdvertisementCalls.push({
+						gateOpen:
+							sharedLog._peerSessions.isReceiveCleanupGateOpen(sourceHash),
+						peerSession: properties.peerSession,
+						receiveEpoch: properties.receiveEpoch,
+					});
+					return true;
+				});
 			const delayedMessage = new AddedReplicationSegmentMessage({
 				segments: [remoteRange.toReplicationRange()],
 			});
@@ -298,6 +318,14 @@ describe("receive admission replication-info recovery epoch", () => {
 				expect(recoveryCalls[0].receiveEpoch).to.equal(
 					recoveryCalls[1].receiveEpoch,
 				);
+				expect(reAdvertisementCalls).to.have.length(1);
+				expect(reAdvertisementCalls[0].gateOpen).to.be.true;
+				expect(reAdvertisementCalls[0].peerSession).to.equal(
+					sharedLog._peerSessions.current(sourceHash),
+				);
+				expect(reAdvertisementCalls[0].receiveEpoch).to.equal(
+					recoveryCalls[1].receiveEpoch,
+				);
 
 				releaseHandler.resolve();
 				await receive;
@@ -313,6 +341,7 @@ describe("receive admission replication-info recovery epoch", () => {
 				coherentDelete.restore();
 				applyQueue.restore();
 				synchronizer.restore();
+				v2ReAdvertisement.restore();
 				v2Recovery.restore();
 				scheduleRequests.restore();
 			}

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -1,6 +1,7 @@
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { Ed25519PublicKey } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/test-utils";
+import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
@@ -21,6 +22,7 @@ import {
 	AllReplicatingSegmentsMessage,
 	FullReplicationInfoV2Message,
 	RequestReplicationInfoV2Message,
+	ResponseRoleMessage,
 	StoppedReplicating,
 	StoppedReplicationInfoV2Message,
 } from "../src/replication.js";
@@ -372,7 +374,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises V2 readiness before replication snapshot retrieval", async () => {
+	it("starts advertising V2 readiness before replication snapshot retrieval", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -390,6 +392,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		const snapshot = sinon
 			.stub(log, "getMyReplicationSegments")
 			.rejects(snapshotFailure);
+		const markReady = sinon.spy(log._v2Receive, "recordLocalCapabilityReady");
 
 		try {
 			await expect(
@@ -410,9 +413,13 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			expect(
 				capability!.capabilities & SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
 			).to.equal(SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY);
+			await waitForResolved(() => expect(markReady.calledOnce).to.be.true, {
+				timeout: 5_000,
+			});
 		} finally {
 			send.restore();
 			snapshot.restore();
+			markReady.restore();
 		}
 	});
 
@@ -444,13 +451,15 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				}
 				return [] as any;
 			});
-		const markReady = sinon.spy(log._v2Receive, "markLocalCapabilityReady");
+		const advertise = sinon.spy(log._v2Receive, "advertiseLocalCapability");
+		const markReady = sinon.spy(log._v2Receive, "recordLocalCapabilityReady");
 		const requests = sinon
 			.stub(log, "scheduleReplicationInfoRequests")
 			.callsFake(() => {});
 		let subscription: Promise<void> | undefined;
 		let subscriptionSettled = false;
 		let legacySnapshotTimeout: ReturnType<typeof setTimeout> | undefined;
+		let subscriptionTimeout: ReturnType<typeof setTimeout> | undefined;
 
 		try {
 			subscription = log
@@ -471,7 +480,17 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			]);
 			clearTimeout(legacySnapshotTimeout);
 			legacySnapshotTimeout = undefined;
-			await new Promise<void>((resolve) => setImmediate(resolve));
+			await Promise.race([
+				subscription,
+				new Promise<never>((_, reject) => {
+					subscriptionTimeout = setTimeout(
+						() => reject(new Error("subscription waited for capability ACK")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(subscriptionTimeout);
+			subscriptionTimeout = undefined;
 
 			expect(sent[0]).to.be.instanceOf(SyncCapabilitiesMessage);
 			expect(
@@ -479,18 +498,176 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 					(message) => message instanceof AllReplicatingSegmentsMessage,
 				),
 			).to.be.true;
-			expect(subscriptionSettled).to.be.false;
+			expect(subscriptionSettled).to.be.true;
 			expect(markReady.called).to.be.false;
 			expect(requests.calledOnce).to.be.true;
 
 			releaseCapabilityAcknowledgement();
+			await waitForResolved(() => expect(markReady.calledOnce).to.be.true, {
+				timeout: 5_000,
+			});
+		} finally {
+			clearTimeout(legacySnapshotTimeout);
+			clearTimeout(subscriptionTimeout);
+			releaseCapabilityAcknowledgement();
+			await subscription?.catch(() => {});
+			await advertise.firstCall?.returnValue.firstAttempt.catch(() => {});
+			send.restore();
+			advertise.restore();
+			markReady.restore();
+			requests.restore();
+		}
+	});
+
+	it("holds V2 readiness behind the complete v8 legacy startup path across recovery", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { compatibility: 8, replicate: true, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		let releaseLegacySnapshot!: () => void;
+		const legacySnapshotGate = new Promise<void>((resolve) => {
+			releaseLegacySnapshot = resolve;
+		});
+		let markLegacySnapshotAttempted!: () => void;
+		const legacySnapshotAttempted = new Promise<void>((resolve) => {
+			markLegacySnapshotAttempted = resolve;
+		});
+		let releaseLegacyRole!: () => void;
+		const legacyRoleGate = new Promise<void>((resolve) => {
+			releaseLegacyRole = resolve;
+		});
+		let markLegacyRoleAttempted!: () => void;
+		const legacyRoleAttempted = new Promise<void>((resolve) => {
+			markLegacyRoleAttempted = resolve;
+		});
+		const sent: unknown[] = [];
+		const send = sinon
+			.stub(log.rpc, "send")
+			.callsFake(async (message: unknown) => {
+				sent.push(message);
+				if (message instanceof AllReplicatingSegmentsMessage) {
+					markLegacySnapshotAttempted();
+					await legacySnapshotGate;
+				}
+				if (message instanceof ResponseRoleMessage) {
+					markLegacyRoleAttempted();
+					await legacyRoleGate;
+				}
+				return [] as any;
+			});
+		const advertise = sinon.spy(log._v2Receive, "advertiseLocalCapability");
+		const markReady = sinon.spy(log._v2Receive, "recordLocalCapabilityReady");
+		const requests = sinon
+			.stub(log, "scheduleReplicationInfoRequests")
+			.callsFake(() => {
+				expect(markReady.called).to.be.false;
+				expect(
+					sent.some(
+						(message) => message instanceof RequestReplicationInfoV2Message,
+					),
+				).to.be.false;
+			});
+		let subscription: Promise<void> | undefined;
+		let legacySnapshotTimeout: ReturnType<typeof setTimeout> | undefined;
+		let capabilityTimeout: ReturnType<typeof setTimeout> | undefined;
+		let legacyRoleTimeout: ReturnType<typeof setTimeout> | undefined;
+
+		try {
+			subscription = log._onSubscription({
+				detail: { from: remote, topics: [db.log.topic] },
+			});
+			await Promise.race([
+				legacySnapshotAttempted,
+				new Promise<never>((_, reject) => {
+					legacySnapshotTimeout = setTimeout(
+						() => reject(new Error("legacy snapshot was not attempted")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(legacySnapshotTimeout);
+			legacySnapshotTimeout = undefined;
+			expect(advertise.calledOnce).to.be.true;
+			const advertisement = advertise.firstCall.returnValue;
+			await Promise.race([
+				advertisement.firstAttempt,
+				new Promise<never>((_, reject) => {
+					capabilityTimeout = setTimeout(
+						() => reject(new Error("capability ACK did not settle")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(capabilityTimeout);
+			capabilityTimeout = undefined;
+			const peerHash = remote.hashcode();
+			const peerSession = log._peerSessions.current(peerHash);
+			expect(peerSession?.phase).to.equal("open");
+			log.advanceReplicationInfoRecoveryEpoch(peerHash);
+			const receiveEpoch = log._peerSessions.receiveEpoch(peerHash);
+			expect(
+				log._v2Receive.reAdvertiseLocalCapabilityForRecovery({
+					peerHash,
+					peerSession,
+					receiveEpoch,
+				}),
+			).to.be.true;
+			expect(advertise.calledTwice).to.be.true;
+			const recoveryAdvertisement = advertise.secondCall.returnValue;
+			expect(recoveryAdvertisement).to.not.equal(advertisement);
+			await Promise.race([
+				recoveryAdvertisement.firstAttempt,
+				new Promise<never>((_, reject) => {
+					capabilityTimeout = setTimeout(
+						() => reject(new Error("recovery capability ACK did not settle")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(capabilityTimeout);
+			capabilityTimeout = undefined;
+
+			expect(sent[0]).to.be.instanceOf(SyncCapabilitiesMessage);
+			expect(markReady.called).to.be.false;
+			expect(requests.called).to.be.false;
+			expect(
+				sent.some(
+					(message) => message instanceof RequestReplicationInfoV2Message,
+				),
+			).to.be.false;
+
+			releaseLegacySnapshot();
+			await Promise.race([
+				legacyRoleAttempted,
+				new Promise<never>((_, reject) => {
+					legacyRoleTimeout = setTimeout(
+						() => reject(new Error("legacy v8 role was not attempted")),
+						5_000,
+					);
+				}),
+			]);
+			clearTimeout(legacyRoleTimeout);
+			legacyRoleTimeout = undefined;
+			expect(markReady.called).to.be.false;
+			expect(requests.called).to.be.false;
+
+			releaseLegacyRole();
 			await subscription;
+			expect(requests.calledOnce).to.be.true;
+			expect(markReady.calledOnce).to.be.true;
+			await new Promise<void>((resolve) => setImmediate(resolve));
 			expect(markReady.calledOnce).to.be.true;
 		} finally {
 			clearTimeout(legacySnapshotTimeout);
-			releaseCapabilityAcknowledgement();
+			clearTimeout(capabilityTimeout);
+			clearTimeout(legacyRoleTimeout);
+			releaseLegacySnapshot();
+			releaseLegacyRole();
 			await subscription?.catch(() => {});
 			send.restore();
+			advertise.restore();
 			markReady.restore();
 			requests.restore();
 		}

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -44,6 +44,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 	let currentSession: object;
 	let currentReceiveEpoch: object;
 	let currentSenderTransportSession: bigint;
+	let peerStateReady: boolean;
 	let sendRequest: sinon.SinonStub;
 	let refreshLocalCapability: sinon.SinonStub;
 	let coordinator: ReplicationInfoV2ReceiveCoordinator;
@@ -58,8 +59,14 @@ describe("receive admission replication-info V2 receiver state", () => {
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => receiverTransportSession,
 			isClosed: () => closed,
+			isPeerSessionCurrent: (_peerHash, peerSession) =>
+				peerSession === currentSession,
+			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
+				receiveEpoch === currentReceiveEpoch,
 			isPeerStateCurrent: (_peerHash, peerSession, receiveEpoch) =>
-				peerSession === currentSession && receiveEpoch === currentReceiveEpoch,
+				peerStateReady &&
+				peerSession === currentSession &&
+				receiveEpoch === currentReceiveEpoch,
 			isSenderTransportSessionCurrent: (_peerHash, transportSession) =>
 				transportSession === currentSenderTransportSession,
 			sendRequest,
@@ -113,6 +120,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		currentSession = {};
 		currentReceiveEpoch = {};
 		currentSenderTransportSession = senderTransportSession;
+		peerStateReady = true;
 		sendRequest = sinon.stub().resolves();
 		refreshLocalCapability = sinon.stub().callsFake(async () => ({
 			receiverTransportSession,
@@ -158,6 +166,663 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect([...retried.receiverChallenge]).to.deep.equal([
 			...first.receiverChallenge,
 		]);
+	});
+
+	it("holds an ACK behind the legacy barrier and releases idempotently", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({ requestRetryMs: 5 });
+		const lifecycle = new AbortController();
+		expect(observeSender()).to.be.true;
+
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await handle.firstAttempt;
+		const advertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(advertisement.acknowledgedReady).to.exist;
+		expect(advertisement.ready).to.be.false;
+		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
+			.false;
+		expect(sendRequest.notCalled).to.be.true;
+
+		handle.releaseLegacyBarrier();
+		const ready =
+			coordinator._localCapabilityReadyBySession.get(currentSession);
+		handle.releaseLegacyBarrier();
+		expect(
+			coordinator._localCapabilityReadyBySession.get(currentSession),
+		).to.equal(ready);
+		expect(advertisement.ready).to.be.true;
+		await clock.tickAsync(1);
+		expect(sendRequest.calledOnce).to.be.true;
+	});
+
+	it("promotes when the ACK arrives after the legacy barrier release", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_100 });
+		const pending = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.callsFake(() => pending.promise);
+		coordinator = createCoordinator();
+		const lifecycle = new AbortController();
+		expect(observeSender()).to.be.true;
+
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		handle.releaseLegacyBarrier();
+		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
+			.false;
+		pending.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await handle.firstAttempt;
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)?.ready,
+		).to.be.true;
+		await clock.tickAsync(1);
+		expect(sendRequest.calledOnce).to.be.true;
+	});
+
+	it("stops retrying after an ACK while the legacy barrier remains closed", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_200 });
+		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
+		refreshLocalCapability.onSecondCall().callsFake(async () => ({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		}));
+		coordinator = createCoordinator({ requestRetryMs: 5 });
+		const lifecycle = new AbortController();
+		expect(observeSender()).to.be.true;
+
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await handle.firstAttempt;
+		const advertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(advertisement.timer).to.exist;
+		expect((advertisement.timer as any).hasRef()).to.be.false;
+
+		await clock.tickAsync(5);
+		expect(refreshLocalCapability.callCount).to.equal(2);
+		expect(advertisement.acknowledgedReady).to.exist;
+		expect(advertisement.ready).to.be.false;
+		expect(advertisement.timer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(refreshLocalCapability.callCount).to.equal(2);
+		expect(sendRequest.notCalled).to.be.true;
+
+		handle.releaseLegacyBarrier();
+		await clock.tickAsync(0);
+		expect(advertisement.ready).to.be.true;
+		expect(sendRequest.calledOnce).to.be.true;
+	});
+
+	it("parks one failed worker across a temporary receive gate closure", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_300 });
+		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
+		refreshLocalCapability.onSecondCall().callsFake(async () => ({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		}));
+		coordinator = createCoordinator({ requestRetryMs: 5 });
+		const lifecycle = new AbortController();
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await handle.firstAttempt;
+		handle.releaseLegacyBarrier();
+		const advertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+
+		peerStateReady = false;
+		await clock.tickAsync(10);
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash),
+		).to.equal(advertisement);
+		expect(advertisement.controller.signal.aborted).to.be.false;
+		expect(advertisement.timer).to.exist;
+
+		peerStateReady = true;
+		await clock.tickAsync(5);
+		expect(refreshLocalCapability.callCount).to.equal(2);
+		expect(advertisement.ready).to.be.true;
+		expect(advertisement.timer).to.be.undefined;
+	});
+
+	it("keeps independent bounded capability workers and barriers for two peers", async () => {
+		const clock = sinon.useFakeTimers({ now: 2_000 });
+		const secondSender = key(3);
+		const sessionByPeer = new Map<string, object>();
+		const epochByPeer = new Map<string, object>();
+		const attemptsByPeer = new Map<string, number>();
+		const lifecycle = new AbortController();
+		for (const target of [sender, secondSender]) {
+			sessionByPeer.set(target.hashcode(), {});
+			epochByPeer.set(target.hashcode(), {});
+		}
+		coordinator = new ReplicationInfoV2ReceiveCoordinator({
+			getSelfKey: () => self,
+			getReceiverTransportSession: () => receiverTransportSession,
+			isClosed: () => false,
+			isPeerSessionCurrent: (hash, peerSession) =>
+				sessionByPeer.get(hash) === peerSession,
+			isReceiveEpochCurrent: (hash, receiveEpoch) =>
+				epochByPeer.get(hash) === receiveEpoch,
+			isPeerStateCurrent: (hash, peerSession, receiveEpoch) =>
+				sessionByPeer.get(hash) === peerSession &&
+				epochByPeer.get(hash) === receiveEpoch,
+			isSenderTransportSessionCurrent: () => true,
+			sendRequest: async () => {},
+			refreshLocalCapability: async ({ peerHash }) => {
+				const attempt = (attemptsByPeer.get(peerHash) ?? 0) + 1;
+				attemptsByPeer.set(peerHash, attempt);
+				if (attempt === 1) {
+					throw new Error("first advert failed");
+				}
+				return {
+					receiverTransportSession,
+					requestNotBeforeMs: Date.now(),
+				};
+			},
+			requestRetryMs: 5,
+			maxRequestRetryMs: 20,
+		});
+
+		const handles = [sender, secondSender].map((target) =>
+			coordinator.advertiseLocalCapability({
+				target,
+				peerSession: sessionByPeer.get(target.hashcode())!,
+				receiveEpoch: epochByPeer.get(target.hashcode())!,
+				signal: lifecycle.signal,
+			}),
+		);
+		await Promise.all(handles.map((handle) => handle.firstAttempt));
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(2);
+		expect(
+			[...coordinator._localCapabilityAdvertisementsByPeer.values()].every(
+				(state) => state.timer !== undefined,
+			),
+		).to.be.true;
+
+		await clock.tickAsync(5);
+		expect([...attemptsByPeer.values()]).to.deep.equal([2, 2]);
+		expect(
+			[...coordinator._localCapabilityAdvertisementsByPeer.values()].every(
+				(state) =>
+					state.acknowledgedReady !== undefined &&
+					!state.ready &&
+					state.timer === undefined,
+			),
+		).to.be.true;
+
+		handles[0].releaseLegacyBarrier();
+		expect(
+			coordinator._localCapabilityReadyBySession.has(
+				sessionByPeer.get(peerHash)!,
+			),
+		).to.be.true;
+		expect(
+			coordinator._localCapabilityReadyBySession.has(
+				sessionByPeer.get(secondSender.hashcode())!,
+			),
+		).to.be.false;
+		handles[1].releaseLegacyBarrier();
+		expect(
+			[...coordinator._localCapabilityAdvertisementsByPeer.values()].every(
+				(state) => state.ready,
+			),
+		).to.be.true;
+	});
+
+	it("fences stale completion and release after a session replacement", async () => {
+		const oldAck = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.onFirstCall().callsFake(() => oldAck.promise);
+		refreshLocalCapability.onSecondCall().resolves({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		const oldSession = currentSession;
+		const oldEpoch = currentReceiveEpoch;
+		const oldLifecycle = new AbortController();
+		const oldHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: oldSession,
+			receiveEpoch: oldEpoch,
+			signal: oldLifecycle.signal,
+		});
+
+		currentSession = {};
+		currentReceiveEpoch = {};
+		const replacementSession = currentSession;
+		const newLifecycle = new AbortController();
+		const replacementHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: replacementSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: newLifecycle.signal,
+		});
+		await replacementHandle.firstAttempt;
+		replacementHandle.releaseLegacyBarrier();
+		const replacement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(replacement.peerSession).to.equal(replacementSession);
+		expect(replacement.ready).to.be.true;
+
+		oldHandle.releaseLegacyBarrier();
+		oldAck.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await oldHandle.firstAttempt;
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash),
+		).to.equal(replacement);
+		expect(coordinator._localCapabilityReadyBySession.has(replacementSession))
+			.to.be.true;
+		expect(coordinator._localCapabilityReadyBySession.has(oldSession)).to.be
+			.false;
+	});
+
+	it("fences an in-flight old-epoch completion after same-session recovery", async () => {
+		const oldAck = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.onFirstCall().callsFake(() => oldAck.promise);
+		refreshLocalCapability.onSecondCall().resolves({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		const peerSession = currentSession;
+		const oldEpoch = currentReceiveEpoch;
+		const lifecycle = new AbortController();
+		const oldHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession,
+			receiveEpoch: oldEpoch,
+			signal: lifecycle.signal,
+		});
+		const oldAdvertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.reAdvertiseLocalCapabilityForRecovery({
+				peerHash,
+				peerSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		const replacement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(replacement).not.to.equal(oldAdvertisement);
+		expect(replacement.context).to.equal(oldAdvertisement.context);
+		await replacement.firstAttempt;
+		expect(replacement.acknowledgedReady).to.exist;
+
+		oldHandle.releaseLegacyBarrier();
+		expect(replacement.ready).to.be.true;
+		const replacementReady =
+			coordinator._localCapabilityReadyBySession.get(peerSession);
+		expect(replacementReady?.advertisement).to.equal(replacement);
+
+		oldAck.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await oldHandle.firstAttempt;
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash),
+		).to.equal(replacement);
+		expect(
+			coordinator._localCapabilityContextBySession.get(peerSession),
+		).to.equal(replacement.context);
+		expect(
+			coordinator._localCapabilityReadyBySession.get(peerSession),
+		).to.equal(replacementReady);
+		expect(replacement.controller.signal.aborted).to.be.false;
+		expect(replacement.ready).to.be.true;
+	});
+
+	it("cancels a capability generation across lifecycle abort and reopen", async () => {
+		const pending = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.onFirstCall().callsFake(() => pending.promise);
+		refreshLocalCapability.onSecondCall().resolves({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		const oldSession = currentSession;
+		const oldLifecycle = new AbortController();
+		const staleHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: oldSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: oldLifecycle.signal,
+		});
+		oldLifecycle.abort();
+		staleHandle.releaseLegacyBarrier();
+		pending.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await staleHandle.firstAttempt;
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(0);
+		expect(coordinator._localCapabilityReadyBySession.has(oldSession)).to.be
+			.false;
+
+		currentSession = {};
+		currentReceiveEpoch = {};
+		const currentLifecycle = new AbortController();
+		const currentHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: currentLifecycle.signal,
+		});
+		await currentHandle.firstAttempt;
+		currentHandle.releaseLegacyBarrier();
+		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
+			.true;
+	});
+
+	it("bounds repeated local capability starts to one retry slot", async () => {
+		const clock = sinon.useFakeTimers({ now: 4_000 });
+		refreshLocalCapability.rejects(new Error("advert failed"));
+		coordinator = createCoordinator({
+			requestRetryMs: 5,
+			maxRequestRetryMs: 20,
+		});
+		const lifecycle = new AbortController();
+		const first = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		for (let index = 0; index < 10_000; index++) {
+			const coalesced = coordinator.advertiseLocalCapability({
+				target: sender,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+				signal: lifecycle.signal,
+			});
+			expect(coalesced.firstAttempt).to.equal(first.firstAttempt);
+		}
+		await first.firstAttempt;
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(1);
+		const state =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(state.attempts).to.equal(1);
+		expect(state.timer).to.exist;
+
+		await clock.tickAsync(5 + 10 + 20 + 20);
+		expect(refreshLocalCapability.callCount).to.equal(5);
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(1);
+		expect(state.timer).to.exist;
+	});
+
+	it("fences a capability retry when the local transport session rotates", async () => {
+		const clock = sinon.useFakeTimers({ now: 5_000 });
+		let localTransportSession = receiverTransportSession;
+		refreshLocalCapability.rejects(new Error("advert failed"));
+		coordinator = new ReplicationInfoV2ReceiveCoordinator({
+			getSelfKey: () => self,
+			getReceiverTransportSession: () => localTransportSession,
+			isClosed: () => closed,
+			isPeerSessionCurrent: (_peerHash, peerSession) =>
+				peerSession === currentSession,
+			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
+				receiveEpoch === currentReceiveEpoch,
+			isPeerStateCurrent: (_peerHash, peerSession, receiveEpoch) =>
+				peerSession === currentSession && receiveEpoch === currentReceiveEpoch,
+			isSenderTransportSessionCurrent: (_peerHash, transportSession) =>
+				transportSession === currentSenderTransportSession,
+			sendRequest,
+			refreshLocalCapability,
+			requestRetryMs: 5,
+			maxRequestRetryMs: 20,
+		});
+		const lifecycle = new AbortController();
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await handle.firstAttempt;
+		const stale =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(stale.timer).to.exist;
+
+		localTransportSession++;
+		handle.releaseLegacyBarrier();
+		await clock.tickAsync(5);
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(stale.controller.signal.aborted).to.be.true;
+		expect(stale.timer).to.be.undefined;
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(0);
+		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
+			.false;
+	});
+
+	it("clears an ACKed advert when transport rotates before barrier release", async () => {
+		let localTransportSession = receiverTransportSession;
+		coordinator = new ReplicationInfoV2ReceiveCoordinator({
+			getSelfKey: () => self,
+			getReceiverTransportSession: () => localTransportSession,
+			isClosed: () => closed,
+			isPeerSessionCurrent: (_peerHash, peerSession) =>
+				peerSession === currentSession,
+			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
+				receiveEpoch === currentReceiveEpoch,
+			isPeerStateCurrent: (_peerHash, peerSession, receiveEpoch) =>
+				peerSession === currentSession && receiveEpoch === currentReceiveEpoch,
+			isSenderTransportSessionCurrent: (_peerHash, transportSession) =>
+				transportSession === currentSenderTransportSession,
+			sendRequest,
+			refreshLocalCapability,
+		});
+		const lifecycle = new AbortController();
+		const handle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await handle.firstAttempt;
+		const stale =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		expect(stale.acknowledgedReady).to.exist;
+
+		localTransportSession++;
+		handle.releaseLegacyBarrier();
+		expect(stale.controller.signal.aborted).to.be.true;
+		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(0);
+		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
+			.false;
+		expect(coordinator._localCapabilityContextBySession.has(currentSession)).to
+			.be.false;
+	});
+
+	it("recovers before remote capability without bypassing the opening barrier", async () => {
+		const clock = sinon.useFakeTimers({ now: 5_100 });
+		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
+		refreshLocalCapability.onSecondCall().callsFake(async () => ({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		}));
+		const oldEpoch = currentReceiveEpoch;
+		const lifecycle = new AbortController();
+		const openingHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: oldEpoch,
+			signal: lifecycle.signal,
+		});
+		await openingHandle.firstAttempt;
+		const openingAdvertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+
+		peerStateReady = false;
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.reAdvertiseLocalCapabilityForRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		const replacement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		await replacement.firstAttempt;
+		expect(replacement).not.to.equal(openingAdvertisement);
+		expect(replacement.context).to.equal(openingAdvertisement.context);
+		expect(replacement.receiveEpoch).to.equal(currentReceiveEpoch);
+		expect(replacement.ready).to.be.false;
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+
+		peerStateReady = true;
+		await clock.tickAsync(5);
+		expect(refreshLocalCapability.callCount).to.equal(2);
+		expect(replacement.acknowledgedReady).to.exist;
+		expect(replacement.ready).to.be.false;
+		expect(observeSender()).to.be.true;
+		expect(coordinator._receiveStates.get(peerHash)?.receiverBinding).to.be
+			.undefined;
+
+		openingHandle.releaseLegacyBarrier();
+		expect(replacement.ready).to.be.true;
+		expect(coordinator._receiveStates.get(peerHash)?.receiverBinding).to.exist;
+		await clock.tickAsync(1);
+		expect(sendRequest.calledOnce).to.be.true;
+	});
+
+	it("keeps recovery readiness across remote sender-state replacement", async () => {
+		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
+		refreshLocalCapability.onSecondCall().resolves({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		const lifecycle = new AbortController();
+		const openingHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await openingHandle.firstAttempt;
+		openingHandle.releaseLegacyBarrier();
+
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.reAdvertiseLocalCapabilityForRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		const advertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		await advertisement.firstAttempt;
+		expect(advertisement.ready).to.be.true;
+		expect(observeSender()).to.be.true;
+		const oldState = coordinator._receiveStates.get(peerHash)!;
+		const oldBinding = oldState.receiverBinding!.slice();
+		const ready =
+			coordinator._localCapabilityReadyBySession.get(currentSession);
+
+		currentSenderTransportSession++;
+		expect(observeSender(2n, currentSenderTransportSession)).to.be.true;
+		const replacementState = coordinator._receiveStates.get(peerHash)!;
+		expect(oldState.controller.signal.aborted).to.be.true;
+		expect(replacementState).not.to.equal(oldState);
+		expect([...replacementState.receiverBinding!]).not.to.deep.equal([
+			...oldBinding,
+		]);
+		expect(
+			coordinator._localCapabilityReadyBySession.get(currentSession),
+		).to.equal(ready);
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash),
+		).to.equal(advertisement);
+		expect(advertisement.controller.signal.aborted).to.be.false;
+		expect(lifecycle.signal.aborted).to.be.false;
+	});
+
+	it("uses immediate refreshGrant after cutover without a parallel advert", async () => {
+		const clock = sinon.useFakeTimers({ now: 5_200 });
+		const lifecycle = new AbortController();
+		const openingHandle = coordinator.advertiseLocalCapability({
+			target: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			signal: lifecycle.signal,
+		});
+		await openingHandle.firstAttempt;
+		openingHandle.releaseLegacyBarrier();
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(8),
+			sequence: 1n,
+			segments: [],
+		});
+		const admission = prepare(full);
+		expect(admission).to.exist;
+		expect(coordinator.commit(admission!)).to.be.true;
+		const advertisement =
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		const refreshesBeforeRecovery = refreshLocalCapability.callCount;
+
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		expect(
+			coordinator.reAdvertiseLocalCapabilityForRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+		expect(
+			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash),
+		).to.equal(advertisement);
+		await clock.tickAsync(0);
+		expect(refreshLocalCapability.callCount).to.equal(
+			refreshesBeforeRecovery + 1,
+		);
+		await clock.tickAsync(1);
+		expect(sendRequest.calledOnce).to.be.true;
 	});
 
 	it("orders Full, Added and recovery Full independently of transport time", () => {
@@ -1077,6 +1742,8 @@ describe("receive admission replication-info V2 receiver state", () => {
 			isClosed: () => false,
 			isPeerSessionOpen: (_hash, peerSession) =>
 				peerSession === senderPeerSession,
+			isPeerSessionCurrent: (_hash, peerSession) =>
+				peerSession === senderPeerSession,
 			captureReplicationOwnershipLifecycle: () => ownershipController,
 			isReplicationOwnershipLifecycleActive: (controller) =>
 				controller === ownershipController && !controller.signal.aborted,
@@ -1207,6 +1874,179 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			},
 			{ timeout: 20_000 },
 		);
+	});
+
+	it("recovers first capability-advert failures for both exact peer sessions", async () => {
+		session = await TestSession.disconnected(2);
+		const store1 = new EventStore();
+		const store2 = new EventStore({ id: store1.id });
+		const logs = [store1.log as any, store2.log as any];
+		const adverts: sinon.SinonStub[] = [];
+		for (const log of logs) {
+			const original =
+				log.advertiseReplicationInfoV2ReceiveCapability.bind(log);
+			let first = true;
+			adverts.push(
+				sinon
+					.stub(log, "advertiseReplicationInfoV2ReceiveCapability")
+					.callsFake(async (...args: unknown[]) => {
+						if (first) {
+							first = false;
+							throw new Error("first capability advert failed");
+						}
+						return original(...args);
+					}),
+			);
+		}
+		const db1 = await session.peers[0].open(store1, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const db2 = await session.peers[1].open(store2, {
+			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+		});
+		await session.connect([[session.peers[0], session.peers[1]]]);
+		const log1 = db1.log as any;
+		const log2 = db2.log as any;
+		const hash1 = session.peers[0].identity.publicKey.hashcode();
+		const hash2 = session.peers[1].identity.publicKey.hashcode();
+
+		await waitForResolved(
+			() => {
+				expect(log1._v2Receive._receiveStates.get(hash2)?.phase).to.equal(
+					"active",
+				);
+				expect(log2._v2Receive._receiveStates.get(hash1)?.phase).to.equal(
+					"active",
+				);
+				expect(adverts[0].callCount).to.be.greaterThanOrEqual(2);
+				expect(adverts[1].callCount).to.be.greaterThanOrEqual(2);
+				const advert1 =
+					log1._v2Receive._localCapabilityAdvertisementsByPeer.get(hash2);
+				const advert2 =
+					log2._v2Receive._localCapabilityAdvertisementsByPeer.get(hash1);
+				expect(advert1?.ready).to.be.true;
+				expect(advert2?.ready).to.be.true;
+				expect(advert1?.peerSession).to.equal(
+					log1._peerSessions.current(hash2),
+				);
+				expect(advert2?.peerSession).to.equal(
+					log2._peerSessions.current(hash1),
+				);
+			},
+			{ timeout: 20_000 },
+		);
+	});
+
+	it("restores a rejected V2 delta with a Full while its legacy sidecar is suppressed", async () => {
+		session = await TestSession.connected(2);
+		const db1 = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const db2 = await EventStore.open<EventStore<string, any>>(
+			db1.address!,
+			session.peers[1],
+			{
+				args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			},
+		);
+		const receiver = db1.log as any;
+		const senderLog = db2.log as any;
+		const senderHash = session.peers[1].identity.publicKey.hashcode();
+		const receiverHash = session.peers[0].identity.publicKey.hashcode();
+		await waitForResolved(
+			() => {
+				expect(
+					receiver._v2Receive._receiveStates.get(senderHash)?.phase,
+				).to.equal("active");
+				expect(senderLog._v2Send._sendStates.get(receiverHash)?.established).to
+					.be.true;
+			},
+			{ timeout: 20_000 },
+		);
+
+		const range = new ReplicationRangeMessageU64({
+			id: bytes(42),
+			offset: 10n,
+			factor: 10n,
+			timestamp: 10n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const indexedRange = range.toReplicationRangeIndexable(
+			session.peers[1].identity.publicKey,
+		);
+		const legacy = new AddedReplicationSegmentMessage({ segments: [range] });
+		const getSegments = sinon
+			.stub(senderLog, "getMyReplicationSegments")
+			.resolves([indexedRange]);
+		const originalSend = senderLog.rpc.send.bind(senderLog.rpc);
+		let rejectedV2Delta = 0;
+		let suppressedLegacy = 0;
+		let recoveryFull: FullReplicationInfoV2Message | undefined;
+		const send = sinon
+			.stub(senderLog.rpc, "send")
+			.callsFake(async (message: unknown, options: unknown) => {
+				if (message === legacy) {
+					suppressedLegacy++;
+					return [];
+				}
+				if (
+					message instanceof AddedReplicationInfoV2Message &&
+					rejectedV2Delta === 0
+				) {
+					rejectedV2Delta++;
+					throw new Error("ambiguous V2 delta delivery");
+				}
+				if (message instanceof FullReplicationInfoV2Message) {
+					recoveryFull = message;
+				}
+				return originalSend(message, options);
+			});
+		const queueLegacyRepair = sinon.stub(
+			senderLog._announcements,
+			"queueCurrentReplicationStateAnnouncementRepair",
+		);
+		(senderLog._v2Send as any).sendRetryMs = 25;
+		(senderLog._v2Send as any).maxSendRetryMs = 50;
+
+		try {
+			await senderLog._announcements.sendReplicationAnnouncement(legacy);
+			await senderLog._v2Send.drain();
+			const failedState = senderLog._v2Send._sendStates.get(receiverHash);
+			expect(rejectedV2Delta).to.equal(1);
+			expect(suppressedLegacy).to.equal(1);
+			expect(failedState?.suspended).to.be.true;
+			const beforeRecovery = await receiver.replicationIndex
+				.iterate({ query: { hash: senderHash } })
+				.all();
+			expect(
+				beforeRecovery.some(
+					(result: any) => result.value.idString === indexedRange.idString,
+				),
+			).to.be.false;
+
+			await waitForResolved(
+				async () => {
+					const ranges = await receiver.replicationIndex
+						.iterate({ query: { hash: senderHash } })
+						.all();
+					expect(
+						ranges.map((result: any) => result.value.idString),
+					).to.deep.equal([indexedRange.idString]);
+					expect(
+						receiver._v2Receive._receiveStates.get(senderHash)?.phase,
+					).to.equal("active");
+				},
+				{ timeout: 10_000 },
+			);
+			expect(recoveryFull).to.exist;
+			expect(recoveryFull!.sequence).to.equal(failedState!.nextSequence - 1n);
+			expect(getSegments.called).to.be.true;
+			expect(queueLegacyRepair.calledOnce).to.be.true;
+		} finally {
+			queueLegacyRepair.restore();
+			send.restore();
+			getSegments.restore();
+		}
 	});
 
 	it("rejects transport-generation downgrade replay on the signed host path", async () => {

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -33,13 +33,37 @@ describe("receive admission replication-info V2 sender streams", () => {
 	const self = key(1);
 	const peerA = key(2);
 	const peerB = key(3);
-	const senderTransportSession = 0x20000000000001n;
+	const initialSenderTransportSession = 0x20000000000001n;
+	let senderTransportSession: bigint;
 	let closed: boolean;
 	let openSessions: Set<object>;
+	let closedReadinessGates: Set<object>;
 	let rpcSend: sinon.SinonStub;
 	let getSegments: sinon.SinonStub;
 	let ownershipController: AbortController;
 	let coordinator: ReplicationInfoV2SendCoordinator<"u32">;
+
+	const createCoordinator = (options?: {
+		sendRetryMs?: number;
+		maxSendRetryMs?: number;
+	}) =>
+		new ReplicationInfoV2SendCoordinator<"u32">({
+			getRpc: () => ({ send: rpcSend }) as any,
+			getSelfKey: () => self,
+			getSenderTransportSession: () => senderTransportSession,
+			getMyReplicationSegments: getSegments,
+			validatePersistedReplicationRangeSnapshot: () => {},
+			isClosed: () => closed,
+			isPeerSessionCurrent: (_peerHash, peerSession) =>
+				openSessions.has(peerSession),
+			isPeerSessionOpen: (_peerHash, peerSession) =>
+				openSessions.has(peerSession) && !closedReadinessGates.has(peerSession),
+			captureReplicationOwnershipLifecycle: () => ownershipController,
+			isReplicationOwnershipLifecycleActive: (controller) =>
+				controller === ownershipController && !controller.signal.aborted,
+			sendRetryMs: options?.sendRetryMs,
+			maxSendRetryMs: options?.maxSendRetryMs,
+		});
 
 	const makeRequest = (
 		receiverChallenge: Uint8Array,
@@ -69,23 +93,13 @@ describe("receive admission replication-info V2 sender streams", () => {
 
 	beforeEach(() => {
 		closed = false;
+		senderTransportSession = initialSenderTransportSession;
 		openSessions = new Set();
+		closedReadinessGates = new Set();
 		rpcSend = sinon.stub().resolves([]);
 		getSegments = sinon.stub().resolves([]);
 		ownershipController = new AbortController();
-		coordinator = new ReplicationInfoV2SendCoordinator<"u32">({
-			getRpc: () => ({ send: rpcSend }) as any,
-			getSelfKey: () => self,
-			getSenderTransportSession: () => senderTransportSession,
-			getMyReplicationSegments: getSegments,
-			validatePersistedReplicationRangeSnapshot: () => {},
-			isClosed: () => closed,
-			isPeerSessionOpen: (_peerHash, peerSession) =>
-				openSessions.has(peerSession),
-			captureReplicationOwnershipLifecycle: () => ownershipController,
-			isReplicationOwnershipLifecycleActive: (controller) =>
-				controller === ownershipController && !controller.signal.aborted,
-		});
+		coordinator = createCoordinator();
 	});
 
 	afterEach(() => {
@@ -118,6 +132,18 @@ describe("receive admission replication-info V2 sender streams", () => {
 		openSessions.delete(peerSession);
 		expect(accept(peerA, peerSession, challenge(4))).to.be.false;
 		await coordinator.drain();
+		expect(rpcSend.notCalled).to.be.true;
+		expect(coordinator._sendStates.size).to.equal(0);
+	});
+
+	it("rejects a request when captured ownership is already inactive", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		ownershipController.abort();
+
+		expect(accept(peerA, peerSession, challenge(41))).to.be.false;
+		await coordinator.drain();
+		expect(getSegments.notCalled).to.be.true;
 		expect(rpcSend.notCalled).to.be.true;
 		expect(coordinator._sendStates.size).to.equal(0);
 	});
@@ -267,6 +293,33 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(rpcSend.calledOnce).to.be.true;
 	});
 
+	it("fences an old state when the local sender transport session rotates", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const oldSnapshot = pDefer<never[]>();
+		getSegments.onFirstCall().returns(oldSnapshot.promise);
+		expect(accept(peerA, peerSession, challenge(42), 10n)).to.be.true;
+		await waitForResolved(() => expect(getSegments.calledOnce).to.be.true);
+		const oldState = coordinator._sendStates.get(peerA.hashcode())!;
+
+		senderTransportSession += 1n;
+		oldSnapshot.resolve([]);
+		await coordinator.drain();
+		expect(oldState.controller.signal.aborted).to.be.true;
+		expect(coordinator._sendStates.size).to.equal(0);
+		expect(rpcSend.notCalled).to.be.true;
+
+		expect(accept(peerA, peerSession, challenge(43), 11n)).to.be.true;
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+		const replacement = rpcSend.firstCall
+			.args[0] as FullReplicationInfoV2Message;
+		expect(replacement.sequence).to.equal(1n);
+		expect(coordinator._sendStates.get(peerA.hashcode())?.peerSession).to.equal(
+			peerSession,
+		);
+	});
+
 	it("keeps independent sequences and challenges for two destinations", async () => {
 		const sessionA = {};
 		const sessionB = {};
@@ -355,6 +408,379 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(failedState?.established).to.be.true;
 	});
 
+	it("self-heals an ambiguous send with a Full at the next sequence", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		rpcSend.onFirstCall().rejects(new Error("ambiguous delivery"));
+		rpcSend.onSecondCall().resolves([]);
+
+		expect(accept(peerA, peerSession, challenge(26))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(state.suspended).to.be.true;
+		expect(state.nextSequence).to.equal(2n);
+		expect(state.retryAttempts).to.equal(1);
+		expect(state.retryTimer).to.exist;
+		expect((state.retryTimer as any).hasRef()).to.be.false;
+
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.firstCall.args[0]).to.be.instanceOf(
+			FullReplicationInfoV2Message,
+		);
+		const recovered = rpcSend.secondCall
+			.args[0] as FullReplicationInfoV2Message;
+		expect(recovered).to.be.instanceOf(FullReplicationInfoV2Message);
+		expect(recovered.sequence).to.equal(2n);
+		expect(state.suspended).to.be.false;
+		expect(state.retryAttempts).to.equal(0);
+		expect(state.retryTimer).to.be.undefined;
+	});
+
+	it("parks sequence one when readiness closes during snapshot creation", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const snapshot = pDefer<never[]>();
+		getSegments.returns(snapshot.promise);
+
+		expect(accept(peerA, peerSession, challenge(36))).to.be.true;
+		await clock.tickAsync(0);
+		expect(getSegments.calledOnce).to.be.true;
+		closedReadinessGates.add(peerSession);
+		snapshot.resolve([]);
+		await coordinator.drain();
+
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(rpcSend.notCalled).to.be.true;
+		expect(state.nextSequence).to.equal(1n);
+		expect(state.suspended).to.be.true;
+		expect(state.pending).to.deep.equal({ kind: "snapshot" });
+		expect(state.retryTimer).to.exist;
+
+		closedReadinessGates.delete(peerSession);
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+		const resumed = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		expect(resumed.sequence).to.equal(1n);
+		expect(state.established).to.be.true;
+	});
+
+	it("recovers when readiness closes before a successful send continuation", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		let closeGateOnSend = true;
+		rpcSend.callsFake(async () => {
+			if (closeGateOnSend) {
+				closeGateOnSend = false;
+				closedReadinessGates.add(peerSession);
+			}
+			return [];
+		});
+
+		expect(accept(peerA, peerSession, challenge(44))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(rpcSend.calledOnce).to.be.true;
+		expect(rpcSend.firstCall.args[0].sequence).to.equal(1n);
+		expect(state.nextSequence).to.equal(2n);
+		expect(state.suspended).to.be.true;
+		expect(state.pending).to.deep.equal({ kind: "snapshot" });
+
+		closedReadinessGates.delete(peerSession);
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		const recovered = rpcSend.secondCall
+			.args[0] as FullReplicationInfoV2Message;
+		expect(recovered).to.be.instanceOf(FullReplicationInfoV2Message);
+		expect(recovered.sequence).to.equal(2n);
+		expect(state.established).to.be.true;
+	});
+
+	it("recovers a consumed sequence rejection after the readiness gate reopens", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(37))).to.be.true;
+		await coordinator.drain();
+		const initial = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		const rejectedSend = pDefer<void>();
+		rpcSend.onSecondCall().returns(rejectedSend.promise);
+
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await clock.tickAsync(0);
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
+		closedReadinessGates.add(peerSession);
+		rejectedSend.reject(new Error("gate closed after sequence consumption"));
+		await coordinator.drain();
+
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(state.nextSequence).to.equal(3n);
+		expect(state.inFlightSequence).to.be.undefined;
+		expect(state.suspended).to.be.true;
+		expect(state.pending).to.deep.equal({ kind: "snapshot" });
+
+		closedReadinessGates.delete(peerSession);
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(3);
+		const recovered = rpcSend.thirdCall.args[0] as FullReplicationInfoV2Message;
+		expect(recovered).to.be.instanceOf(FullReplicationInfoV2Message);
+		expect(recovered.sequence).to.equal(3n);
+		expect([...recovered.senderEpoch]).to.deep.equal([...initial.senderEpoch]);
+		expect([...recovered.receiverChallenge]).to.deep.equal([
+			...initial.receiverChallenge,
+		]);
+	});
+
+	it("spends a MAX_U64 stream before ownership teardown can retain it", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(38))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		state.nextSequence = (1n << 64n) - 1n;
+		rpcSend.resetHistory();
+		rpcSend.callsFake(
+			async (_message, options) =>
+				await new Promise<void>((_resolve, reject) => {
+					options.signal.addEventListener(
+						"abort",
+						() => reject(new Error("ownership closed at MAX_U64")),
+						{ once: true },
+					);
+				}),
+		);
+
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
+		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
+		ownershipController.abort();
+		await coordinator.drain();
+
+		expect(state.inFlightSequence).to.be.undefined;
+		expect(coordinator._sendStates.has(peerA.hashcode())).to.be.false;
+		expect(coordinator._spentPeerSessions.has(peerSession)).to.be.true;
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.calledOnce).to.be.true;
+	});
+
+	it("lets an actual PeerSession replacement start a new binding at sequence one", async () => {
+		const oldPeerSession = {};
+		const newPeerSession = {};
+		openSessions.add(oldPeerSession);
+		expect(accept(peerA, oldPeerSession, challenge(39))).to.be.true;
+		await coordinator.drain();
+		const oldState = coordinator._sendStates.get(peerA.hashcode())!;
+		const oldBinding = (
+			rpcSend.firstCall.args[0] as FullReplicationInfoV2Message
+		).receiverChallenge.slice();
+
+		closedReadinessGates.add(oldPeerSession);
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		expect(oldState.suspended).to.be.true;
+		expect(oldState.pending).to.deep.equal({ kind: "snapshot" });
+		openSessions.delete(oldPeerSession);
+		openSessions.add(newPeerSession);
+
+		expect(accept(peerA, newPeerSession, challenge(40), 2n)).to.be.true;
+		await coordinator.drain();
+		expect(oldState.controller.signal.aborted).to.be.true;
+		expect(rpcSend.callCount).to.equal(2);
+		const replacement = rpcSend.secondCall
+			.args[0] as FullReplicationInfoV2Message;
+		expect(replacement.sequence).to.equal(1n);
+		expect([...replacement.receiverChallenge]).to.not.deep.equal([
+			...oldBinding,
+		]);
+		expect(coordinator._sendStates.get(peerA.hashcode())?.peerSession).to.equal(
+			newPeerSession,
+		);
+	});
+
+	it("coalesces every backoff mutation into the current authoritative Full", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		rpcSend.onFirstCall().rejects(new Error("ambiguous delivery"));
+		rpcSend.onSecondCall().resolves([]);
+
+		expect(accept(peerA, peerSession, challenge(27))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		for (let index = 0; index < 10_000; index++) {
+			coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		}
+		expect(state.pending).to.deep.equal({ kind: "snapshot" });
+		expect(state.retryTimer).to.exist;
+
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.secondCall.args[0]).to.be.instanceOf(
+			FullReplicationInfoV2Message,
+		);
+		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
+		expect(getSegments.callCount).to.equal(2);
+	});
+
+	it("lets a newer same-challenge request preempt backoff exactly once", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const receiverChallenge = challenge(28);
+		rpcSend.onFirstCall().rejects(new Error("ambiguous delivery"));
+		rpcSend.onSecondCall().resolves([]);
+
+		expect(accept(peerA, peerSession, receiverChallenge, 10n)).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		expect(state.retryTimer).to.exist;
+		expect(accept(peerA, peerSession, receiverChallenge, 11n)).to.be.true;
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
+		expect(state.retryTimer).to.be.undefined;
+
+		await clock.tickAsync(1_000);
+		await coordinator.drain();
+		expect(rpcSend.callCount).to.equal(2);
+	});
+
+	it("fences retry timers on peer, reopen, session and ownership teardown", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		rpcSend.rejects(new Error("ambiguous delivery"));
+
+		expect(accept(peerA, peerSession, challenge(29))).to.be.true;
+		await coordinator.drain();
+		const cleared = coordinator._sendStates.get(peerA.hashcode())!;
+		coordinator.clearPeer(peerA.hashcode(), peerSession);
+		expect(cleared.retryTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(rpcSend.callCount).to.equal(1);
+
+		rpcSend.resetHistory();
+		rpcSend.rejects(new Error("ambiguous delivery"));
+		const reopeningSession = {};
+		openSessions.add(reopeningSession);
+		expect(accept(peerA, reopeningSession, challenge(30))).to.be.true;
+		await coordinator.drain();
+		const reopening = coordinator._sendStates.get(peerA.hashcode())!;
+		coordinator.resetForOpen();
+		expect(reopening.retryTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(rpcSend.callCount).to.equal(1);
+
+		rpcSend.resetHistory();
+		rpcSend.rejects(new Error("ambiguous delivery"));
+		const rotatedSession = {};
+		openSessions.add(rotatedSession);
+		expect(accept(peerA, rotatedSession, challenge(31))).to.be.true;
+		await coordinator.drain();
+		openSessions.delete(rotatedSession);
+		await clock.tickAsync(5);
+		expect(rpcSend.callCount).to.equal(1);
+		expect(coordinator._sendStates.has(peerA.hashcode())).to.be.false;
+
+		rpcSend.resetHistory();
+		rpcSend.rejects(new Error("ambiguous delivery"));
+		const ownershipSession = {};
+		openSessions.add(ownershipSession);
+		expect(accept(peerA, ownershipSession, challenge(32))).to.be.true;
+		await coordinator.drain();
+		const retained = coordinator._sendStates.get(peerA.hashcode())!;
+		ownershipController.abort();
+		expect(retained.retryTimer).to.be.undefined;
+		await clock.tickAsync(5);
+		expect(rpcSend.callCount).to.equal(1);
+		expect(retained.retryTimer).to.be.undefined;
+		expect(coordinator._sendStates.get(peerA.hashcode())).to.equal(retained);
+	});
+
+	it("retires an ambiguous MAX_U64 attempt without scheduling a retry", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(33))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		state.nextSequence = (1n << 64n) - 1n;
+		rpcSend.resetHistory();
+		rpcSend.rejects(new Error("ambiguous final delivery"));
+
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await coordinator.drain();
+		expect(rpcSend.calledOnce).to.be.true;
+		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
+		expect(coordinator._sendStates.has(peerA.hashcode())).to.be.false;
+		expect(coordinator._spentPeerSessions.has(peerSession)).to.be.true;
+		await clock.tickAsync(100);
+		expect(rpcSend.calledOnce).to.be.true;
+	});
+
+	it("backs off a failed destination without delaying another destination", async () => {
+		const clock = sinon.useFakeTimers();
+		coordinator.clearForClose();
+		coordinator = createCoordinator({ sendRetryMs: 5, maxSendRetryMs: 20 });
+		const sessionA = {};
+		const sessionB = {};
+		openSessions.add(sessionA);
+		openSessions.add(sessionB);
+		let failedA = false;
+		rpcSend.callsFake(async (_message, options) => {
+			if (!failedA && options.mode.to[0] === peerA.hashcode()) {
+				failedA = true;
+				throw new Error("peer A delivery failed");
+			}
+			return [];
+		});
+
+		expect(accept(peerA, sessionA, challenge(34))).to.be.true;
+		expect(accept(peerB, sessionB, challenge(35))).to.be.true;
+		await coordinator.drain();
+		expect(coordinator._sendStates.get(peerA.hashcode())?.retryTimer).to.exist;
+		expect(coordinator._sendStates.get(peerB.hashcode())?.established).to.be
+			.true;
+		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		await coordinator.drain();
+		expect(
+			rpcSend.args.some(
+				(args) =>
+					args[1].mode.to[0] === peerB.hashcode() &&
+					args[0] instanceof AddedReplicationInfoV2Message,
+			),
+		).to.be.true;
+
+		await clock.tickAsync(5);
+		await coordinator.drain();
+		expect(coordinator._sendStates.get(peerA.hashcode())?.established).to.be
+			.true;
+	});
+
 	it("never wraps or recreates a stream after u64 exhaustion", async () => {
 		const peerSession = {};
 		openSessions.add(peerSession);
@@ -411,10 +837,49 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(terminal.segments).to.deep.equal([]);
 	});
 
-	it("uses the last safe u64 sequence for an idle terminal reset", async () => {
+	it("consumes a new sequence for every terminal attempt, including sync throws", async () => {
+		const peerSessionA = {};
+		const peerSessionB = {};
+		openSessions.add(peerSessionA);
+		openSessions.add(peerSessionB);
+		expect(accept(peerA, peerSessionA, challenge(45))).to.be.true;
+		expect(accept(peerB, peerSessionB, challenge(46))).to.be.true;
+		await coordinator.drain();
+		const stateA = coordinator._sendStates.get(peerA.hashcode())!;
+		const stateB = coordinator._sendStates.get(peerB.hashcode())!;
+		ownershipController.abort();
+		rpcSend.resetHistory();
+		rpcSend.onFirstCall().throws(new Error("synchronous terminal failure"));
+		rpcSend.onSecondCall().resolves([]);
+
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.callCount).to.equal(2);
+		const failed = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		const continued = rpcSend.secondCall
+			.args[0] as FullReplicationInfoV2Message;
+		expect(failed.sequence).to.equal(2n);
+		expect(continued.sequence).to.equal(2n);
+		expect(continued.segments).to.deep.equal([]);
+		expect(stateA.nextSequence).to.equal(3n);
+		expect(stateB.nextSequence).to.equal(3n);
+
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.callCount).to.equal(4);
+		const retriedA = rpcSend.thirdCall.args[0] as FullReplicationInfoV2Message;
+		const retriedB = rpcSend.getCall(3).args[0] as FullReplicationInfoV2Message;
+		expect(retriedA.sequence).to.equal(3n);
+		expect(retriedB.sequence).to.equal(3n);
+		expect(retriedA.segments).to.deep.equal([]);
+		expect(retriedB.segments).to.deep.equal([]);
+		expect(stateA.nextSequence).to.equal(4n);
+		expect(stateB.nextSequence).to.equal(4n);
+	});
+
+	it("spends the last u64 terminal sequence and cannot retry or recreate it", async () => {
 		const peerSession = {};
 		openSessions.add(peerSession);
-		expect(accept(peerA, peerSession, challenge(24))).to.be.true;
+		const receiverChallenge = challenge(24);
+		expect(accept(peerA, peerSession, receiverChallenge)).to.be.true;
 		await coordinator.drain();
 		const state = coordinator._sendStates.get(peerA.hashcode())!;
 		state.nextSequence = (1n << 64n) - 1n;
@@ -426,6 +891,17 @@ describe("receive admission replication-info V2 sender streams", () => {
 		const terminal = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
 		expect(terminal.sequence).to.equal((1n << 64n) - 1n);
 		expect(terminal.segments).to.deep.equal([]);
+		expect(state.nextSequence).to.equal(1n << 64n);
+		expect(coordinator._spentPeerSessions.has(peerSession)).to.be.true;
+		expect(coordinator._sendStates.has(peerA.hashcode())).to.be.false;
+
+		rpcSend.resetHistory();
+		await coordinator.sendTerminalReset(new AbortController().signal);
+		expect(rpcSend.notCalled).to.be.true;
+		ownershipController = new AbortController();
+		expect(accept(peerA, peerSession, receiverChallenge, 2n)).to.be.false;
+		await coordinator.drain();
+		expect(rpcSend.notCalled).to.be.true;
 	});
 
 	it("uses the last safe u64 sequence after an ambiguous predecessor", async () => {


### PR DESCRIPTION
## Summary

- keep authenticated V2 sender streams alive across temporary cleanup gates while preserving consumed-sequence and `MAX_U64` fences
- split receiver session ownership, receive-epoch generation, and temporary readiness so capability negotiation self-heals without bypassing the legacy startup barrier
- re-advertise capability after pre-ready recovery and add deterministic coverage for session, epoch, transport, barrier, and terminal-reset races

## Validation

- `@peerbit/shared-log` TypeScript build
- Prettier and ESLint on all changed files
- sender coordinator: 29/29; race stress: 580/580
- receiver coordinator: 33/33; race stress: 280/280
- changeset guard tests: 52/52; exact package coverage accepted

Includes a patch changeset for `@peerbit/shared-log`.
