### PR TITLE
feat(shared-log): default replication info to v2

### DIFF
--- a/.changeset/fast-peers-use-v2.md
+++ b/.changeset/fast-peers-use-v2.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Use authenticated replication-info V2 by default while retaining legacy fallback for explicit pre-v10 compatibility opens.

--- a/.changeset/fast-peers-use-v2.md
+++ b/.changeset/fast-peers-use-v2.md
@@ -1,5 +1,8 @@
 ---
 "@peerbit/shared-log": patch
+"@peerbit/pubsub": patch
+"@peerbit/pubsub-interface": patch
+"@peerbit/document": patch
 ---
 
-Use authenticated replication-info V2 by default while retaining legacy fallback for explicit pre-v10 compatibility opens.
+Use authenticated replication-info V2 by default while retaining legacy fallback for explicit pre-v10 compatibility opens, bind subscription events to their signed transport generation so reconnect handshakes cannot inherit stale capabilities, and establish both document-index and shared-log topics before reporting peer readiness.

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -42,6 +42,7 @@ import {
 import {
 	DataMessage,
 	FOREGROUND_READ_MESSAGE_PRIORITY,
+	type PeerRef,
 	type PeerRefs,
 	SilentDelivery,
 } from "@peerbit/stream-interface";
@@ -7078,7 +7079,33 @@ export class DocumentIndex<
 			timeout?: number;
 		},
 	): Promise<string[]> {
-		const hashes = await super.waitFor(other, options);
+		// A document index and its SharedLog use separate RPC topics. Establish
+		// both before polling the replication index; otherwise a late-connected
+		// peer can be ready for queries while its replication-info session has
+		// never opened.
+		const reusableOther =
+			typeof (other as IterableIterator<PeerRef>).next === "function"
+				? [...(other as IterableIterator<PeerRef>)]
+				: other;
+		const waitController = new AbortController();
+		const waitOptions = {
+			...options,
+			signal: options?.signal
+				? AbortSignal.any([options.signal, waitController.signal])
+				: waitController.signal,
+		};
+		let hashes: string[];
+		try {
+			const [logHashes, indexHashes] = await Promise.all([
+				this._log.waitFor(reusableOther, waitOptions),
+				super.waitFor(reusableOther, waitOptions),
+			]);
+			const logPeers = new Set(logHashes);
+			hashes = indexHashes.filter((hash) => logPeers.has(hash));
+		} finally {
+			// If either topic wait rejects, retire the sibling's listeners/polling.
+			waitController.abort();
+		}
 		for (const key of hashes) {
 			await waitFor(
 				async () =>

--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -10404,6 +10404,7 @@ describe("index", () => {
 						replicate: false,
 					},
 				});
+				await nonReplicator.docs.index.waitFor(store.node.identity.publicKey);
 				const docResolved = await nonReplicator.docs.index.get(id, {
 					waitFor: 5e3,
 				});
@@ -14869,10 +14870,12 @@ describe("index", () => {
 
 						await session.connect([[session.peers[0], session.peers[2]]]); // connect the nodes!
 
-						await observer.docs.log.waitForReplicator(
-							writer2.node.identity.publicKey,
-							{ eager: true },
+						const readyWriter2 = await observer.docs.index.waitFor(
+							[writer2.node.identity.publicKey].values(),
 						);
+						expect(readyWriter2).to.deep.equal([
+							writer2.node.identity.publicKey.hashcode(),
+						]);
 
 						const iterator = observer.docs.index.iterate(
 							{ sort: new Sort({ key: "id", direction: SortDirection.DESC }) }, // 4, 3, 2, 1
@@ -14899,9 +14902,8 @@ describe("index", () => {
 						expect(second.map((x) => x.id)).to.deep.equal(["2"]);
 
 						await session.connect([[session.peers[0], session.peers[1]]]); // connect the nodes!
-						await observer.docs.log.waitForReplicator(
+						await observer.docs.index.waitFor(
 							writer1.node.identity.publicKey,
-							{ eager: true },
 						);
 
 						const third = await waitForResolved(

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -15531,10 +15531,11 @@ export class SharedLog<
 
 	async afterOpen(): Promise<void> {
 		await super.afterOpen();
-		// This is a subscription fallback, not peer discovery. The broader
-		// _getTopicSubscribers() union also contains connected/provider/fanout
-		// candidates that have not subscribed to this log; treating those as an
-		// opening creates a false predecessor before their first real subscribe.
+		// Start the broader discovery eagerly, in parallel with rebalance, for its
+		// routing/cache side effects. It also contains connected/provider/fanout
+		// candidates that have not subscribed to this log, so only the authoritative
+		// pubsub snapshot below may create subscription fallback sessions.
+		const subscriberDiscoveryPromise = this._getTopicSubscribers(this.topic);
 		const existingSubscribersPromise = this.node.services.pubsub.getSubscribers(
 			this.topic,
 		);
@@ -15558,6 +15559,7 @@ export class SharedLog<
 		this._liveness.startReplicatorLivenessSweep();
 
 		await this.rebalanceParticipation();
+		await subscriberDiscoveryPromise;
 
 		// Take into account existing subscription
 		(await existingSubscribersPromise)?.forEach((v) => {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -15531,7 +15531,13 @@ export class SharedLog<
 
 	async afterOpen(): Promise<void> {
 		await super.afterOpen();
-		const existingSubscribersPromise = this._getTopicSubscribers(this.topic);
+		// This is a subscription fallback, not peer discovery. The broader
+		// _getTopicSubscribers() union also contains connected/provider/fanout
+		// candidates that have not subscribed to this log; treating those as an
+		// opening creates a false predecessor before their first real subscribe.
+		const existingSubscribersPromise = this.node.services.pubsub.getSubscribers(
+			this.topic,
+		);
 		const replicationLifecycleController =
 			this._instanceLifecycle?.membershipLifecycleController;
 
@@ -15561,9 +15567,23 @@ export class SharedLog<
 			if (this.closed) {
 				return;
 			}
-			void this.runSubscriptionChangeCallback(() =>
-				this.handleSubscriptionChange(v, [this.topic], true),
-			);
+			// The live subscribe event and this after-open snapshot can report the
+			// same initial transport generation. The live callback rotates its
+			// PeerSession synchronously, so any current session here proves the
+			// fallback is stale/duplicate. Rotating again would erase the signed
+			// capability binding that the first callback just established.
+			if (this._peerSessions.current(v.hashcode()) !== null) {
+				return;
+			}
+			void this.runSubscriptionChangeCallback(async () => {
+				// The live event may rotate after the outer check but before this queued
+				// fallback runs. Recheck at execution so the snapshot cannot create a
+				// duplicate successor session in that window.
+				if (this._peerSessions.current(v.hashcode()) !== null) {
+					return;
+				}
+				await this.handleSubscriptionChange(v, [this.topic], true);
+			});
 		});
 	}
 
@@ -23556,8 +23576,15 @@ export class SharedLog<
 		// yield; a late queue completion must never enter the new session.
 		this._v2Receive.clearPeer(peerHash);
 		this._v2Send.clearPeer(peerHash);
-		this._peerSyncCapabilitySessions.delete(peerHash);
-		this._peerSyncCapabilityTimestamps.delete(peerHash);
+		if (!subscribed || expectedSubscriptionEpoch.hasPredecessor) {
+			// Departures and successor openings revoke the signed transport binding.
+			// Only the first opening may inherit a capability that arrived before its
+			// subscription callback. afterOpen() deduplicates its subscriber snapshot
+			// against the live callback, so a true successor can never be mistaken for
+			// that startup race.
+			this._peerSyncCapabilitySessions.delete(peerHash);
+			this._peerSyncCapabilityTimestamps.delete(peerHash);
+		}
 		if (subscribed) {
 			const pendingOpeningCapabilities =
 				this._openingSyncCapabilitiesByPeer.get(peerHash);

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2086,7 +2086,11 @@ export class SharedLog<
 	// reconnect barrier commits. See PeerSessionRegistry._replicationInfoBlockedPeers.
 	private _replicationInfoRequestByPeer!: Map<
 		string,
-		{ attempts: number; timer?: ReturnType<typeof setTimeout> }
+		{
+			attempts: number;
+			timer?: ReturnType<typeof setTimeout>;
+			peerSession?: PeerSession;
+		}
 	>;
 	private _replicationInfoApplyQueueByPeer!: Map<string, Promise<void>>;
 	// Range ids are global primary keys while receive lanes are per peer. Keep
@@ -3382,6 +3386,7 @@ export class SharedLog<
 					error,
 				),
 			enqueueReplicationInfoV2: (message) => this._v2Send.enqueue(message),
+			isLegacyReplicationInfoEnabled: () => this.legacyReplicationInfoEnabled,
 			isClosed: () => this.closed,
 			getCloseSignal: () => this._closeController.signal,
 			getMyReplicationSegments: () => this.getMyReplicationSegments(),
@@ -3738,6 +3743,14 @@ export class SharedLog<
 
 	get compatibility(): number | undefined {
 		return this._logProperties?.compatibility;
+	}
+
+	/**
+	 * Legacy replication-info is an explicit compatibility fallback. Current
+	 * logs never infer or re-enable it from a remote peer's capabilities.
+	 */
+	private get legacyReplicationInfoEnabled(): boolean {
+		return this.compatibility !== undefined && this.compatibility < 10;
 	}
 
 	get isAdaptiveReplicating() {
@@ -14163,7 +14176,9 @@ export class SharedLog<
 		this.domain = options?.domain
 			? (options.domain(this) as unknown as D)
 			: (createReplicationDomainHash(
-					options?.compatibility && options?.compatibility < 10 ? "u32" : "u64",
+					options?.compatibility !== undefined && options.compatibility < 10
+						? "u32"
+						: "u64",
 				)(this) as unknown as D);
 		this.indexableDomain = createIndexableDomainFromResolution(
 			this.domain.resolution,
@@ -14309,8 +14324,12 @@ export class SharedLog<
 		}
 
 		this._closeController = new AbortController();
-		this._announcements.setupReplicationAnnouncementRetryFunction();
-		this._announcements.setupReplicationAnnouncementRepairFunction();
+		if (this.legacyReplicationInfoEnabled) {
+			this._announcements.setupReplicationAnnouncementRetryFunction();
+			this._announcements.setupReplicationAnnouncementRepairFunction();
+		} else {
+			this._announcements.cancelCurrentReplicationStateAnnouncementRetry();
+		}
 		this._closeController.signal.addEventListener("abort", () => {
 			for (const [_peer, state] of this._replicationInfoRequestByPeer) {
 				if (state.timer) clearTimeout(state.timer);
@@ -15754,7 +15773,9 @@ export class SharedLog<
 		const peerSession = this._peerSessions.current(peerHash);
 		const preserveV2Session =
 			peerSession?.phase === "open" && peerSession.isActive();
-		this.cancelReplicationInfoRequests(peerHash);
+		if (this.legacyReplicationInfoEnabled || !preserveV2Session) {
+			this.cancelReplicationInfoRequests(peerHash);
+		}
 		this._liveness._replicatorLivenessFailures.delete(peerHash);
 		this._liveness._replicatorLastActivityAt.delete(peerHash);
 		if (!preserveV2Session) {
@@ -16925,15 +16946,18 @@ export class SharedLog<
 				}, 2_000);
 				try {
 					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
-					await Promise.all([
-						this.rpc
-							.send(reset, {
-								priority: CONVERGENCE_MESSAGE_PRIORITY,
-								signal: abort.signal,
-							})
-							.catch(() => {}),
-						this._v2Send.sendTerminalReset(abort.signal),
-					]);
+					const resets = [this._v2Send.sendTerminalReset(abort.signal)];
+					if (this.legacyReplicationInfoEnabled) {
+						resets.push(
+							this.rpc
+								.send(reset, {
+									priority: CONVERGENCE_MESSAGE_PRIORITY,
+									signal: abort.signal,
+								})
+								.catch(() => {}),
+						);
+					}
+					await Promise.all(resets);
 				} finally {
 					clearTimeout(abortTimer);
 				}
@@ -17055,15 +17079,18 @@ export class SharedLog<
 				}, 2_000);
 				try {
 					const reset = new AllReplicatingSegmentsMessage({ segments: [] });
-					await Promise.all([
-						this.rpc
-							.send(reset, {
-								priority: CONVERGENCE_MESSAGE_PRIORITY,
-								signal: abort.signal,
-							})
-							.catch(() => {}),
-						this._v2Send.sendTerminalReset(abort.signal),
-					]);
+					const resets = [this._v2Send.sendTerminalReset(abort.signal)];
+					if (this.legacyReplicationInfoEnabled) {
+						resets.push(
+							this.rpc
+								.send(reset, {
+									priority: CONVERGENCE_MESSAGE_PRIORITY,
+									signal: abort.signal,
+								})
+								.catch(() => {}),
+						);
+					}
+					await Promise.all(resets);
 				} finally {
 					clearTimeout(abortTimer);
 				}
@@ -17588,6 +17615,19 @@ export class SharedLog<
 			this.throwIfNativeDurableCommitFailed();
 			if (!context.from) {
 				throw new Error("Missing from in update role message");
+			}
+			if (
+				!this.legacyReplicationInfoEnabled &&
+				(msg instanceof RequestReplicationInfoMessage ||
+					msg instanceof ResponseRoleMessage ||
+					msg instanceof AllReplicatingSegmentsMessage ||
+					msg instanceof AddedReplicationSegmentMessage ||
+					msg instanceof StoppedReplicating)
+			) {
+				// These variants remain registered decode tombstones, but current logs
+				// fail closed before leases, synchronizer work, liveness, watermarks or
+				// mutations. Only an explicit pre-v10 compatibility open admits them.
+				return;
 			}
 			// Snapshot receive ownership before any async handler gets a chance to
 			// yield. Replication-info messages reach their branch only after the
@@ -19889,7 +19929,10 @@ export class SharedLog<
 					return;
 				}
 				this._liveness.markReplicatorActivity(fromHash);
-				if (msg instanceof FullReplicationInfoV2Message) {
+				if (
+					msg instanceof FullReplicationInfoV2Message &&
+					this.legacyReplicationInfoEnabled
+				) {
 					this.cancelReplicationInfoRequests(fromHash);
 				}
 			});
@@ -20572,17 +20615,29 @@ export class SharedLog<
 
 			requestAttempts++;
 
-			this.rpc
-				.send(new RequestReplicationInfoMessage(), {
-					mode: new AcknowledgeDelivery({ redundancy: 1, to: [key] }),
-				})
-				.catch((e) => {
-					// Best-effort: missing peers / unopened RPC should not fail the wait logic.
-					if (isNotStartedError(e as Error)) {
-						return;
-					}
-					logger.error(e?.toString?.() ?? String(e));
-				});
+			if (this.legacyReplicationInfoEnabled) {
+				this.rpc
+					.send(new RequestReplicationInfoMessage(), {
+						mode: new AcknowledgeDelivery({ redundancy: 1, to: [key] }),
+					})
+					.catch((e) => {
+						// Best-effort: missing peers / unopened RPC should not fail the wait logic.
+						if (isNotStartedError(e as Error)) {
+							return;
+						}
+						logger.error(e?.toString?.() ?? String(e));
+					});
+			} else {
+				const peerHash = key.hashcode();
+				const peerSession = this._peerSessions.current(peerHash);
+				if (peerSession?.phase === "open") {
+					this._v2Receive.resumeParkedRequest({
+						peerHash,
+						peerSession,
+						receiveEpoch: this._peerSessions.receiveEpoch(peerHash),
+					});
+				}
+			}
 
 			if (requestAttempts < maxRequestAttempts) {
 				requestTimer = setTimeout(requestReplicationInfo, requestIntervalMs);
@@ -23316,6 +23371,73 @@ export class SharedLog<
 		this._replicationInfoRequestByPeer.delete(peerHash);
 	}
 
+	private scheduleReplicationInfoV2Recovery(
+		peer: PublicSignKey,
+		replicationLifecycleController = this._instanceLifecycle
+			?.membershipLifecycleController,
+	) {
+		if (
+			!replicationLifecycleController ||
+			!this.isReplicationLifecycleActive(replicationLifecycleController)
+		) {
+			return;
+		}
+		const peerHash = peer.hashcode();
+		const peerSession = this._peerSessions.current(peerHash);
+		if (!peerSession || peerSession.phase !== "open") {
+			return;
+		}
+		const requestStates = this._replicationInfoRequestByPeer;
+		const existing = requestStates.get(peerHash);
+		if (existing?.peerSession === peerSession) {
+			return;
+		}
+		if (existing) {
+			if (existing.timer) {
+				clearTimeout(existing.timer);
+			}
+			requestStates.delete(peerHash);
+		}
+		const state: {
+			attempts: number;
+			timer?: ReturnType<typeof setTimeout>;
+			peerSession: PeerSession;
+		} = {
+			attempts: 0,
+			peerSession,
+		};
+		requestStates.set(peerHash, state);
+		const cancel = () => {
+			if (requestStates.get(peerHash) !== state) {
+				return;
+			}
+			if (state.timer) {
+				clearTimeout(state.timer);
+			}
+			requestStates.delete(peerHash);
+		};
+		const intervalMs = Math.max(50, this.waitForReplicatorRequestIntervalMs);
+		const tick = () => {
+			if (
+				!this.isReplicationLifecycleActive(replicationLifecycleController) ||
+				peerSession.phase !== "open" ||
+				!this._peerSessions.isCurrent(peerHash, peerSession)
+			) {
+				cancel();
+				return;
+			}
+			this._v2Receive.resumeParkedRequest({
+				peerHash,
+				peerSession,
+				receiveEpoch: this._peerSessions.receiveEpoch(peerHash),
+			});
+			state.attempts++;
+			state.timer = setTimeout(tick, intervalMs);
+			state.timer.unref?.();
+		};
+		tick();
+	}
+
 	private scheduleReplicationInfoRequests(
 		peer: PublicSignKey,
 		replicationLifecycleController = this._instanceLifecycle
@@ -23325,6 +23447,13 @@ export class SharedLog<
 			!replicationLifecycleController ||
 			!this.isReplicationLifecycleActive(replicationLifecycleController)
 		) {
+			return;
+		}
+		if (!this.legacyReplicationInfoEnabled) {
+			this.scheduleReplicationInfoV2Recovery(
+				peer,
+				replicationLifecycleController,
+			);
 			return;
 		}
 		const peerHash = peer.hashcode();
@@ -23360,7 +23489,6 @@ export class SharedLog<
 				cancel();
 				return;
 			}
-
 			state.attempts++;
 
 			this.rpc
@@ -23419,6 +23547,10 @@ export class SharedLog<
 		if (!ownsSubscriptionEpoch()) {
 			return;
 		}
+		// A reconnect can arrive before the previous exact-session recovery tick
+		// observes its stale session. Retire that job synchronously so it cannot
+		// suppress the replacement session's scheduler in the shared peer slot.
+		this.cancelReplicationInfoRequests(peerHash);
 		// A destination stream is scoped to exactly one topic-subscription
 		// session. Abort the predecessor synchronously before either barrier can
 		// yield; a late queue completion must never enter the new session.
@@ -23577,6 +23709,17 @@ export class SharedLog<
 				receiveEpoch,
 				signal: replicationLifecycleController.signal,
 			});
+		if (!this.legacyReplicationInfoEnabled) {
+			// Current logs have no legacy startup work to order ahead of RequestV2.
+			// Releasing is synchronous and exact-session fenced; the ACK may still
+			// arrive later and promote readiness through the coordinator.
+			localCapabilityAdvertisement.releaseLegacyBarrier();
+			this.scheduleReplicationInfoV2Recovery(
+				publicKey,
+				replicationLifecycleController,
+			);
+			return;
+		}
 
 		try {
 			let replicationSegments: ReplicationRangeIndexable<R>[];

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -15575,15 +15575,9 @@ export class SharedLog<
 			if (this._peerSessions.current(v.hashcode()) !== null) {
 				return;
 			}
-			void this.runSubscriptionChangeCallback(async () => {
-				// The live event may rotate after the outer check but before this queued
-				// fallback runs. Recheck at execution so the snapshot cannot create a
-				// duplicate successor session in that window.
-				if (this._peerSessions.current(v.hashcode()) !== null) {
-					return;
-				}
-				await this.handleSubscriptionChange(v, [this.topic], true);
-			});
+			void this.runSubscriptionChangeCallback(() =>
+				this.handleSubscriptionChange(v, [this.topic], true),
+			);
 		});
 	}
 

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -19366,19 +19366,37 @@ export class SharedLog<
 								timestamp: capabilityTimestamp,
 								openingSession: receiveSession!,
 							});
-						} else if (
-							this.observePeerSyncCapabilities({
+						} else {
+							const observed = this.observePeerSyncCapabilities({
 								peerHash: receiveFromHash,
 								capabilities: msg.capabilities,
 								transportSession: capabilityTransportSession,
 								timestamp: capabilityTimestamp,
-							}) &&
-							receiveSession?.phase === "open"
-						) {
-							this.promoteReplicationInfoV2ReceiveCapability(
-								context.from,
-								receiveSession,
-							);
+							});
+							if (observed && receiveSession?.phase === "open") {
+								this.promoteReplicationInfoV2ReceiveCapability(
+									context.from,
+									receiveSession,
+								);
+							} else if (observed && receiveSession === null) {
+								// A capability can arrive before the sender's topic Subscribe after
+								// reconnect. Ask that authenticated peer for its authoritative
+								// subscriber snapshot; the resulting Subscribe creates the real
+								// PeerSession and completes the symmetric capability handshake.
+								// Never synthesize membership from capability traffic alone.
+								void Promise.resolve()
+									.then(() =>
+										this.node.services.pubsub.requestSubscribers(
+											this.topic,
+											context.from,
+										),
+									)
+									.catch((error) => {
+										if (!isNotStartedError(error as Error)) {
+											logger.error(error?.toString?.() ?? String(error));
+										}
+									});
+							}
 						}
 					}
 					return;
@@ -23541,6 +23559,7 @@ export class SharedLog<
 		topics: string[],
 		subscribed: boolean,
 		subscriptionEpoch?: PeerSession,
+		subscriptionTransportSession?: bigint,
 	) {
 		if (!topics.includes(this.topic)) {
 			return;
@@ -23572,12 +23591,19 @@ export class SharedLog<
 		// yield; a late queue completion must never enter the new session.
 		this._v2Receive.clearPeer(peerHash);
 		this._v2Send.clearPeer(peerHash);
-		if (!subscribed || expectedSubscriptionEpoch.hasPredecessor) {
+		const capabilityTransportSession =
+			this._peerSyncCapabilitySessions.get(peerHash);
+		const canInheritCapability =
+			subscribed &&
+			(subscriptionTransportSession !== undefined
+				? capabilityTransportSession === subscriptionTransportSession
+				: !expectedSubscriptionEpoch.hasPredecessor);
+		if (!canInheritCapability) {
 			// Departures and successor openings revoke the signed transport binding.
-			// Only the first opening may inherit a capability that arrived before its
-			// subscription callback. afterOpen() deduplicates its subscriber snapshot
-			// against the live callback, so a true successor can never be mistaken for
-			// that startup race.
+			// A live successor may inherit a capability that arrived just before its
+			// Subscribe only when both signed frames belong to the same transport
+			// generation. Snapshot fallbacks lack that proof, so only their first
+			// opening may inherit pre-opening capability state.
 			this._peerSyncCapabilitySessions.delete(peerHash);
 			this._peerSyncCapabilityTimestamps.delete(peerHash);
 		}
@@ -25271,6 +25297,7 @@ export class SharedLog<
 			evt.detail.topics,
 			true,
 			subscriptionEpoch,
+			evt.detail.session,
 		);
 	}
 

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -31,6 +31,11 @@ export type PeerReceiveAdmissionOptions = {
 export class PeerSession {
 	readonly peerHash: string;
 	readonly kind: PeerSessionKind;
+	// True when rotate() superseded an earlier subscription generation. This is
+	// deliberately independent of the predecessor's phase/kind: a newer
+	// transport can announce a subscription without first delivering an
+	// unsubscribe, and must not inherit the old transport's signed capability.
+	readonly hasPredecessor: boolean;
 	// The lifecycle controller live at rotation. All current seams pair the
 	// epoch check with a lifecycle check against a controller captured in the
 	// same synchronous window as the epoch advance; capturing it here
@@ -59,10 +64,12 @@ export class PeerSession {
 		peerHash: string,
 		kind: PeerSessionKind,
 		replicationLifecycleController: AbortController | undefined,
+		hasPredecessor: boolean,
 	) {
 		this.peerHash = peerHash;
 		this.kind = kind;
 		this.replicationLifecycleController = replicationLifecycleController;
+		this.hasPredecessor = hasPredecessor;
 		this.phase = kind;
 	}
 
@@ -278,6 +285,7 @@ export class PeerSessionRegistry {
 			peerHash,
 			kind,
 			this.deps.getReplicationLifecycleController(),
+			previous !== undefined,
 		);
 		this.sessions.set(peerHash, next);
 		return next;

--- a/packages/programs/data/shared-log/src/replication-announcement.ts
+++ b/packages/programs/data/shared-log/src/replication-announcement.ts
@@ -204,9 +204,10 @@ export type ReplicationAnnouncementDeps<R extends "u32" | "u64"> = {
 	// Owner-routed so coordinator spies keep observing re-entrant queueing.
 	queueCurrentReplicationStateAnnouncementRepair: () => void;
 	queueCurrentReplicationStateAnnouncementRetry: (error: unknown) => boolean;
-	// Best-effort sidecar. The legacy publish remains the primary operation and
-	// retains its exact rejection/retry semantics during mixed-version rollout.
+	// V2 is always current. Legacy publication is enabled only for an explicit
+	// compatibility open and retains its exact rejection/retry semantics there.
 	enqueueReplicationInfoV2: (message: LegacyReplicationInfoMessage) => void;
+	isLegacyReplicationInfoEnabled: () => boolean;
 };
 
 type LegacyReplicationInfoMessage =
@@ -270,6 +271,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 
 	queueCurrentReplicationStateAnnouncementRetry(error: unknown): boolean {
 		if (
+			!this.deps.isLegacyReplicationInfoEnabled() ||
 			this.deps.isClosed() ||
 			this.deps.getCloseSignal().aborted ||
 			this._replicationAnnouncementRetryController.signal.aborted ||
@@ -362,6 +364,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 
 	queueCurrentReplicationStateAnnouncementRepair(): void {
 		if (
+			!this.deps.isLegacyReplicationInfoEnabled() ||
 			this.deps.isClosed() ||
 			this.deps.getCloseSignal().aborted ||
 			this._replicationAnnouncementRepairController.signal.aborted ||
@@ -437,6 +440,11 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	async repairCurrentReplicationStateAnnouncement(
 		context?: ReplicationAnnouncementRepairWorkerContext,
 	): Promise<void> {
+		if (!this.deps.isLegacyReplicationInfoEnabled()) {
+			this._announcementRepairBinding.pending = false;
+			this._announcementRepairBinding.targets.clear();
+			return;
+		}
 		if (!this._announcementRepairBinding.pending) {
 			return;
 		}
@@ -645,6 +653,9 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				this.rotateAnnouncementSession();
 				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
 				this.deps.enqueueReplicationInfoV2(message);
+				if (!this.deps.isLegacyReplicationInfoEnabled()) {
+					return;
+				}
 				try {
 					await this.deps.getRpc().send(message, {
 						priority: CONVERGENCE_MESSAGE_PRIORITY,
@@ -677,6 +688,10 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	}
 
 	async retryCurrentReplicationStateAnnouncement(): Promise<void> {
+		if (!this.deps.isLegacyReplicationInfoEnabled()) {
+			this._replicationAnnouncementRetryPending = false;
+			return;
+		}
 		const session = this._announcementSession;
 		const controller = this._replicationAnnouncementRetryController;
 		try {

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -991,6 +991,44 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		return true;
 	}
 
+	/**
+	 * Resume only a request generation that exhausted its bounded retries.
+	 * Wait/liveness callers may nudge recovery without invalidating an active,
+	 * timed or in-flight request and without advancing the receive epoch.
+	 */
+	resumeParkedRequest(properties: {
+		peerHash: string;
+		peerSession: object;
+		receiveEpoch: object | null;
+	}): boolean {
+		const state = this._receiveStates.get(properties.peerHash);
+		if (
+			!state ||
+			state.peerSession !== properties.peerSession ||
+			state.receiveEpoch !== properties.receiveEpoch ||
+			!this.deps.isPeerStateCurrent(
+				properties.peerHash,
+				properties.peerSession,
+				properties.receiveEpoch,
+			) ||
+			state.phase === "active" ||
+			!state.requestParked ||
+			state.requestTimer !== undefined ||
+			state.requestInFlight !== undefined ||
+			this._reservedAdmissionsByPeer.has(properties.peerHash) ||
+			state.receiverBinding === undefined ||
+			state.lastSequence === MAX_U64
+		) {
+			return false;
+		}
+		state.requestAttempts = 0;
+		state.requestsSinceCapabilityRefresh = 0;
+		state.capabilityRefreshRequired = true;
+		state.requestParked = false;
+		this.armRequest(state, 0);
+		return true;
+	}
+
 	private transitionToResync(
 		state: ReplicationInfoV2ReceiveState,
 		options?: { force?: boolean; refreshCapability?: boolean },
@@ -1154,6 +1192,14 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		const { state } = admission;
 		this._reservedAdmissionsByPeer.set(peerHash, admission);
 		state.reservedAdmission = admission;
+		if (state.requestTimer) {
+			clearTimeout(state.requestTimer);
+			state.requestTimer = undefined;
+		}
+		if (state.legacyFallbackTimer) {
+			clearTimeout(state.legacyFallbackTimer);
+			state.legacyFallbackTimer = undefined;
+		}
 		return admission;
 	}
 
@@ -1174,6 +1220,30 @@ export class ReplicationInfoV2ReceiveCoordinator {
 				(currentState !== state && currentState.phase !== "active"))
 		) {
 			this.transitionToResync(currentState, { force: true });
+		} else if (
+			currentState === state &&
+			!admission.committed &&
+			this.isStateCurrent(state) &&
+			state.phase !== "active" &&
+			state.requestTimer === undefined &&
+			state.requestInFlight === undefined &&
+			!state.requestParked
+		) {
+			// Reserving a Full pauses this generation's retry timer. If its host
+			// apply lane releases without committing, restore the bounded request
+			// worker so the exact current generation cannot become stranded.
+			this.armRequest(state, 0);
+		}
+		if (
+			currentState === state &&
+			this.isStateCurrent(state) &&
+			state.phase === "active" &&
+			state.legacyFallbackFingerprint !== undefined
+		) {
+			// A reservation also pauses compat sidecar recovery. Matching commits
+			// clear the evidence; an uncommitted or non-matching frame restores its
+			// bounded fallback without invalidating work in the host apply lane.
+			this.armLegacyFallback(state);
 		}
 	}
 
@@ -1281,6 +1351,19 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (state.legacyFallbackTimer) {
 			return true;
 		}
+		this.armLegacyFallback(state);
+		return true;
+	}
+
+	private armLegacyFallback(state: ReplicationInfoV2ReceiveState): void {
+		if (
+			state.legacyFallbackTimer ||
+			state.phase !== "active" ||
+			state.legacyFallbackFingerprint === undefined ||
+			this._reservedAdmissionsByPeer.has(state.peerHash)
+		) {
+			return;
+		}
 		state.legacyFallbackTimer = setTimeout(() => {
 			state.legacyFallbackTimer = undefined;
 			if (this.isStateCurrent(state) && state.phase === "active") {
@@ -1291,7 +1374,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			}
 		}, this.legacyFallbackDelayMs);
 		state.legacyFallbackTimer.unref?.();
-		return true;
 	}
 
 	private clearLegacyFallback(state: ReplicationInfoV2ReceiveState): void {
@@ -1418,8 +1500,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			this._receiveStates.get(state.peerHash) !== state ||
 			state.controller.signal.aborted ||
 			this.deps.isClosed() ||
-			(this._reservedAdmissionsByPeer.has(state.peerHash) &&
-				this._reservedAdmissionsByPeer.get(state.peerHash)?.state !== state) ||
+			this._reservedAdmissionsByPeer.has(state.peerHash) ||
 			state.receiverBinding === undefined ||
 			state.phase === "active" ||
 			state.requestParked ||
@@ -1449,6 +1530,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	private async refreshGrant(
 		state: ReplicationInfoV2ReceiveState,
 	): Promise<boolean> {
+		const version = state.version;
 		const refreshed = await this.deps.refreshLocalCapability({
 			peerHash: state.peerHash,
 			target: state.target,
@@ -1458,6 +1540,8 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		});
 		if (
 			!refreshed ||
+			state.version !== version ||
+			this._reservedAdmissionsByPeer.has(state.peerHash) ||
 			!this.isStateCurrent(state) ||
 			this.deps.getReceiverTransportSession() !==
 				refreshed.receiverTransportSession
@@ -1489,7 +1573,10 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (state.requestInFlight) {
 			return;
 		}
-		if (!this.isStateCurrent(state)) {
+		if (
+			!this.isStateCurrent(state) ||
+			this._reservedAdmissionsByPeer.has(state.peerHash)
+		) {
 			return;
 		}
 		if (
@@ -1512,7 +1599,10 @@ export class ReplicationInfoV2ReceiveCoordinator {
 					return;
 				}
 			}
-			if (!this.isStateCurrent(state)) {
+			if (
+				!this.isStateCurrent(state) ||
+				this._reservedAdmissionsByPeer.has(state.peerHash)
+			) {
 				return;
 			}
 			const ready = this._localCapabilityReadyBySession.get(state.peerSession);
@@ -1558,6 +1648,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 				if (
 					this._receiveStates.get(state.peerHash) === state &&
 					!state.controller.signal.aborted &&
+					!this._reservedAdmissionsByPeer.has(state.peerHash) &&
 					!state.requestTimer &&
 					state.phase !== "active"
 				) {

--- a/packages/programs/data/shared-log/src/replication-info-v2-send.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-send.ts
@@ -649,7 +649,27 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 				sends.push(Promise.reject(error));
 			}
 		}
-		await Promise.allSettled(sends);
+		if (sends.length === 0 || signal.aborted) {
+			return;
+		}
+
+		// Terminal reset is best-effort and the caller owns its close/drop bound.
+		// A transport is expected to observe the signal, but a disconnected
+		// acknowledgement path can leave its promise pending indefinitely. Do not
+		// let such a transport retain the whole terminal operation past the bound.
+		await new Promise<void>((resolve) => {
+			let finished = false;
+			const finish = () => {
+				if (finished) return;
+				finished = true;
+				signal.removeEventListener("abort", finish);
+				resolve();
+			};
+			signal.addEventListener("abort", finish, { once: true });
+			void Promise.allSettled(sends).then(finish);
+			// Close the check/listener race if the caller aborted synchronously.
+			if (signal.aborted) finish();
+		});
 	}
 
 	async drain(signal?: AbortSignal): Promise<void> {

--- a/packages/programs/data/shared-log/src/sync/factory.ts
+++ b/packages/programs/data/shared-log/src/sync/factory.ts
@@ -114,7 +114,7 @@ export function createSyncronizer<R extends "u32" | "u64">(
 			sendRawExchangeHeads: props.sendRawExchangeHeads,
 		});
 	} else {
-		if (props.compatibility && props.compatibility < 10) {
+		if (props.compatibility !== undefined && props.compatibility < 10) {
 			return new SimpleSyncronizer({
 				log: props.log,
 				rpc: props.rpc,

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -24,10 +24,14 @@ describe("events", () => {
 		await session.stop();
 	});
 
-	const openDisconnectedLog = async (peers = 2) => {
+	const openDisconnectedLog = async (peers = 2, compatibility?: number) => {
 		session = await TestSession.disconnected(peers);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				...(compatibility !== undefined ? { compatibility } : {}),
+			},
 		});
 		return {
 			db,
@@ -132,7 +136,7 @@ describe("events", () => {
 	};
 
 	it("announces the authoritative empty snapshot after a reset put commits then throws", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const { log, replicationIndex } = await openDisconnectedLog(1, 9);
 		const selfKey = session.peers[0].identity.publicKey;
 		const selfHash = selfKey.hashcode();
 		const numbers = log.indexableDomain.numbers;
@@ -491,7 +495,7 @@ describe("events", () => {
 	});
 
 	it("accepts only an ordered legacy replacement pair and applies its final range", async () => {
-		const { db, log, replicationIndex } = await openDisconnectedLog(2);
+		const { db, log, replicationIndex } = await openDisconnectedLog(2, 9);
 		const ownerKey = session.peers[1].identity.publicKey;
 		const ownerHash = ownerKey.hashcode();
 		const id = randomBytes(32);
@@ -756,7 +760,7 @@ describe("events", () => {
 	});
 
 	it("announces the authoritative snapshot when a merge removal precedes a failed replacement", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const { log, replicationIndex } = await openDisconnectedLog(1, 9);
 		const selfKey = session.peers[0].identity.publicKey;
 		const selfHash = selfKey.hashcode();
 		const first = makeReplicationRange(log, {
@@ -843,7 +847,7 @@ describe("events", () => {
 	});
 
 	it("queues a preliminary removal once when its delete commits then throws", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const { log, replicationIndex } = await openDisconnectedLog(1, 9);
 		const selfKey = session.peers[0].identity.publicKey;
 		const selfHash = selfKey.hashcode();
 		const first = makeReplicationRange(log, {
@@ -909,7 +913,7 @@ describe("events", () => {
 	});
 
 	it("announces the current snapshot when post-write maturity bookkeeping fails", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(1);
+		const { log, replicationIndex } = await openDisconnectedLog(1, 9);
 		const selfHash = session.peers[0].identity.publicKey.hashcode();
 		const range = makeReplicationRange(log, {
 			id: randomBytes(32),
@@ -963,7 +967,7 @@ describe("events", () => {
 	});
 
 	it("poisons ownership instead of announcing an invalid persisted snapshot", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const { log, replicationIndex } = await openDisconnectedLog(2, 9);
 		const selfKey = session.peers[0].identity.publicKey;
 		const selfHash = selfKey.hashcode();
 		const invalid = makeReplicationRange(log, {
@@ -1479,7 +1483,7 @@ describe("events", () => {
 	});
 
 	it("keeps incremental owner state within the snapshot limit and reconnects at the limit", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const { log, replicationIndex } = await openDisconnectedLog(2, 9);
 		const selfKey = session.peers[0].identity.publicKey;
 		const selfHash = selfKey.hashcode();
 		const ranges = Array.from({ length: 4096 }, (_, index) =>
@@ -1550,7 +1554,7 @@ describe("events", () => {
 	});
 
 	it("rejects over-limit stopped announcements before liveness, queues, or queries", async () => {
-		const { log, replicationIndex } = await openDisconnectedLog(2);
+		const { log, replicationIndex } = await openDisconnectedLog(2, 9);
 		const remoteKey = session.peers[1].identity.publicKey;
 		const duplicateId = randomBytes(32);
 		const markActivity = sinon.spy(log._liveness, "markReplicatorActivity");
@@ -1834,7 +1838,7 @@ describe("events", () => {
 	}
 
 	it("orders a delayed adaptive Added announcement before the authoritative empty snapshot", async () => {
-		const { db, log } = await openDisconnectedLog(1);
+		const { db, log } = await openDisconnectedLog(1, 9);
 		const [currentRange] = await db.log.replicate({
 			factor: 0.2,
 			offset: 0.1,
@@ -1971,7 +1975,10 @@ describe("events", () => {
 				await releaseLowerAppend.promise;
 				return { entries: [entry], removed: [] };
 			});
-		const deleteCoordinates = sinon.spy((log as any)._coordinates, "deleteCoordinatesForHashes");
+		const deleteCoordinates = sinon.spy(
+			(log as any)._coordinates,
+			"deleteCoordinatesForHashes",
+		);
 		const coalesced = sinon.spy(log, "processLocalAppendManyCoalesced");
 		const planLocal = sinon.spy(log, "planNativeLocalAppendEntries");
 		const planDelivery = sinon.spy(log, "planNativeAppendEntries");
@@ -2123,6 +2130,11 @@ describe("events", () => {
 		const { db, log } = await openDisconnectedLog(1);
 		const lowerAppendStarted = pDefer<void>();
 		const releaseLowerAppend = pDefer<void>();
+		// This case targets the fallback path even when the Rust-core matrix makes
+		// a native backbone available for the same commit-only operation.
+		const nativeCommitOnly = sinon
+			.stub(log, "appendLocallyPreparedPayloadNativeBackboneCommitOnly")
+			.returns(undefined);
 		const lowerAppend = sinon
 			.stub(log.log, "appendLocallyPreparedCommitOnly")
 			.callsFake(async () => {
@@ -2160,6 +2172,7 @@ describe("events", () => {
 			expect(finishAppend.called).to.be.false;
 		} finally {
 			releaseLowerAppend.resolve();
+			nativeCommitOnly.restore();
 			lowerAppend.restore();
 			finishAppend.restore();
 			log._replicationRangeMutationFailure = undefined;
@@ -2184,7 +2197,10 @@ describe("events", () => {
 				return {} as any;
 			});
 		const applyChange = sinon.spy(log, "applyChange");
-		const deleteCoordinates = sinon.spy((log as any)._coordinates, "deleteCoordinatesForHashes");
+		const deleteCoordinates = sinon.spy(
+			(log as any)._coordinates,
+			"deleteCoordinatesForHashes",
+		);
 		const planLocal = sinon.spy(log, "planNativeLocalAppendEntries");
 		const planDelivery = sinon.spy(log, "planNativeAppendEntries");
 		const processLocalAppend = sinon.spy(log, "processLocalAppend");
@@ -2887,7 +2903,10 @@ describe("events", () => {
 				staleLatestCommit,
 		};
 		const canUseResidentState = sinon
-			.stub((log as any)._coordinates, "canUseNativeBackboneResidentCoordinateState")
+			.stub(
+				(log as any)._coordinates,
+				"canUseNativeBackboneResidentCoordinateState",
+			)
 			.returns(true);
 		const context = sinon.stub(log, "createLeaderSelectionContext").resolves({
 			roleAge: 0,
@@ -2994,7 +3013,10 @@ describe("events", () => {
 			await session.peers[0].open(db, {
 				args: { replicate: false, timeUntilRoleMaturity: 0 },
 			});
-			const deleteCoordinates = sinon.spy((log as any)._coordinates, "deleteCoordinatesForHashes");
+			const deleteCoordinates = sinon.spy(
+				(log as any)._coordinates,
+				"deleteCoordinatesForHashes",
+			);
 			const planHeads = sinon.spy(log, "planEntryLeaderBatch");
 
 			try {
@@ -3023,7 +3045,7 @@ describe("events", () => {
 	});
 
 	it("fences a blocked replication announcement from reopened repair queues", async () => {
-		const { db, log } = await openDisconnectedLog(1);
+		const { db, log } = await openDisconnectedLog(1, 9);
 		const announcementStarted = pDefer<void>();
 		const releaseAnnouncement = pDefer<void>();
 		let announcementSignal: AbortSignal | undefined;
@@ -3061,7 +3083,11 @@ describe("events", () => {
 			expect(announcementSignal?.aborted).to.be.true;
 			await db.close();
 			await session.peers[0].open(db, {
-				args: { replicate: false, timeUntilRoleMaturity: 0 },
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+					compatibility: 9,
+				},
 			});
 			queueRepair.resetHistory();
 			queueRetry.resetHistory();
@@ -3082,7 +3108,7 @@ describe("events", () => {
 	});
 
 	it("does not let a stale announcement retry poison reopened ownership", async () => {
-		const { db, log } = await openDisconnectedLog(1);
+		const { db, log } = await openDisconnectedLog(1, 9);
 		const snapshotReadStarted = pDefer<void>();
 		const releaseSnapshotRead = pDefer<void>();
 		const getMyReplicationSegments = sinon
@@ -3106,7 +3132,11 @@ describe("events", () => {
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
 			await db.close();
 			await session.peers[0].open(db, {
-				args: { replicate: false, timeUntilRoleMaturity: 0 },
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+					compatibility: 9,
+				},
 			});
 			const reopenedLifecycle =
 				log._instanceLifecycle?.ownershipLifecycleController;
@@ -3129,7 +3159,7 @@ describe("events", () => {
 	});
 
 	it("does not let a stale announcement repair poison reopened ownership", async () => {
-		const { db, log } = await openDisconnectedLog(1);
+		const { db, log } = await openDisconnectedLog(1, 9);
 		const snapshotReadStarted = pDefer<void>();
 		const releaseSnapshotRead = pDefer<void>();
 		const getMyReplicationSegments = sinon
@@ -3154,7 +3184,11 @@ describe("events", () => {
 			log.poisonReplicationOwnership(new Error("forced ownership poison"));
 			await db.close();
 			await session.peers[0].open(db, {
-				args: { replicate: false, timeUntilRoleMaturity: 0 },
+				args: {
+					replicate: false,
+					timeUntilRoleMaturity: 0,
+					compatibility: 9,
+				},
 			});
 			const reopenedLifecycle =
 				log._instanceLifecycle?.ownershipLifecycleController;
@@ -3723,7 +3757,7 @@ describe("events", () => {
 	});
 
 	it("suppresses pending maturity while terminal close is still in progress", async () => {
-		const { db, log } = await openDisconnectedLog();
+		const { db, log } = await openDisconnectedLog(2, 9);
 		const remoteKey = session.peers[1].identity.publicKey;
 		const numbers = log.indexableDomain.numbers;
 		const range = new log.indexableDomain.constructorRange({
@@ -4203,10 +4237,10 @@ describe("events", () => {
 		session = await TestSession.connected(2);
 
 		const db1 = await session.peers[0].open(new EventStore(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: 1, timeUntilRoleMaturity: 0 },
 		});
 		await session.peers[1].open(db1.clone(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: 1, timeUntilRoleMaturity: 0 },
 		});
 
 		const remoteKey = session.peers[1].identity.publicKey;
@@ -4286,7 +4320,8 @@ describe("events", () => {
 			expect(log._liveness._replicatorLastActivityAt.has(remoteHash)).to.be
 				.true;
 			expect(log._gidPeersHistory.get(gid)?.has(remoteHash)).to.be.true;
-			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.false;
+			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be
+				.false;
 			expect(disconnected.calledOnceWith(remoteHash)).to.be.true;
 			expect(leaves).to.deep.equal([]);
 
@@ -4354,8 +4389,15 @@ describe("events", () => {
 			}
 			return originalDel(query, options);
 		}) as any);
-		const unblock = sinon.spy(log._peerSessions._replicationInfoBlockedPeers, "delete");
+		const unblock = sinon.spy(
+			log._peerSessions._replicationInfoBlockedPeers,
+			"delete",
+		);
 		const scheduleRequests = sinon.spy(log, "scheduleReplicationInfoRequests");
+		const scheduleV2Recovery = sinon.spy(
+			log,
+			"scheduleReplicationInfoV2Recovery",
+		);
 		const disconnected = sinon.spy(log.syncronizer, "onPeerDisconnected");
 		const leaves: string[] = [];
 		db1.log.events.addEventListener("replicator:leave", (event) => {
@@ -4393,6 +4435,7 @@ describe("events", () => {
 			expect(log._peerSessions.isReplicationInfoBlocked(remoteHash)).to.be.true;
 			expect(unblock.neverCalledWith(remoteHash)).to.be.true;
 			expect(scheduleRequests.notCalled).to.be.true;
+			expect(scheduleV2Recovery.notCalled).to.be.true;
 			expect(disconnected.callCount).to.equal(2);
 			expect(disconnected.alwaysCalledWith(remoteHash)).to.be.true;
 			expect(leaves).to.deep.equal([remoteHash]);
@@ -4400,6 +4443,7 @@ describe("events", () => {
 			del.restore();
 			unblock.restore();
 			scheduleRequests.restore();
+			scheduleV2Recovery.restore();
 			releaseDelete.resolve();
 			disconnected.restore();
 		}
@@ -4503,10 +4547,10 @@ describe("events", () => {
 		session = await TestSession.connected(2);
 
 		const db1 = await session.peers[0].open(new EventStore(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 		await session.peers[1].open(db1.clone(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 
 		const remoteKey = session.peers[1].identity.publicKey;
@@ -4584,10 +4628,10 @@ describe("events", () => {
 		session = await TestSession.connected(2);
 
 		const db1 = await session.peers[0].open(new EventStore(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 		await session.peers[1].open(db1.clone(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 
 		const remoteKey = session.peers[1].identity.publicKey;
@@ -4649,10 +4693,10 @@ describe("events", () => {
 		session = await TestSession.connected(2);
 
 		const db1 = await session.peers[0].open(new EventStore(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 		await session.peers[1].open(db1.clone(), {
-			args: { replicate: 1, timeUntilRoleMaturity: 0 },
+			args: { replicate: 1, timeUntilRoleMaturity: 0, compatibility: 9 },
 		});
 
 		const remoteKey = session.peers[1].identity.publicKey;

--- a/packages/programs/data/shared-log/test/join.spec.ts
+++ b/packages/programs/data/shared-log/test/join.spec.ts
@@ -623,7 +623,7 @@ describe("join", () => {
 
 	it("will emit one message when replicating multiple entries", async () => {
 		db1 = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false },
+			args: { replicate: false, compatibility: 9 },
 		});
 		db2 = db1.clone();
 
@@ -637,7 +637,7 @@ describe("join", () => {
 		};
 
 		db2 = await session.peers[1].open(db2, {
-			args: { replicate: false },
+			args: { replicate: false, compatibility: 9 },
 		});
 
 		await waitForResolved(() => expect(subscribed).to.be.true); // we do this to assert that this message producing event has happend before we test stuff later
@@ -669,7 +669,7 @@ describe("join", () => {
 
 	it("will emit one message when replicating new and already joined entries", async () => {
 		db1 = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false },
+			args: { replicate: false, compatibility: 9 },
 		});
 		db2 = db1.clone();
 
@@ -683,7 +683,7 @@ describe("join", () => {
 		};
 
 		db2 = await session.peers[1].open(db2, {
-			args: { replicate: false },
+			args: { replicate: false, compatibility: 9 },
 		});
 
 		await waitForResolved(() => expect(subscribed).to.be.true); // we do this to assert that this message producing event has happend before we test stuff later

--- a/packages/programs/data/shared-log/test/leader.spec.ts
+++ b/packages/programs/data/shared-log/test/leader.spec.ts
@@ -11,6 +11,7 @@ import {
 import { TestSession } from "@peerbit/test-utils";
 import { delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import sinon from "sinon";
 import { ExchangeHeadsMessage } from "../src/exchange-heads.js";
 import { slowDownMessage } from "./utils.js";
 import { EventStore } from "./utils/stores/event-store.js";
@@ -729,34 +730,34 @@ describe(`isLeader`, function () {
 			]);
 
 			await waitForResolved(
-					async () => {
-						expect((await db1.log.getReplicators()).size).equal(2);
-						expect((await db2.log.getReplicators()).size).equal(2);
+				async () => {
+					expect((await db1.log.getReplicators()).size).equal(2);
+					expect((await db2.log.getReplicators()).size).equal(2);
 
-						const expected = [
-							...session.peers.map((x) => x.identity.publicKey.hashcode()),
-						].sort();
+					const expected = [
+						...session.peers.map((x) => x.identity.publicKey.hashcode()),
+					].sort();
 
-						const coverAll = [
-							...(await db1.log.getCover({ args: undefined }, { roleAge: 0 })),
-						].sort();
-						expect(coverAll.length).to.be.greaterThan(0);
-						for (const peer of coverAll) {
-							expect(expected).to.include(peer);
-						}
+					const coverAll = [
+						...(await db1.log.getCover({ args: undefined }, { roleAge: 0 })),
+					].sort();
+					expect(coverAll.length).to.be.greaterThan(0);
+					for (const peer of coverAll) {
+						expect(expected).to.include(peer);
+					}
 
-						const coverReachableOnly = [
-							...(await db1.log.getCover(
-								{ args: undefined },
-								{ roleAge: 0, reachableOnly: true },
-							)),
-						].sort();
-						expect(coverReachableOnly).to.deep.equal(coverAll);
-					},
-					{
-						timeout: 60 * 1000,
-						timeoutMessage: "reachableOnly cover not ready",
-					},
+					const coverReachableOnly = [
+						...(await db1.log.getCover(
+							{ args: undefined },
+							{ roleAge: 0, reachableOnly: true },
+						)),
+					].sort();
+					expect(coverReachableOnly).to.deep.equal(coverAll);
+				},
+				{
+					timeout: 60 * 1000,
+					timeoutMessage: "reachableOnly cover not ready",
+				},
 			);
 
 			await db1.close();
@@ -934,6 +935,10 @@ describe(`isLeader`, function () {
 				});
 
 				await delay(MATURE_TIME);
+				// Evaluate the first cover assertion at the intended historical instant:
+				// db1 is mature, while peers opened below are not. Their sequential open
+				// and handshake time must not silently mature them before the assertion.
+				const oneMatureNow = Date.now();
 
 				db2 = await EventStore.open<EventStore<string, any>>(
 					db1.address!,
@@ -983,19 +988,24 @@ describe(`isLeader`, function () {
 				// db2 is not mature from db3 perspective (?). Might be (?)
 				// this test is kind of pointless anyway since we got the range.test.ts that tests all the cases
 
-				for (let i = 1; i < 3; i++) {
-					db3.log.replicas.min = { getValue: () => i };
-					let list = await db3.log.getCover(
-						{ args: undefined },
-						{
-							roleAge: MATURE_TIME,
-						},
-					);
-					expect(list).to.have.length(2); // TODO unmature nodes should not be queried
-					expect(list).to.have.members([
-						session.peers[0].identity.publicKey.hashcode(),
-						session.peers[2].identity.publicKey.hashcode(),
-					]);
+				const now = sinon.stub(Date, "now").returns(oneMatureNow);
+				try {
+					for (let i = 1; i < 3; i++) {
+						db3.log.replicas.min = { getValue: () => i };
+						const list = await db3.log.getCover(
+							{ args: undefined },
+							{
+								roleAge: MATURE_TIME,
+							},
+						);
+						expect(list).to.have.length(2); // TODO unmature nodes should not be queried
+						expect(list).to.have.members([
+							session.peers[0].identity.publicKey.hashcode(),
+							session.peers[2].identity.publicKey.hashcode(),
+						]);
+					}
+				} finally {
+					now.restore();
 				}
 
 				await delay(MATURE_TIME);

--- a/packages/programs/data/shared-log/test/lifecycle.spec.ts
+++ b/packages/programs/data/shared-log/test/lifecycle.spec.ts
@@ -182,7 +182,7 @@ describe("lifecycle", () => {
 		it(`${operation} drains an admitted subscription callback before retiring replication state`, async () => {
 			session = await TestSession.connected(2);
 			const db = await session.peers[0].open(new EventStore(), {
-				args: { replicate: { factor: 1 } },
+				args: { compatibility: 9, replicate: { factor: 1 } },
 			});
 			const sharedLog = db.log;
 			const replicationSegments = await sharedLog.getMyReplicationSegments();
@@ -319,10 +319,45 @@ describe("lifecycle", () => {
 	}
 
 	for (const operation of ["close", "drop"] as const) {
-		it(`${operation} publishes an admitted replication snapshot before the terminal reset`, async () => {
+		it(`${operation} uses only the V2 replication-info terminal path by default`, async () => {
 			session = await TestSession.connected(2);
 			const db = await session.peers[0].open(new EventStore(), {
 				args: { replicate: { factor: 1 } },
+			});
+			const sharedLog = db.log as any;
+			const sent: unknown[] = [];
+			const send = sinon
+				.stub(sharedLog.rpc, "send")
+				.callsFake(async (message) => {
+					sent.push(message);
+					return [] as any;
+				});
+			const v2Terminal = sinon
+				.stub(sharedLog._v2Send, "sendTerminalReset")
+				.resolves();
+
+			try {
+				await db[operation]();
+				expect(v2Terminal.calledOnce).to.be.true;
+				expect(
+					sent.filter(
+						(message) =>
+							message instanceof AllReplicatingSegmentsMessage &&
+							message.segments.length === 0,
+					),
+				).to.have.length(0);
+			} finally {
+				send.restore();
+				v2Terminal.restore();
+			}
+		});
+	}
+
+	for (const operation of ["close", "drop"] as const) {
+		it(`${operation} publishes an admitted replication snapshot before the terminal reset`, async () => {
+			session = await TestSession.connected(2);
+			const db = await session.peers[0].open(new EventStore(), {
+				args: { compatibility: 9, replicate: { factor: 1 } },
 			});
 			const sharedLog = db.log;
 			const order: string[] = [];
@@ -356,6 +391,15 @@ describe("lifecycle", () => {
 					}
 					return [] as any;
 				});
+			const originalV2Terminal = (
+				sharedLog as any
+			)._v2Send.sendTerminalReset.bind((sharedLog as any)._v2Send);
+			const v2Terminal = sinon
+				.stub((sharedLog as any)._v2Send, "sendTerminalReset")
+				.callsFake(async (...args: unknown[]) => {
+					order.push("v2-terminal-reset");
+					return originalV2Terminal(...args);
+				});
 			let terminating: Promise<unknown> | undefined;
 
 			try {
@@ -384,12 +428,15 @@ describe("lifecycle", () => {
 				expect(order).to.deep.equal([
 					"snapshot-start",
 					"snapshot-finish",
+					"v2-terminal-reset",
 					"terminal-reset",
 				]);
+				expect(v2Terminal.calledOnce).to.be.true;
 			} finally {
 				releaseSnapshot();
 				await terminating?.catch(() => {});
 				send.restore();
+				v2Terminal.restore();
 			}
 		});
 	}
@@ -447,7 +494,7 @@ describe("lifecycle", () => {
 	it("does not publish a request snapshot from a closed generation after reopen", async () => {
 		session = await TestSession.connected(1);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: { factor: 1 } },
+			args: { compatibility: 9, replicate: { factor: 1 } },
 		});
 		const sharedLog = db.log;
 		const requestMessage = new RequestReplicationInfoMessage();
@@ -509,7 +556,7 @@ describe("lifecycle", () => {
 				),
 			).to.have.length(0);
 
-			await session.peers[0].open(db);
+			await session.peers[0].open(db, { args: { compatibility: 9 } });
 			expect((sharedLog as any)._activeReceiveHandlersByPeer.size).to.equal(0);
 		} finally {
 			releaseSynchronizer();

--- a/packages/programs/data/shared-log/test/migration.spec.ts
+++ b/packages/programs/data/shared-log/test/migration.spec.ts
@@ -3,11 +3,17 @@ import { SilentDelivery } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
+import { SyncCapabilitiesMessage } from "../src/exchange-heads.js";
 import {
+	AddedReplicationInfoV2Message,
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
 	RequestReplicationInfoMessage,
+	RequestReplicationInfoV2Message,
 	ResponseRoleMessage,
+	StoppedReplicating,
+	StoppedReplicationInfoV2Message,
 } from "../src/replication.js";
 import { Replicator } from "../src/role.js";
 import { RatelessIBLTSynchronizer } from "../src/sync/rateless-iblt.js";
@@ -17,9 +23,20 @@ import { EventStore } from "./utils/stores/event-store.js";
 describe(`migration-8-9`, function () {
 	let session: TestSession;
 	let db1: EventStore<string, any>, db2: EventStore<string, any>;
+	let fakeOldLegacyRequests = 0;
+	let fakeOldV2Messages = 0;
+
+	const isReplicationInfoV2Message = (message: unknown) =>
+		message instanceof SyncCapabilitiesMessage ||
+		message instanceof RequestReplicationInfoV2Message ||
+		message instanceof FullReplicationInfoV2Message ||
+		message instanceof AddedReplicationInfoV2Message ||
+		message instanceof StoppedReplicationInfoV2Message;
 
 	const setup = async (compatibility?: number, order: boolean = false) => {
-		session = await TestSession.connected(2, [
+		fakeOldLegacyRequests = 0;
+		fakeOldV2Messages = 0;
+		session = await TestSession.disconnected(2, [
 			{
 				libp2p: {
 					privateKey: keys.privateKeyFromRaw(
@@ -60,16 +77,24 @@ describe(`migration-8-9`, function () {
 					},
 					compatibility,
 					onMessage: async (msg, context) => {
-						if (msg instanceof AddedReplicationSegmentMessage) {
+						if (isReplicationInfoV2Message(msg)) {
+							fakeOldV2Messages++;
+							return;
+						}
+						if (
+							msg instanceof AddedReplicationSegmentMessage ||
+							msg instanceof StoppedReplicating
+						) {
 							return; // this message type did not exist before
 						}
 						if (msg instanceof AllReplicatingSegmentsMessage) {
 							return; // this message type did not exist before
 						}
 						if (msg instanceof RequestReplicationInfoMessage) {
+							fakeOldLegacyRequests++;
 							// TODO we never respond to this message, nor in older version do we need to send it
 							// we are keeping this here to mimic the old behaviour
-							await db.log.rpc.send(
+							await db1.log.rpc.send(
 								new ResponseRoleMessage({
 									role: new Replicator({ factor: 1, offset: 0 }),
 								}),
@@ -80,6 +105,7 @@ describe(`migration-8-9`, function () {
 									}),
 								},
 							);
+							return;
 						}
 						return onMessageDefault(msg, context);
 					},
@@ -106,6 +132,27 @@ describe(`migration-8-9`, function () {
 			db1 = await createV8();
 		}
 
+		// Install both directions of the fake-old protocol boundary before the
+		// peers connect. This prevents the current implementation hidden behind
+		// the fixture from making the compatibility assertions pass through V2.
+		const originalFakeOldSend = db1.log.rpc.send.bind(db1.log.rpc);
+		(db1.log.rpc as any).send = async (message: unknown, options: unknown) => {
+			if (isReplicationInfoV2Message(message)) {
+				fakeOldV2Messages++;
+				return;
+			}
+			if (
+				message instanceof AddedReplicationSegmentMessage ||
+				message instanceof AllReplicatingSegmentsMessage ||
+				message instanceof StoppedReplicating
+			) {
+				return;
+			}
+			return originalFakeOldSend(message as any, options as any);
+		};
+
+		await session.connect([[session.peers[0], session.peers[1]]]);
+
 		await db1.waitFor(session.peers[1].peerId);
 		await db2.waitFor(session.peers[0].peerId);
 	};
@@ -118,7 +165,7 @@ describe(`migration-8-9`, function () {
 			await db2.drop();
 		}
 
-		await session.stop();
+		await session?.stop();
 	});
 
 	it("8-9, replicates database of 1 entry", async () => {
@@ -128,6 +175,8 @@ describe(`migration-8-9`, function () {
 
 		await db1.add(value);
 		await waitForResolved(() => expect(db2.log.log.length).equal(1));
+		expect(fakeOldLegacyRequests).to.be.greaterThan(0);
+		expect(fakeOldV2Messages).to.be.greaterThan(0);
 	});
 
 	it("9-8, replicates database of 1 entry", async () => {
@@ -137,9 +186,11 @@ describe(`migration-8-9`, function () {
 
 		await db2.add(value);
 		await waitForResolved(() => expect(db1.log.log.length).equal(1));
+		expect(fakeOldLegacyRequests).to.be.greaterThan(0);
+		expect(fakeOldV2Messages).to.be.greaterThan(0);
 	});
 
-	it("can turn off old behaviour", async () => {
+	it("does not fall back to legacy when compatibility is omitted", async () => {
 		await setup(undefined);
 		const value = "hello";
 		await db1.add(value);
@@ -150,6 +201,8 @@ describe(`migration-8-9`, function () {
 				throw new Error("timeout");
 			}),
 		).to.be.rejectedWith("timeout");
+		expect(fakeOldLegacyRequests).to.equal(0);
+		expect(fakeOldV2Messages).to.be.greaterThan(0);
 	});
 
 	it("v8 uses simple sync u32", async () => {
@@ -164,8 +217,14 @@ describe(`migration-8-9`, function () {
 		expect(db1.log.domain.resolution).to.equal("u32");
 	});
 
+	it("v0 stays on simple sync u32", async () => {
+		await setup(0);
+		expect(db1.log.syncronizer).to.be.instanceOf(SimpleSyncronizer);
+		expect(db1.log.domain.resolution).to.equal("u32");
+	});
+
 	it("v10+ uses iblt u64", async () => {
-		await setup(undefined);
+		await setup(10);
 		expect(db1.log.syncronizer).to.be.instanceOf(RatelessIBLTSynchronizer);
 		expect(db1.log.domain.resolution).to.equal("u64");
 	});

--- a/packages/programs/data/shared-log/test/receive-admission-ordering.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-ordering.spec.ts
@@ -30,7 +30,7 @@ describe("receive admission replication-info ordering watermark", () => {
 	const openLogWithSyntheticOwner = async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = db.log as any;
 		const ownerKey = session.peers[1].identity.publicKey;
@@ -45,10 +45,13 @@ describe("receive admission replication-info ordering watermark", () => {
 				timestamp: 1n,
 			});
 		const receive = (message: unknown, timestamp: bigint) =>
-			db.log.onMessage(message as any, {
-				from: ownerKey,
-				message: { header: { timestamp } },
-			} as any);
+			db.log.onMessage(
+				message as any,
+				{
+					from: ownerKey,
+					message: { header: { timestamp } },
+				} as any,
+			);
 		return {
 			db,
 			log,

--- a/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission-pins.spec.ts
@@ -61,10 +61,20 @@ describe("receive admission replication-info recovery epoch", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const target = await session.peers[0].open(store, {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = session.peers[1].identity.publicKey;
@@ -84,6 +94,11 @@ describe("receive admission replication-info recovery epoch", () => {
 			const scheduleRequests = sinon
 				.stub(sharedLog, "scheduleReplicationInfoRequests")
 				.callsFake(() => {});
+			// This test manually drives the legacy receive lane. V2 cutover is
+			// covered separately and must not bypass the fence under test.
+			const forceLegacyReceivePath = sinon
+				.stub(sharedLog._v2Receive, "isLegacyCutover")
+				.returns(false);
 
 			const delayedMessage = new AddedReplicationSegmentMessage({
 				segments: [remoteRange.toReplicationRange()],
@@ -178,6 +193,7 @@ describe("receive admission replication-info recovery epoch", () => {
 				releaseHandler.resolve();
 				applyQueue.restore();
 				synchronizer.restore();
+				forceLegacyReceivePath.restore();
 				scheduleRequests.restore();
 			}
 		} finally {
@@ -193,10 +209,20 @@ describe("receive admission replication-info recovery epoch", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const target = await session.peers[0].open(store, {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = session.peers[1].identity.publicKey;
@@ -213,6 +239,11 @@ describe("receive admission replication-info recovery epoch", () => {
 			const scheduleRequests = sinon
 				.stub(sharedLog, "scheduleReplicationInfoRequests")
 				.callsFake(() => {});
+			// This test manually drives the legacy receive lane. V2 cutover is
+			// covered separately and must not bypass the fence under test.
+			const forceLegacyReceivePath = sinon
+				.stub(sharedLog._v2Receive, "isLegacyCutover")
+				.returns(false);
 			const recoveryCalls: Array<{
 				gateOpen: boolean;
 				receiveEpoch: object | null;
@@ -343,6 +374,7 @@ describe("receive admission replication-info recovery epoch", () => {
 				synchronizer.restore();
 				v2ReAdvertisement.restore();
 				v2Recovery.restore();
+				forceLegacyReceivePath.restore();
 				scheduleRequests.restore();
 			}
 		} finally {
@@ -633,10 +665,10 @@ describe("receive admission control-plane dispatch precedence", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const source = await session.peers[0].open(store.clone(), {
-				args: { replicate: false, setup },
+				args: { compatibility: 9, replicate: false, setup },
 			});
 			const target = await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup },
+				args: { compatibility: 9, replicate: 1, setup },
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = source.node.identity.publicKey;
@@ -699,10 +731,20 @@ describe("receive admission control-plane lease one-shot", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const target = await session.peers[0].open(store, {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = session.peers[1].identity.publicKey;
@@ -827,10 +869,10 @@ describe("receive admission receive error envelope", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const source = await session.peers[0].open(store.clone(), {
-				args: { replicate: false, setup },
+				args: { compatibility: 9, replicate: false, setup },
 			});
 			const target = await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup },
+				args: { compatibility: 9, replicate: 1, setup },
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = source.node.identity.publicKey;

--- a/packages/programs/data/shared-log/test/receive-admission.spec.ts
+++ b/packages/programs/data/shared-log/test/receive-admission.spec.ts
@@ -218,10 +218,20 @@ describe("receive admission", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const target = await session.peers[0].open(store, {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = session.peers[1].identity.publicKey;
@@ -986,10 +996,20 @@ describe("receive admission", () => {
 		try {
 			const store = new EventStore<string, any>();
 			const target = await session.peers[0].open(store, {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			await session.peers[1].open(store.clone(), {
-				args: { replicate: 1, setup, timeUntilRoleMaturity: 0 },
+				args: {
+					compatibility: 9,
+					replicate: 1,
+					setup,
+					timeUntilRoleMaturity: 0,
+				},
 			});
 			const sharedLog = target.log as any;
 			const sourceKey = session.peers[1].identity.publicKey;
@@ -1006,6 +1026,11 @@ describe("receive admission", () => {
 			const delayedMessage = new AllReplicatingSegmentsMessage({
 				segments: [remoteRange.toReplicationRange()],
 			});
+			// This test manually drives the legacy receive lane. V2 cutover is
+			// covered separately and must not bypass the cleanup fence under test.
+			const forceLegacyReceivePath = sinon
+				.stub(sharedLog._v2Receive, "isLegacyCutover")
+				.returns(false);
 			const originalSynchronizerOnMessage =
 				sharedLog.syncronizer.onMessage.bind(sharedLog.syncronizer);
 			const synchronizer = sinon
@@ -1047,6 +1072,7 @@ describe("receive admission", () => {
 			} finally {
 				releaseSynchronizer.resolve();
 				synchronizer.restore();
+				forceLegacyReceivePath.restore();
 			}
 		} finally {
 			releaseSynchronizer.resolve();

--- a/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
@@ -22,6 +22,7 @@ describe("replication announcement retries", () => {
 		session = await TestSession.disconnected(1);
 		return session.peers[0].open(new EventStore<string, any>(), {
 			args: {
+				compatibility: 9,
 				replicate,
 				timeUntilRoleMaturity: 0,
 			},
@@ -45,6 +46,41 @@ describe("replication announcement retries", () => {
 			await session.stop();
 			session = undefined;
 		}
+	});
+
+	it("keeps legacy announcement retry and repair dormant by default", async () => {
+		session = await TestSession.disconnected(1);
+		const store = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = store.log as any;
+		const enqueueV2 = sinon.spy(log._v2Send, "enqueue");
+		const send = sinon.stub(store.log.rpc, "send").resolves([] as any);
+		const snapshot = sinon.spy(log, "getMyReplicationSegments");
+		log._announcements.setupReplicationAnnouncementRetryFunction(10);
+		log._announcements.setupReplicationAnnouncementRepairFunction(10, 3);
+
+		await log._announcements.sendReplicationAnnouncement(
+			new AddedReplicationSegmentMessage({ segments: [] }),
+		);
+		expect(enqueueV2.calledOnce).to.be.true;
+		expect(send.notCalled).to.be.true;
+		expect(
+			log._announcements.queueCurrentReplicationStateAnnouncementRetry(
+				new TimeoutError("legacy retry must stay disabled"),
+			),
+		).to.be.false;
+		log._announcements.queueCurrentReplicationStateAnnouncementRepair();
+		expect(log._announcements._announcementRepairBinding.pending).to.be.false;
+
+		log._announcements._announcementRepairBinding.pending = true;
+		await log._announcements.repairCurrentReplicationStateAnnouncement();
+		expect(log._announcements._announcementRepairBinding.pending).to.be.false;
+		log._announcements._replicationAnnouncementRetryPending = true;
+		await log._announcements.retryCurrentReplicationStateAnnouncement();
+		expect(log._announcements._replicationAnnouncementRetryPending).to.be.false;
+		expect(snapshot.notCalled).to.be.true;
+		expect(send.notCalled).to.be.true;
 	});
 
 	it("contains an adaptive timeout and retries the locally committed range as a full snapshot", async () => {
@@ -167,6 +203,7 @@ describe("replication announcement retries", () => {
 		session = await TestSession.connected(2);
 		const writer = await session.peers[0].open(new EventStore<string, any>(), {
 			args: {
+				compatibility: 9,
 				replicate: { factor: 1, offset: 0 },
 				timeUntilRoleMaturity: 0,
 				waitForReplicatorRequestIntervalMs: 25,
@@ -175,6 +212,7 @@ describe("replication announcement retries", () => {
 		});
 		const reader = await session.peers[1].open(writer.clone(), {
 			args: {
+				compatibility: 9,
 				replicate: false,
 				timeUntilRoleMaturity: 0,
 				waitForReplicatorRequestIntervalMs: 25,
@@ -246,7 +284,7 @@ describe("replication announcement retries", () => {
 	it("retries only a subscriber that did not acknowledge", async () => {
 		session = await TestSession.disconnected(3);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		useFastAnnouncementRepair(log);
@@ -288,7 +326,7 @@ describe("replication announcement retries", () => {
 	it("caps acknowledged repair retries and coalesces newer mutations", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		log._announcements.setupReplicationAnnouncementRepairFunction(25, 3);
@@ -357,7 +395,7 @@ describe("replication announcement retries", () => {
 	it("caps each generation at eight targets and rotates the next cohort", async () => {
 		session = await TestSession.disconnected(11);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		log._announcements.setupReplicationAnnouncementRepairFunction(10_000, 3);
@@ -411,7 +449,7 @@ describe("replication announcement retries", () => {
 	it("preempts an in-flight stale repair with the next mutation generation", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		useFastAnnouncementRepair(log);
@@ -488,7 +526,7 @@ describe("replication announcement retries", () => {
 	it("does not let a stale collection failure clear a newer pending repair", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		useFastAnnouncementRepair(log);
@@ -563,7 +601,7 @@ describe("replication announcement retries", () => {
 	it("cancels a queued acknowledged repair on close", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		log._announcements.setupReplicationAnnouncementRepairFunction(100, 3);
@@ -989,7 +1027,7 @@ describe("replication announcement retries", () => {
 	it("does not let a repair worker outlive a repair function reconfiguration", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		useFastAnnouncementRepair(log);
@@ -1126,7 +1164,7 @@ describe("replication announcement retries", () => {
 	it("does not let a repair worker from a previous open service the reopened log", async () => {
 		session = await TestSession.disconnected(2);
 		const store = await session.peers[0].open(new EventStore<string, any>(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = store.log as any;
 		useFastAnnouncementRepair(log);
@@ -1168,7 +1206,7 @@ describe("replication announcement retries", () => {
 
 		await store.close();
 		await session.peers[0].open(store, {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		reopened = true;
 		log._announcements._announcementRepairBinding.pending = true;

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -21,11 +21,13 @@ import {
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
 	FullReplicationInfoV2Message,
+	RequestReplicationInfoMessage,
 	RequestReplicationInfoV2Message,
 	ResponseRoleMessage,
 	StoppedReplicating,
 	StoppedReplicationInfoV2Message,
 } from "../src/replication.js";
+import { Observer } from "../src/role.js";
 import { EventStore } from "./utils/stores/index.js";
 
 const RECEIVER_CHALLENGE = Uint8Array.from({ length: 32 }, (_, index) => index);
@@ -79,16 +81,24 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		session = undefined;
 	});
 
-	it("keeps every legacy replication-info payload byte-identical", () => {
-		expect(hex(new AllReplicatingSegmentsMessage({ segments: [] }))).to.equal(
-			"00010200000000",
-		);
-		expect(hex(new AddedReplicationSegmentMessage({ segments: [] }))).to.equal(
-			"00010300000000",
-		);
-		expect(hex(new StoppedReplicating({ segmentIds: [] }))).to.equal(
-			"00010400000000",
-		);
+	it("keeps every legacy replication-info variant tag byte-identical", () => {
+		const cases = [
+			[new RequestReplicationInfoMessage(), "000100"],
+			[new ResponseRoleMessage({ role: new Observer() }), "0001010101"],
+			[new AllReplicatingSegmentsMessage({ segments: [] }), "00010200000000"],
+			[new AddedReplicationSegmentMessage({ segments: [] }), "00010300000000"],
+			[new StoppedReplicating({ segmentIds: [] }), "00010400000000"],
+		] as const;
+
+		for (const [message, expected] of cases) {
+			const bytes = serialize(message);
+			expect(Buffer.from(bytes).toString("hex")).to.equal(expected);
+			const decoded = deserialize(bytes, TransportMessage);
+			expect(decoded.constructor).to.equal(message.constructor);
+			expect(Buffer.from(serialize(decoded)).toString("hex")).to.equal(
+				expected,
+			);
+		}
 	});
 
 	it("pins the V2 tags, fixed-field order and little-endian u64", () => {
@@ -310,7 +320,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		}
 	});
 
-	it("advertises sender and receiver readiness while legacy remains primary", async () => {
+	it("uses V2-only replication-info startup by default", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: true, timeUntilRoleMaturity: 0 },
@@ -327,11 +337,27 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		const requests = sinon
 			.stub(log, "scheduleReplicationInfoRequests")
 			.callsFake(() => {});
+		const v2Recovery = sinon
+			.stub(log, "scheduleReplicationInfoV2Recovery")
+			.callsFake(() => {});
+		const snapshot = sinon.spy(log, "getMyReplicationSegments");
+		const advertise = sinon.spy(log._v2Receive, "advertiseLocalCapability");
+		const markReady = sinon.spy(log._v2Receive, "recordLocalCapabilityReady");
 
 		try {
 			await log._onSubscription({
 				detail: { from: remote, topics: [db.log.topic] },
 			});
+			const capabilityAdvertisement = advertise.returnValues[0];
+			expect(capabilityAdvertisement).to.exist;
+			await capabilityAdvertisement.firstAttempt;
+			const remoteHash = remote.hashcode();
+			const peerSession = log._peerSessions.current(remoteHash);
+			expect(
+				log._v2Receive._localCapabilityContextBySession.get(peerSession)
+					.legacyBarrierReleased,
+			).to.be.true;
+			expect(markReady.calledOnce).to.be.true;
 			const capability = sent.find(
 				(message) => message instanceof SyncCapabilitiesMessage,
 			) as SyncCapabilitiesMessage | undefined;
@@ -358,7 +384,14 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 				sent.some(
 					(message) => message instanceof AllReplicatingSegmentsMessage,
 				),
-			).to.be.true;
+			).to.be.false;
+			expect(
+				sent.some(
+					(message) =>
+						message instanceof RequestReplicationInfoMessage ||
+						message instanceof ResponseRoleMessage,
+				),
+			).to.be.false;
 			expect(
 				sent.some(
 					(message) =>
@@ -368,16 +401,181 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 						message instanceof StoppedReplicationInfoV2Message,
 				),
 			).to.be.false;
+			expect(snapshot.notCalled).to.be.true;
+			expect(requests.notCalled).to.be.true;
+			expect(v2Recovery.calledOnce).to.be.true;
 		} finally {
 			send.restore();
 			requests.restore();
+			v2Recovery.restore();
+			snapshot.restore();
+			advertise.restore();
+			markReady.restore();
+		}
+	});
+
+	it("drops every legacy replication-info control message in default mode", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+
+		const synchronizer = sinon
+			.stub(log.syncronizer, "onMessage")
+			.resolves(false);
+		const request = sinon.spy(log, "handleRequestReplicationInfo");
+		const announcement = sinon.spy(log, "handleReplicationInfoAnnouncement");
+		const stopped = sinon.spy(log, "handleStoppedReplicating");
+		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
+		const add = sinon.spy(log, "addReplicationRange");
+		const remove = sinon.spy(log, "removeReplicationRanges");
+		const send = sinon.spy(log.rpc, "send");
+		const acquireLease = sinon.spy(log, "acquirePeerReceiveLease");
+		const validateRanges = sinon.spy(
+			log,
+			"validateReplicationRangeAnnouncement",
+		);
+		const validateStopped = sinon.spy(
+			log,
+			"validateStoppedReplicationAnnouncement",
+		);
+		const messages = [
+			new RequestReplicationInfoMessage(),
+			new ResponseRoleMessage({ role: new Observer() }),
+			new AllReplicatingSegmentsMessage({ segments: [] }),
+			new AddedReplicationSegmentMessage({ segments: [] }),
+			new StoppedReplicating({ segmentIds: [] }),
+		];
+
+		try {
+			for (const [index, message] of messages.entries()) {
+				await db.log.onMessage(message, {
+					from: remote,
+					message: {
+						header: { session: 1n, timestamp: BigInt(index + 1) },
+					},
+				} as any);
+			}
+
+			expect(synchronizer.notCalled).to.be.true;
+			expect(request.notCalled).to.be.true;
+			expect(announcement.notCalled).to.be.true;
+			expect(stopped.notCalled).to.be.true;
+			expect(activity.notCalled).to.be.true;
+			expect(add.notCalled).to.be.true;
+			expect(remove.notCalled).to.be.true;
+			expect(send.notCalled).to.be.true;
+			expect(acquireLease.notCalled).to.be.true;
+			expect(validateRanges.notCalled).to.be.true;
+			expect(validateStopped.notCalled).to.be.true;
+			expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
+			expect(
+				await db.log.replicationIndex.count({ query: { hash: remoteHash } }),
+			).to.equal(0);
+		} finally {
+			synchronizer.restore();
+			request.restore();
+			announcement.restore();
+			stopped.restore();
+			activity.restore();
+			add.restore();
+			remove.restore();
+			send.restore();
+			acquireLease.restore();
+			validateRanges.restore();
+			validateStopped.restore();
+		}
+	});
+
+	it("replaces one exact-session V2 recovery nudge across rapid reconnect", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+			},
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+		const resume = sinon
+			.stub(log._v2Receive, "resumeParkedRequest")
+			.returns(false);
+		const clock = sinon.useFakeTimers();
+
+		try {
+			log.scheduleReplicationInfoV2Recovery(
+				remote,
+				log._instanceLifecycle.membershipLifecycleController,
+			);
+			expect(resume.calledOnce).to.be.true;
+			expect(log._replicationInfoRequestByPeer.has(remoteHash)).to.be.true;
+			await clock.tickAsync(150);
+			expect(resume.callCount).to.equal(4);
+			for (const call of resume.getCalls()) {
+				expect(call.args[0]).to.deep.equal({
+					peerHash: remoteHash,
+					peerSession,
+					receiveEpoch: log._peerSessions.receiveEpoch(remoteHash),
+				});
+			}
+			const exactSessionRecovery =
+				log._replicationInfoRequestByPeer.get(remoteHash);
+			log.cleanupPeerDisconnectTracking(remoteHash);
+			expect(log._replicationInfoRequestByPeer.get(remoteHash)).to.equal(
+				exactSessionRecovery,
+			);
+
+			const replacementSession = log._peerSessions.rotate(
+				remoteHash,
+				"opening",
+			);
+			log._peerSessions.unblockReplicationInfo(remoteHash);
+			log._peerSessions.markOpen(remoteHash, replacementSession);
+			log.scheduleReplicationInfoV2Recovery(
+				remote,
+				log._instanceLifecycle.membershipLifecycleController,
+			);
+			expect(resume.callCount).to.equal(5);
+			expect(
+				log._replicationInfoRequestByPeer.get(remoteHash).peerSession,
+			).to.equal(replacementSession);
+			await clock.tickAsync(50);
+			expect(resume.callCount).to.equal(6);
+			expect(resume.lastCall.args[0]).to.deep.equal({
+				peerHash: remoteHash,
+				peerSession: replacementSession,
+				receiveEpoch: log._peerSessions.receiveEpoch(remoteHash),
+			});
+
+			log._peerSessions.rotate(remoteHash, "departing");
+			await clock.tickAsync(50);
+			expect(resume.callCount).to.equal(6);
+			expect(log._replicationInfoRequestByPeer.has(remoteHash)).to.be.false;
+		} finally {
+			clock.restore();
+			resume.restore();
 		}
 	});
 
 	it("starts advertising V2 readiness before replication snapshot retrieval", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: true, timeUntilRoleMaturity: 0 },
+			args: {
+				compatibility: 9,
+				replicate: true,
+				timeUntilRoleMaturity: 0,
+			},
 		});
 		const log = db.log as any;
 		const remote = session.peers[1].identity.publicKey;
@@ -426,7 +624,11 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 	it("does not hold the legacy snapshot behind the V2 capability acknowledgement", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: true, timeUntilRoleMaturity: 0 },
+			args: {
+				compatibility: 9,
+				replicate: true,
+				timeUntilRoleMaturity: 0,
+			},
 		});
 		const log = db.log as any;
 		const remote = session.peers[1].identity.publicKey;

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/exchange-heads.js";
 import {
 	ReplicationIntent,
+	ReplicationRangeMessageU32,
 	ReplicationRangeMessageU64,
 } from "../src/ranges.js";
 import { deriveReplicationInfoV2ReceiverBinding } from "../src/replication-info-v2-binding.js";
@@ -1568,7 +1569,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 			senderTransportSession,
 			transportTimestamp: 2n,
 		})!;
-		expect(state.legacyFallbackTimer).to.exist;
+		expect(state.legacyFallbackTimer).to.be.undefined;
 		coordinator.release(reserved);
 		expect(state.legacyFallbackTimer).to.exist;
 		const committed = coordinator.reserve(matching, {
@@ -1655,6 +1656,295 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(coordinator.commit(prepare(full)!)).to.be.true;
 		await clock.tickAsync(1_000);
 		expect(sendRequest.callCount).to.equal(2);
+	});
+
+	it("resumes only an exact parked request without invalidating live work", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({
+			requestRetryMs: 2,
+			maxRequestRetryMs: 4,
+			requestMaxAttempts: 2,
+		});
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		await clock.tickAsync(10);
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(state.requestParked).to.be.true;
+		expect(sendRequest.callCount).to.equal(2);
+		const parkedVersion = state.version;
+		const parkedAttempts = state.requestAttempts;
+		const parkedBinding = state.receiverBinding;
+
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: {},
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+		peerStateReady = false;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+		peerStateReady = true;
+		expect(state.version).to.equal(parkedVersion);
+		expect(state.requestAttempts).to.equal(parkedAttempts);
+		expect(state.receiverBinding).to.equal(parkedBinding);
+		expect(state.requestParked).to.be.true;
+		expect(state.capabilityRefreshRequired).to.be.false;
+		expect(state.requestTimer).to.be.undefined;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: {},
+			}),
+		).to.be.false;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		expect(state.requestParked).to.be.false;
+		expect(state.capabilityRefreshRequired).to.be.true;
+		expect(state.requestTimer).to.exist;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+
+		await clock.tickAsync(2);
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(sendRequest.callCount).to.equal(3);
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(15),
+			sequence: 1n,
+			segments: [],
+		});
+		expect(coordinator.commit(prepare(full)!)).to.be.true;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+	});
+
+	it("does not resume a parked request while an authoritative Full is applying", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({
+			requestRetryMs: 2,
+			maxRequestRetryMs: 4,
+			requestMaxAttempts: 2,
+		});
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		await clock.tickAsync(10);
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(state.requestParked).to.be.true;
+		expect(sendRequest.callCount).to.equal(2);
+
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(16),
+			sequence: 1n,
+			segments: [],
+		});
+		const reserved = coordinator.reserve(full, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(reserved).to.exist;
+		expect(
+			coordinator.resumeParkedRequest({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.false;
+		expect(state.requestParked).to.be.true;
+		expect(state.capabilityRefreshRequired).to.be.false;
+		expect(state.requestTimer).to.be.undefined;
+		expect(refreshLocalCapability.notCalled).to.be.true;
+		expect(sendRequest.callCount).to.equal(2);
+
+		expect(coordinator.commit(reserved)).to.be.true;
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(1n);
+		expect(state.requestParked).to.be.false;
+		expect(state.capabilityRefreshRequired).to.be.false;
+		expect(state.requestTimer).to.be.undefined;
+		expect(sendRequest.callCount).to.equal(2);
+	});
+
+	it("pauses an armed request timer while an authoritative Full is applying", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({ requestRetryMs: 2 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		expect(state.requestTimer).to.exist;
+
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch: bytes(17),
+			sequence: 1n,
+			segments: [],
+		});
+		const first = coordinator.reserve(full, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(state.requestTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(sendRequest.notCalled).to.be.true;
+
+		coordinator.release(first);
+		expect(state.requestTimer).to.exist;
+		const committed = coordinator.reserve(full, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(state.requestTimer).to.be.undefined;
+		expect(coordinator.commit(committed)).to.be.true;
+		await clock.tickAsync(100);
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(1n);
+		expect(sendRequest.notCalled).to.be.true;
+	});
+
+	it("does not let an in-flight capability refresh invalidate an applying Full", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		const pendingRefresh = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.callsFake(() => pendingRefresh.promise);
+		coordinator = createCoordinator({ requestRetryMs: 2 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		state.capabilityRefreshRequired = true;
+		await clock.tickAsync(0);
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(state.requestInFlight).to.exist;
+		const version = state.version;
+		const receiverChallenge = state.receiverRequestChallenge;
+		const receiverBinding = state.receiverBinding;
+
+		const full = new FullReplicationInfoV2Message({
+			receiverChallenge: receiverBinding!.slice(),
+			senderEpoch: bytes(18),
+			sequence: 1n,
+			segments: [],
+		});
+		const admission = coordinator.reserve(full, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		const request = state.requestInFlight!;
+		pendingRefresh.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await request;
+
+		expect(state.version).to.equal(version);
+		expect(state.receiverRequestChallenge).to.equal(receiverChallenge);
+		expect(state.receiverBinding).to.equal(receiverBinding);
+		expect(state.requestTimer).to.be.undefined;
+		expect(sendRequest.notCalled).to.be.true;
+		expect(coordinator.commit(admission)).to.be.true;
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(1n);
+	});
+
+	it("pauses compat sidecar recovery while its matching V2 frame is applying", async () => {
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		coordinator = createCoordinator({ legacyFallbackDelayMs: 10 });
+		expect(markLocalReady(999)).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(19);
+		expect(
+			coordinator.commit(
+				prepare(
+					new FullReplicationInfoV2Message({
+						receiverChallenge: state.receiverBinding!.slice(),
+						senderEpoch,
+						sequence: 1n,
+						segments: [],
+					}),
+				)!,
+			),
+		).to.be.true;
+		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
+		coordinator.noteLegacyAnnouncement({
+			peerHash,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+			message: legacy,
+		});
+		expect(state.legacyFallbackTimer).to.exist;
+		const matching = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const first = coordinator.reserve(matching, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+		coordinator.release(first);
+		expect(state.legacyFallbackTimer).to.exist;
+
+		const committed = coordinator.reserve(matching, {
+			from: sender,
+			peerSession: currentSession,
+			receiveEpoch: currentReceiveEpoch,
+			senderTransportSession,
+			transportTimestamp: 2n,
+		})!;
+		const version = state.version;
+		expect(state.legacyFallbackTimer).to.be.undefined;
+		await clock.tickAsync(100);
+		expect(state.version).to.equal(version);
+		expect(coordinator.isAdmissionCurrent(committed)).to.be.true;
+		expect(coordinator.commit(committed)).to.be.true;
+		expect(state.phase).to.equal("active");
+		expect(state.lastSequence).to.equal(2n);
+		expect(state.legacyFallbackTimer).to.be.undefined;
+		expect(state.legacyFallbackFingerprint).to.be.undefined;
 	});
 
 	it("treats MAX_U64 as terminal for the current receiver grant", async () => {
@@ -1874,6 +2164,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			},
 			{ timeout: 20_000 },
 		);
+		expect(
+			receiver._replicationInfoRequestByPeer.get(senderHash)?.peerSession,
+		).to.equal(receiver._peerSessions.current(senderHash));
 	});
 
 	it("recovers first capability-advert failures for both exact peer sessions", async () => {
@@ -1940,13 +2233,13 @@ describe("receive admission replication-info V2 receiver integration", () => {
 	it("restores a rejected V2 delta with a Full while its legacy sidecar is suppressed", async () => {
 		session = await TestSession.connected(2);
 		const db1 = await session.peers[0].open(new EventStore(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const db2 = await EventStore.open<EventStore<string, any>>(
 			db1.address!,
 			session.peers[1],
 			{
-				args: { replicate: 1, timeUntilRoleMaturity: 0 },
+				args: { compatibility: 9, replicate: 1, timeUntilRoleMaturity: 0 },
 			},
 		);
 		const receiver = db1.log as any;
@@ -1964,10 +2257,10 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			{ timeout: 20_000 },
 		);
 
-		const range = new ReplicationRangeMessageU64({
+		const range = new ReplicationRangeMessageU32({
 			id: bytes(42),
-			offset: 10n,
-			factor: 10n,
+			offset: 10,
+			factor: 10,
 			timestamp: 10n,
 			mode: ReplicationIntent.NonStrict,
 		});
@@ -2348,7 +2641,7 @@ describe("receive admission replication-info V2 receiver integration", () => {
 	it("applies sequence order, cuts over legacy and recovers a gap with Full", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
+			args: { compatibility: 9, replicate: false, timeUntilRoleMaturity: 0 },
 		});
 		const log = db.log as any;
 		const remote = session.peers[1].identity.publicKey;
@@ -2392,24 +2685,24 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			log._v2Receive._localCapabilityReadyBySession.get(peerSession);
 		localReady.requestNotBeforeMs = 0;
 		const senderEpoch = bytes(7);
-		const rangeA = new ReplicationRangeMessageU64({
+		const rangeA = new ReplicationRangeMessageU32({
 			id: bytes(8),
-			offset: 10n,
-			factor: 10n,
+			offset: 10,
+			factor: 10,
 			timestamp: 10n,
 			mode: ReplicationIntent.NonStrict,
 		});
-		const rangeB = new ReplicationRangeMessageU64({
+		const rangeB = new ReplicationRangeMessageU32({
 			id: bytes(9),
-			offset: 30n,
-			factor: 10n,
+			offset: 30,
+			factor: 10,
 			timestamp: 11n,
 			mode: ReplicationIntent.NonStrict,
 		});
-		const rangeC = new ReplicationRangeMessageU64({
+		const rangeC = new ReplicationRangeMessageU32({
 			id: bytes(10),
-			offset: 50n,
-			factor: 10n,
+			offset: 50,
+			factor: 10,
 			timestamp: 12n,
 			mode: ReplicationIntent.NonStrict,
 		});

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -1033,52 +1033,58 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(activity.notCalled).to.be.true;
 	});
 
-	it("adds a directed V2 sidecar without changing the legacy primary send", async () => {
-		session = await TestSession.disconnected(2);
-		const db = await session.peers[0].open(new EventStore(), {
-			args: { replicate: false, timeUntilRoleMaturity: 0 },
-		});
-		const log = db.log as any;
-		const remote = session.peers[1].identity.publicKey;
-		const remoteHash = remote.hashcode();
-		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
-		log._peerSessions.unblockReplicationInfo(remoteHash);
-		log._peerSessions.markOpen(remoteHash, peerSession);
-		const receiverTransportSession = 88n;
-		log._peerSyncCapabilities.set(
-			remoteHash,
-			SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
-				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
-		);
-		log._peerSyncCapabilitySessions.set(remoteHash, receiverTransportSession);
-		log._peerSyncCapabilityTimestamps.set(remoteHash, 0n);
-		const send = sinon.stub(log.rpc, "send").resolves([] as any);
-		const request = new RequestReplicationInfoV2Message({
-			receiverChallenge: challenge(21),
-			intendedSender: log.node.identity.publicKey,
-			senderSession: BigInt(log.node.services.pubsub.session),
-		});
-		await log.onMessage(request, {
-			from: remote,
-			message: {
-				header: { session: receiverTransportSession, timestamp: 1n },
-			},
-		} as any);
-		await log._v2Send.drain();
-		send.resetHistory();
+	for (const compatibility of [undefined, 0, 9, 10] as const) {
+		const retainsLegacy = compatibility !== undefined && compatibility < 10;
+		it(`${retainsLegacy ? "retains" : "suppresses"} the legacy primary for compatibility ${String(compatibility)} while sending directed V2 mutations`, async () => {
+			session = await TestSession.disconnected(2);
+			const db = await session.peers[0].open(new EventStore(), {
+				args: { compatibility, replicate: false, timeUntilRoleMaturity: 0 },
+			});
+			const log = db.log as any;
+			const remote = session.peers[1].identity.publicKey;
+			const remoteHash = remote.hashcode();
+			const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+			log._peerSessions.unblockReplicationInfo(remoteHash);
+			log._peerSessions.markOpen(remoteHash, peerSession);
+			const receiverTransportSession = 88n;
+			log._peerSyncCapabilities.set(
+				remoteHash,
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+					SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+			);
+			log._peerSyncCapabilitySessions.set(remoteHash, receiverTransportSession);
+			log._peerSyncCapabilityTimestamps.set(remoteHash, 0n);
+			const send = sinon.stub(log.rpc, "send").resolves([] as any);
+			const request = new RequestReplicationInfoV2Message({
+				receiverChallenge: challenge(21),
+				intendedSender: log.node.identity.publicKey,
+				senderSession: BigInt(log.node.services.pubsub.session),
+			});
+			await log.onMessage(request, {
+				from: remote,
+				message: {
+					header: { session: receiverTransportSession, timestamp: 1n },
+				},
+			} as any);
+			await log._v2Send.drain();
+			send.resetHistory();
 
-		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
-		await log._announcements.sendReplicationAnnouncement(legacy);
-		await log._v2Send.drain();
-		expect(send.calledWith(legacy)).to.be.true;
-		const v2 = send.args
-			.map((args: any[]) => args[0])
-			.find(
+			const legacy = new AddedReplicationSegmentMessage({ segments: [] });
+			await log._announcements.sendReplicationAnnouncement(legacy);
+			await log._v2Send.drain();
+			const outbound = send.args.map((args: any[]) => args[0]);
+			const legacyMessages = outbound.filter(
+				(message: unknown) => message instanceof AddedReplicationSegmentMessage,
+			);
+			const v2Messages = outbound.filter(
 				(message: unknown) => message instanceof AddedReplicationInfoV2Message,
-			) as AddedReplicationInfoV2Message | undefined;
-		expect(v2).to.exist;
-		expect(v2!.sequence).to.equal(2n);
-	});
+			) as AddedReplicationInfoV2Message[];
+			expect(outbound).to.have.length(retainsLegacy ? 2 : 1);
+			expect(legacyMessages).to.have.length(retainsLegacy ? 1 : 0);
+			expect(v2Messages).to.have.length(1);
+			expect(v2Messages[0].sequence).to.equal(2n);
+		});
+	}
 
 	it("uses a newer capability to authorize one bounded challenge rebind", async () => {
 		session = await TestSession.disconnected(2);

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -1064,7 +1064,7 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(activity.notCalled).to.be.true;
 	});
 
-	it("preserves a pre-opening capability but fences successor openings and departure", async () => {
+	it("inherits only transport-matched pre-opening capabilities and fences departure", async () => {
 		session = await TestSession.disconnected(2);
 		const db = await session.peers[0].open(new EventStore(), {
 			args: { replicate: false, timeUntilRoleMaturity: 0 },
@@ -1080,6 +1080,9 @@ describe("receive admission replication-info V2 sender integration", () => {
 				SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
 				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
 		});
+		const requestSubscribers = sinon
+			.stub(session.peers[0].services.pubsub, "requestSubscribers")
+			.resolves();
 		await log.onMessage(capability, {
 			from: remote,
 			message: {
@@ -1093,10 +1096,18 @@ describe("receive admission replication-info V2 sender integration", () => {
 		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
 			remoteTransportSession,
 		);
+		await waitForResolved(
+			() =>
+				expect(requestSubscribers.calledOnceWith(log.topic, remote)).to.be.true,
+		);
 
 		sinon.stub(log.rpc, "send").resolves([] as any);
 		const event = {
-			detail: { from: remote, topics: [log.topic] },
+			detail: {
+				from: remote,
+				topics: [log.topic],
+				session: remoteTransportSession,
+			},
 		} as any;
 		await log._onSubscription(event);
 		const firstSession = log._peerSessions.current(remoteHash);
@@ -1110,13 +1121,6 @@ describe("receive admission replication-info V2 sender integration", () => {
 			log._v2Receive._receiveStates.get(remoteHash)?.senderTransportSession,
 		).to.equal(remoteTransportSession);
 
-		await log._onSubscription(event);
-		const replacement = log._peerSessions.current(remoteHash);
-		expect(replacement).not.to.equal(firstSession);
-		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;
-		expect(log._peerSyncCapabilityTimestamps.has(remoteHash)).to.be.false;
-		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
-
 		const successorTransportSession = 79n;
 		await log.onMessage(capability, {
 			from: remote,
@@ -1127,12 +1131,52 @@ describe("receive admission replication-info V2 sender integration", () => {
 				},
 			},
 		} as any);
+		await log._onSubscription({
+			detail: {
+				from: remote,
+				topics: [log.topic],
+				session: successorTransportSession,
+			},
+		} as any);
+		const replacement = log._peerSessions.current(remoteHash);
+		expect(replacement).not.to.equal(firstSession);
 		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
 			successorTransportSession,
+		);
+		expect(log._peerSyncCapabilityTimestamps.get(remoteHash)).to.equal(
+			capabilityTimestamp + 1n,
 		);
 		expect(
 			log._v2Receive._receiveStates.get(remoteHash)?.senderTransportSession,
 		).to.equal(successorTransportSession);
+
+		await log._onSubscription({
+			detail: {
+				from: remote,
+				topics: [log.topic],
+				session: successorTransportSession + 1n,
+			},
+		} as any);
+		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;
+		expect(log._peerSyncCapabilityTimestamps.has(remoteHash)).to.be.false;
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
+
+		const unboundTransportSession = successorTransportSession + 2n;
+		await log.onMessage(capability, {
+			from: remote,
+			message: {
+				header: {
+					session: unboundTransportSession,
+					timestamp: capabilityTimestamp + 2n,
+				},
+			},
+		} as any);
+		await log._onSubscription({
+			detail: { from: remote, topics: [log.topic] },
+		} as any);
+		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;
+		expect(log._peerSyncCapabilityTimestamps.has(remoteHash)).to.be.false;
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
 
 		await log._onUnsubscription(event);
 		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -875,6 +875,37 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(stateB.nextSequence).to.equal(4n);
 	});
 
+	it("honors the terminal bound when the transport ignores abort", async () => {
+		const peerSession = {};
+		openSessions.add(peerSession);
+		expect(accept(peerA, peerSession, challenge(47))).to.be.true;
+		await coordinator.drain();
+		const state = coordinator._sendStates.get(peerA.hashcode())!;
+		ownershipController.abort();
+		rpcSend.resetHistory();
+		const transport = pDefer<unknown>();
+		rpcSend.returns(transport.promise);
+		const terminalController = new AbortController();
+
+		const terminal = coordinator.sendTerminalReset(terminalController.signal);
+		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
+		let settled = false;
+		void terminal.then(() => {
+			settled = true;
+		});
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(settled).to.be.false;
+
+		terminalController.abort();
+		await terminal;
+		expect(settled).to.be.true;
+		const reset = rpcSend.firstCall.args[0] as FullReplicationInfoV2Message;
+		expect(reset.sequence).to.equal(2n);
+		expect(reset.segments).to.deep.equal([]);
+		expect(state.nextSequence).to.equal(3n);
+		transport.resolve([]);
+	});
+
 	it("spends the last u64 terminal sequence and cannot retry or recreate it", async () => {
 		const peerSession = {};
 		openSessions.add(peerSession);
@@ -1031,6 +1062,91 @@ describe("receive admission replication-info V2 sender integration", () => {
 		await log.onMessage(request, context(receiverTransportSession, 3n));
 		expect(send.notCalled).to.be.true;
 		expect(activity.notCalled).to.be.true;
+	});
+
+	it("preserves a pre-opening capability but fences successor openings and departure", async () => {
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const remoteTransportSession = 78n;
+		const capabilityTimestamp = 10n;
+		const capability = new SyncCapabilitiesMessage({
+			capabilities:
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE |
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND |
+				SYNC_CAPABILITY_REPLICATION_INFO_V2_APPLY,
+		});
+		await log.onMessage(capability, {
+			from: remote,
+			message: {
+				header: {
+					session: remoteTransportSession,
+					timestamp: capabilityTimestamp,
+				},
+			},
+		} as any);
+		expect(log._peerSessions.current(remoteHash)).to.equal(null);
+		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
+			remoteTransportSession,
+		);
+
+		sinon.stub(log.rpc, "send").resolves([] as any);
+		const event = {
+			detail: { from: remote, topics: [log.topic] },
+		} as any;
+		await log._onSubscription(event);
+		const firstSession = log._peerSessions.current(remoteHash);
+		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
+			remoteTransportSession,
+		);
+		expect(log._peerSyncCapabilityTimestamps.get(remoteHash)).to.equal(
+			capabilityTimestamp,
+		);
+		expect(
+			log._v2Receive._receiveStates.get(remoteHash)?.senderTransportSession,
+		).to.equal(remoteTransportSession);
+
+		await log._onSubscription(event);
+		const replacement = log._peerSessions.current(remoteHash);
+		expect(replacement).not.to.equal(firstSession);
+		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;
+		expect(log._peerSyncCapabilityTimestamps.has(remoteHash)).to.be.false;
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
+
+		const successorTransportSession = 79n;
+		await log.onMessage(capability, {
+			from: remote,
+			message: {
+				header: {
+					session: successorTransportSession,
+					timestamp: capabilityTimestamp + 1n,
+				},
+			},
+		} as any);
+		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
+			successorTransportSession,
+		);
+		expect(
+			log._v2Receive._receiveStates.get(remoteHash)?.senderTransportSession,
+		).to.equal(successorTransportSession);
+
+		await log._onUnsubscription(event);
+		expect(log._peerSyncCapabilitySessions.has(remoteHash)).to.be.false;
+		expect(log._peerSyncCapabilityTimestamps.has(remoteHash)).to.be.false;
+	});
+
+	it("does not open a replication session for an unsubscribed discovery candidate", async () => {
+		session = await TestSession.connected(2);
+		const db = await session.peers[0].open(new EventStore(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const remoteHash = session.peers[1].identity.publicKey.hashcode();
+
+		expect((db.log as any)._peerSessions.current(remoteHash)).to.equal(null);
 	});
 
 	for (const compatibility of [undefined, 0, 9, 10] as const) {

--- a/packages/programs/data/shared-log/test/replication.spec.ts
+++ b/packages/programs/data/shared-log/test/replication.spec.ts
@@ -26,8 +26,9 @@ import { createNumbers } from "../src/integers.js";
 import type { ReplicationRangeIndexable } from "../src/ranges.js";
 import {
 	AbsoluteReplicas,
-	AddedReplicationSegmentMessage,
+	AddedReplicationInfoV2Message,
 	AllReplicatingSegmentsMessage,
+	FullReplicationInfoV2Message,
 	decodeReplicas,
 	maxReplicas,
 } from "../src/replication.js";
@@ -213,46 +214,58 @@ testSetups.forEach((setup) => {
 				db2 = await session.peers[1].open(db1.clone(), {
 					args: {
 						setup,
+						compatibility: 9,
 					},
 				});
 
 				const fromHash = session.peers[0].identity.publicKey.hashcode();
+				// This test manually sends the legacy snapshot. V2 cutover is covered
+				// separately and must not satisfy the assertion through another path.
+				const forceLegacyReceivePath = sinon
+					.stub((db2.log as any)._v2Receive, "isLegacyCutover")
+					.returns(false);
 
-				// Ensure we start from a clean state on db2 for db1's ranges.
-				// Clearing through the network can race with periodic replication
-				// announcements and make this test flaky under CI load.
-				await db2.log.replicationIndex.del({
-					query: { hash: fromHash },
-				});
-				await waitForResolved(
-					async () =>
-						expect(
-							await db2.log.replicationIndex.count({
-								query: { hash: fromHash },
-							}),
-						).to.equal(0),
-					{ timeout: 5_000 },
-				);
+				try {
+					// Ensure we start from a clean state on db2 for db1's ranges.
+					// Clearing through the network can race with periodic replication
+					// announcements and make this test flaky under CI load.
+					await db2.log.replicationIndex.del({
+						query: { hash: fromHash },
+					});
+					await waitForResolved(
+						async () =>
+							expect(
+								await db2.log.replicationIndex.count({
+									query: { hash: fromHash },
+								}),
+							).to.equal(0),
+						{ timeout: 5_000 },
+					);
 
-				// Simulate the timing-sensitive case where `Program.waitFor()` rejects.
-				(db2.log as any).waitFor = () => Promise.reject(new Error("boom"));
+					// Simulate the timing-sensitive case where `Program.waitFor()` rejects.
+					(db2.log as any).waitFor = () => Promise.reject(new Error("boom"));
 
-				const segments = (await db1.log.getMyReplicationSegments()).map((x) =>
-					x.toReplicationRange(),
-				);
-				expect(segments.length).to.be.greaterThan(0);
+					const segments = (await db1.log.getMyReplicationSegments()).map((x) =>
+						x.toReplicationRange(),
+					);
+					expect(segments.length).to.be.greaterThan(0);
 
-				await db1.log.rpc.send(new AllReplicatingSegmentsMessage({ segments }));
+					await db1.log.rpc.send(
+						new AllReplicatingSegmentsMessage({ segments }),
+					);
 
-				await waitForResolved(
-					async () =>
-						expect(
-							await db2.log.replicationIndex.count({
-								query: { hash: fromHash },
-							}),
-						).to.be.greaterThan(0),
-					{ timeout: 5_000 },
-				);
+					await waitForResolved(
+						async () =>
+							expect(
+								await db2.log.replicationIndex.count({
+									query: { hash: fromHash },
+								}),
+							).to.be.greaterThan(0),
+						{ timeout: 5_000 },
+					);
+				} finally {
+					forceLegacyReceivePath.restore();
+				}
 			});
 
 			it("logs are unique", async () => {
@@ -2541,13 +2554,13 @@ testSetups.forEach((setup) => {
 									probability: scaleChaosProbability(0.25),
 								},
 								{
-									type: AddedReplicationSegmentMessage,
+									type: AddedReplicationInfoV2Message,
 									minDelayMs: scaleChaosDelay(25),
 									maxDelayMs: scaleChaosDelay(140),
 									probability: scaleChaosProbability(0.25),
 								},
 								{
-									type: AllReplicatingSegmentsMessage,
+									type: FullReplicationInfoV2Message,
 									minDelayMs: scaleChaosDelay(25),
 									maxDelayMs: scaleChaosDelay(140),
 									probability: scaleChaosProbability(0.25),
@@ -4375,8 +4388,8 @@ testSetups.forEach((setup) => {
 						expect(
 							received.some(
 								(m) =>
-									m instanceof AddedReplicationSegmentMessage ||
-									m instanceof AllReplicatingSegmentsMessage,
+									m instanceof AddedReplicationInfoV2Message ||
+									m instanceof FullReplicationInfoV2Message,
 							),
 						).to.equal(true);
 						expect(received.some((m) => m instanceof RequestIPruneV2)).to.equal(true);
@@ -5041,13 +5054,13 @@ testSetups.forEach((setup) => {
 					const slowController = new AbortController();
 					slowDownMessage(
 						db3.log,
-						AddedReplicationSegmentMessage,
+						AddedReplicationInfoV2Message,
 						2000,
 						slowController.signal,
 					);
 					slowDownMessage(
 						db3.log,
-						AllReplicatingSegmentsMessage,
+						FullReplicationInfoV2Message,
 						2000,
 						slowController.signal,
 					);

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -366,13 +366,10 @@ describe("waitForReplicator liveness", () => {
 		const disconnected = sinon.spy(log.syncronizer, "onPeerDisconnected");
 
 		try {
-			const blocker = log.withReplicationInfoApplyQueue(
-				peerHash,
-				async () => {
-					blockerStarted.resolve();
-					await releaseBlocker.promise;
-				},
-			);
+			const blocker = log.withReplicationInfoApplyQueue(peerHash, async () => {
+				blockerStarted.resolve();
+				await releaseBlocker.promise;
+			});
 			await blockerStarted.promise;
 			const blockerTail = log._replicationInfoApplyQueueByPeer.get(peerHash);
 
@@ -680,9 +677,9 @@ describe("waitForReplicator liveness", () => {
 		);
 		await waitForResolved(
 			() =>
-				expect(joinEvents.filter((eventHash) => eventHash === peerHash)).to.have.length(
-					1,
-				),
+				expect(
+					joinEvents.filter((eventHash) => eventHash === peerHash),
+				).to.have.length(1),
 			{ timeout: 20_000, delayInterval: 100 },
 		);
 
@@ -692,6 +689,14 @@ describe("waitForReplicator liveness", () => {
 			hooks.confirmReplicatorSubscriberPresence.bind(hooks);
 		let pingFailuresLeft = 2;
 		let failRecoveryRequests = true;
+		const originalResumeParkedRequest = (
+			db0.log as any
+		)._v2Receive.resumeParkedRequest.bind((db0.log as any)._v2Receive);
+		const resumeParkedRequest = sinon
+			.stub((db0.log as any)._v2Receive, "resumeParkedRequest")
+			.callsFake((properties) =>
+				failRecoveryRequests ? false : originalResumeParkedRequest(properties),
+			);
 		db0.log.rpc.send = async (...args: Parameters<typeof originalSend>) => {
 			const [message] = args;
 			if (message instanceof ReplicationPingMessage && pingFailuresLeft-- > 0) {
@@ -730,11 +735,13 @@ describe("waitForReplicator liveness", () => {
 			);
 			await waitForResolved(
 				() =>
-					expect(joinEvents.filter((eventHash) => eventHash === peerHash)).to.have
-						.length(2),
+					expect(
+						joinEvents.filter((eventHash) => eventHash === peerHash),
+					).to.have.length(2),
 				{ timeout: 20_000, delayInterval: 100 },
 			);
 		} finally {
+			resumeParkedRequest.restore();
 			db0.log.rpc.send = originalSend;
 			hooks.confirmReplicatorSubscriberPresence =
 				originalConfirmSubscriberPresence;
@@ -749,12 +756,14 @@ describe("waitForReplicator liveness", () => {
 			args: {
 				replicate: { factor: 1 },
 				timeUntilRoleMaturity: 0,
+				compatibility: 9,
 			},
 		});
 		await session.peers[1].open(store.clone(), {
 			args: {
 				replicate: { factor: 1 },
 				timeUntilRoleMaturity: 0,
+				compatibility: 9,
 			},
 		});
 

--- a/packages/programs/data/shared-log/test/sharding.spec.ts
+++ b/packages/programs/data/shared-log/test/sharding.spec.ts
@@ -18,8 +18,8 @@ import {
 } from "../src/replication-domain-hash.js";
 import {
 	AbsoluteReplicas,
-	AddedReplicationSegmentMessage,
-	AllReplicatingSegmentsMessage,
+	AddedReplicationInfoV2Message,
+	FullReplicationInfoV2Message,
 	RequestReplicationInfoMessage,
 } from "../src/replication.js";
 import {
@@ -1124,6 +1124,7 @@ testSetups.forEach((setup) => {
 						timeUntilRoleMaturity: 0,
 						waitForReplicatorRequestIntervalMs: 50,
 						waitForReplicatorTimeout: 300,
+						compatibility: 9,
 					},
 				});
 
@@ -1623,13 +1624,13 @@ testSetups.forEach((setup) => {
 							probability: 1,
 						},
 						{
-							type: AddedReplicationSegmentMessage,
+							type: AddedReplicationInfoV2Message,
 							minDelayMs: 100,
 							maxDelayMs: 600,
 							probability: 0.45,
 						},
 						{
-							type: AllReplicatingSegmentsMessage,
+							type: FullReplicationInfoV2Message,
 							minDelayMs: 100,
 							maxDelayMs: 600,
 							probability: 0.45,
@@ -1921,13 +1922,13 @@ testSetups.forEach((setup) => {
 							probability: 0.25,
 						},
 						{
-							type: AddedReplicationSegmentMessage,
+							type: AddedReplicationInfoV2Message,
 							minDelayMs: 25,
 							maxDelayMs: 140,
 							probability: 0.25,
 						},
 						{
-							type: AllReplicatingSegmentsMessage,
+							type: FullReplicationInfoV2Message,
 							minDelayMs: 25,
 							maxDelayMs: 140,
 							probability: 0.25,

--- a/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
+++ b/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
@@ -1,11 +1,11 @@
 import { TestSession } from "@peerbit/test-utils";
-import { TimeoutError, delay } from "@peerbit/time";
+import { TimeoutError, delay, waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
 import {
 	AbsoluteReplicas,
-	encodeReplicas,
 	RequestReplicationInfoMessage,
+	encodeReplicas,
 } from "../src/replication.js";
 import { checkBounded } from "./utils.js";
 import { EventStore } from "./utils/stores/index.js";
@@ -75,6 +75,7 @@ describe("waitForReplicator", () => {
 		session = await TestSession.connected(2);
 		db = await session.peers[0].open(new EventStore<string, any>(), {
 			args: {
+				compatibility: 9,
 				timeUntilRoleMaturity: 0,
 				waitForReplicatorRequestIntervalMs: 50,
 				waitForReplicatorRequestMaxAttempts: 2,
@@ -109,6 +110,96 @@ describe("waitForReplicator", () => {
 		}
 
 		expect(requestCount - baseline).to.equal(2);
+	});
+
+	it("nudges parked V2 recovery without sending legacy requests by default", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 2,
+			},
+		});
+		await session.peers[1].open(db.clone(), {
+			args: {
+				replicate: false,
+				timeUntilRoleMaturity: 0,
+			},
+		});
+		const log = db.log as any;
+		const originalSend = log.rpc.send.bind(log.rpc);
+		let legacyRequests = 0;
+		log.rpc.send = async (message: any, options: any) => {
+			if (message instanceof RequestReplicationInfoMessage) {
+				legacyRequests++;
+				return;
+			}
+			return originalSend(message, options);
+		};
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		await waitForResolved(() =>
+			expect(log._peerSessions.current(remoteHash)?.phase).to.equal("open"),
+		);
+		// Isolate the caller-owned wait loop from the session-lifetime recovery
+		// ticker started at the end of the subscription callback. `markOpen`
+		// precedes that scheduling, so wait for the exact-session job itself.
+		await waitForResolved(() =>
+			expect(
+				log._replicationInfoRequestByPeer.get(remoteHash)?.peerSession,
+			).to.equal(log._peerSessions.current(remoteHash)),
+		);
+		log.cancelReplicationInfoRequests(remoteHash);
+		const scheduleRecovery = sinon
+			.stub(log, "scheduleReplicationInfoV2Recovery")
+			.callsFake(() => {});
+		const resumed: Array<{
+			properties: {
+				peerHash: string;
+				peerSession: object;
+				receiveEpoch: object | null;
+			};
+			currentPeerSession: object | undefined;
+			currentPhase: string | undefined;
+			currentReceiveEpoch: object | null;
+		}> = [];
+		const resume = sinon
+			.stub(log._v2Receive, "resumeParkedRequest")
+			.callsFake((properties: unknown) => {
+				resumed.push({
+					properties: properties as (typeof resumed)[number]["properties"],
+					currentPeerSession: log._peerSessions.current(remoteHash),
+					currentPhase: log._peerSessions.current(remoteHash)?.phase,
+					currentReceiveEpoch: log._peerSessions.receiveEpoch(remoteHash),
+				});
+				return false;
+			});
+
+		try {
+			await expect(
+				db.log.waitForReplicator(remote, {
+					timeout: 300,
+					eager: true,
+				}),
+			).to.be.rejectedWith(TimeoutError);
+			expect(legacyRequests).to.equal(0);
+			expect(resume.callCount).to.equal(2);
+			for (const observation of resumed) {
+				expect(observation.properties.peerHash).to.equal(remoteHash);
+				expect(observation.properties.peerSession).to.equal(
+					observation.currentPeerSession,
+				);
+				expect(observation.currentPhase).to.equal("open");
+				expect(observation.properties.receiveEpoch).to.equal(
+					observation.currentReceiveEpoch,
+				);
+			}
+		} finally {
+			resume.restore();
+			scheduleRecovery.restore();
+			log.rpc.send = originalSend;
+		}
 	});
 
 	it("rejects waitForReplicators when internal leader check throws", async () => {
@@ -186,5 +277,4 @@ describe("waitForReplicator", () => {
 			"Log did not conform to upper bound length of 1 got 2",
 		);
 	});
-
 });

--- a/packages/transport/pubsub-interface/src/index.ts
+++ b/packages/transport/pubsub-interface/src/index.ts
@@ -24,9 +24,16 @@ export class SubscriptionEvent {
 	@field({ type: vec("string") })
 	topics: string[];
 
-	constructor(from: PublicSignKey, topics: string[]) {
+	/**
+	 * Runtime-only signed transport generation of the Subscribe frame, when
+	 * available. Intentionally undecorated: this event metadata is not a wire field.
+	 */
+	session?: bigint;
+
+	constructor(from: PublicSignKey, topics: string[], session?: bigint) {
 		this.from = from;
 		this.topics = topics;
+		this.session = session;
 	}
 }
 

--- a/packages/transport/pubsub/src/index.ts
+++ b/packages/transport/pubsub/src/index.ts
@@ -3889,7 +3889,11 @@ export class TopicControlPlane
 				if (changed.length > 0) {
 					this.dispatchEvent(
 						new CustomEvent<SubscriptionEvent>("subscribe", {
-							detail: new SubscriptionEvent(sender, changed),
+							detail: new SubscriptionEvent(
+								sender,
+								changed,
+								message.header.session,
+							),
 						}),
 					);
 				}
@@ -3998,7 +4002,11 @@ export class TopicControlPlane
 				if (changed.length > 0) {
 					this.dispatchEvent(
 						new CustomEvent<SubscriptionEvent>("subscribe", {
-							detail: new SubscriptionEvent(sender, changed),
+							detail: new SubscriptionEvent(
+								sender,
+								changed,
+								message.header.session,
+							),
 						}),
 					);
 				}

--- a/packages/transport/pubsub/test/subscribe-races.spec.ts
+++ b/packages/transport/pubsub/test/subscribe-races.spec.ts
@@ -2834,6 +2834,33 @@ describe("pubsub (subscribe race regressions)", function () {
 		expect(a.topics.get(TOPIC)).to.equal(undefined);
 	});
 
+	it("exposes the signed transport generation on subscribe events", async () => {
+		const TOPIC = "subscribe-event-transport-session";
+		session = await createDisconnectedSession(2);
+
+		const a = session.peers[0]!.services.pubsub;
+		const b = session.peers[1]!.services.pubsub;
+		await session.connect([[session.peers[0], session.peers[1]]]);
+		await waitForNeighbour(a, b);
+		await b.subscribe(TOPIC);
+
+		let observedSession: bigint | undefined;
+		b.addEventListener("subscribe", (event) => {
+			if (event.detail.from.hashcode() === a.publicKeyHash) {
+				observedSession = event.detail.session;
+			}
+		});
+		await a.subscribe(TOPIC);
+
+		await waitForResolved(() => {
+			const recordedSession = b.topics
+				.get(TOPIC)
+				?.get(a.publicKeyHash)?.session;
+			expect(observedSession).to.equal(recordedSession);
+			expect(observedSession).to.not.equal(undefined);
+		});
+	});
+
 	it("does not advertise cancelled pending subscriptions to peers", async () => {
 		const TOPIC = "subscribe-then-unsubscribe-before-debounce-regression";
 		const debounceDelayMs = 500;

--- a/packages/transport/pubsub/test/unsubscribe-reason.spec.ts
+++ b/packages/transport/pubsub/test/unsubscribe-reason.spec.ts
@@ -1,17 +1,22 @@
 import { getPublicKeyFromPeerId } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/libp2p-test-utils";
 import type {
+	SubscriptionEvent,
 	UnsubcriptionEvent,
 	UnsubscriptionReason,
 } from "@peerbit/pubsub-interface";
 import {
-	SubscriptionData,
 	Subscribe,
+	SubscriptionData,
 	Unsubscribe,
 } from "@peerbit/pubsub-interface";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
-import { FanoutTree, TopicControlPlane, TopicRootControlPlane } from "../src/index.js";
+import {
+	FanoutTree,
+	TopicControlPlane,
+	TopicRootControlPlane,
+} from "../src/index.js";
 
 describe("pubsub (unsubscribe reason)", function () {
 	const createControlEnvelope = (properties: {
@@ -376,6 +381,15 @@ describe("pubsub (unsubscribe reason)", function () {
 		try {
 			const { a, b } = await setupTrackedSubscribers(topic, session);
 			const bPublicKey = getPublicKeyFromPeerId(session.peers[1]!.peerId);
+			let observedSession: bigint | undefined;
+			a.addEventListener(
+				"subscribe",
+				(event: CustomEvent<SubscriptionEvent>) => {
+					if (event.detail.from.hashcode() === b.publicKeyHash) {
+						observedSession = event.detail.session;
+					}
+				},
+			);
 
 			a.topics.get(topic)?.delete(b.publicKeyHash);
 			a.peerToTopic.delete(b.publicKeyHash);
@@ -384,11 +398,14 @@ describe("pubsub (unsubscribe reason)", function () {
 			await a.requestSubscribers(topic, bPublicKey);
 
 			await waitForResolved(() => {
-				expect(a.topics.get(topic)?.has(b.publicKeyHash)).to.equal(true);
+				const recordedSession = a.topics
+					.get(topic)
+					?.get(b.publicKeyHash)?.session;
+				expect(observedSession).to.equal(recordedSession);
+				expect(observedSession).to.not.equal(undefined);
 			});
 		} finally {
 			await session.stop();
 		}
 	});
-
 });


### PR DESCRIPTION
## Summary

- use authenticated replication-info V2 exclusively for default/current SharedLog opens
- retain the existing dual V2 + legacy fallback for explicit `compatibility < 10` opens
- keep legacy wire variants registered as decode tombstones and reject them before receive-side effects in default mode
- keep exact-session V2 recovery alive after initial Full, reconnect safely, and fence request/sidecar timers while durable V2 admissions are applying
- bind subscription events to their signed transport generation and recover pre-session capability delivery through targeted authoritative subscriber snapshots
- establish both document-index and SharedLog topics before `DocumentIndex.waitFor()` reports replication readiness
- migrate legacy behavior tests to explicit compatibility fixtures and add boundary, migration, terminal, retry, reconnect, and wire-count pins

## Rollout note

Pre-B10 peers still running with default/undefined compatibility must be drained or prevented from rejoining before deploying this cutoff. Updated default and explicit compatibility peers still converge over V2; compatibility 8/9 remains available for legacy cohorts.

## Validation

- builds: `@peerbit/pubsub-interface`, `@peerbit/pubsub`, and `@peerbit/shared-log`
- Rust-core Node 22 V2 group: 94 passing
- migration compatibility group: 7 passing
- cutoff/race/terminal/reconnect hardening group: 12 passing
- standard Node 24/mock fast close/reopen: 30/30 focused repetitions across final recovery hardening
- standard Node 24/mock disconnected late join: 20/20, then 10/10 with a one-shot peer iterator pin
- standard Node 24/mock low-level disconnected `waitForReplicator`: 20/20
- signed pubsub session propagation: direct and shard paths passing
- exact non-replicator delete readiness regression: passing on the standard backend
- ESLint passed for all changed files; `git diff --check` passed

The full `@peerbit/document` local build is constrained by pre-existing missing workspace links for `@peerbit/native-backbone` and `@peerbit/document-rust`. Its two exact changed integration paths were executed from freshly emitted current source on the standard JavaScript backend. CI remains authoritative for the complete workspace matrix.