### PR TITLE
fix(shared-log): bootstrap v2 wait sessions

### DIFF
--- a/.changeset/quiet-peers-bootstrap-v2.md
+++ b/.changeset/quiet-peers-bootstrap-v2.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Bootstrap default V2 replication waits from an authoritative subscriber snapshot when the target's SharedLog subscription is missing or departing.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -20630,6 +20630,7 @@ export class SharedLog<
 		}, timeoutMs);
 
 		let requestAttempts = 0;
+		let subscriberSnapshotInFlight: Promise<void> | undefined;
 		const requestIntervalMs = this.waitForReplicatorRequestIntervalMs;
 		const maxRequestAttempts =
 			this.waitForReplicatorRequestMaxAttempts ??
@@ -20637,6 +20638,26 @@ export class SharedLog<
 				WAIT_FOR_REPLICATOR_REQUEST_MIN_ATTEMPTS,
 				Math.ceil(timeoutMs / requestIntervalMs),
 			);
+		const requestSubscriberSnapshot = () => {
+			if (subscriberSnapshotInFlight) {
+				return;
+			}
+			subscriberSnapshotInFlight = Promise.resolve()
+				.then(async () => {
+					if (settled || this.closed) {
+						return;
+					}
+					await this.node.services.pubsub.requestSubscribers(this.topic, key);
+				})
+				.catch((error) => {
+					if (!isNotStartedError(error as Error)) {
+						logger.error(error?.toString?.() ?? String(error));
+					}
+				})
+				.finally(() => {
+					subscriberSnapshotInFlight = undefined;
+				});
+		};
 
 		const requestReplicationInfo = () => {
 			if (settled || this.closed) {
@@ -20670,6 +20691,12 @@ export class SharedLog<
 						peerSession,
 						receiveEpoch: this._peerSessions.receiveEpoch(peerHash),
 					});
+				} else if (peerSession === null || peerSession.phase === "departing") {
+					// A peer can be known to routing before its SharedLog topic
+					// subscription has been observed. Legacy requests used to bootstrap
+					// that case directly; V2 needs an authoritative Subscribe snapshot
+					// before it can create a fenced PeerSession and request a Full.
+					requestSubscriberSnapshot();
 				}
 			}
 

--- a/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
+++ b/packages/programs/data/shared-log/test/wait-for-replicator.spec.ts
@@ -202,6 +202,156 @@ describe("waitForReplicator", () => {
 		}
 	});
 
+	it("requests an authoritative subscriber snapshot when V2 has no peer session", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 2,
+			},
+		});
+
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		expect(log._peerSessions.current(remoteHash)).to.equal(null);
+
+		const requestSubscribers = sinon
+			.stub(session.peers[0].services.pubsub, "requestSubscribers")
+			.resolves();
+		const resume = sinon.stub(log._v2Receive, "resumeParkedRequest");
+
+		try {
+			await expect(
+				log.waitForReplicator(remote, {
+					timeout: 300,
+					eager: true,
+				}),
+			).to.be.rejectedWith(TimeoutError);
+			expect(requestSubscribers.callCount).to.equal(2);
+			for (const call of requestSubscribers.getCalls()) {
+				expect(call.args).to.deep.equal([log.topic, remote]);
+			}
+			expect(resume.notCalled).to.be.true;
+		} finally {
+			resume.restore();
+			requestSubscribers.restore();
+		}
+	});
+
+	it("requests a subscriber snapshot for a departing V2 peer session", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 2,
+			},
+		});
+
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const departing = log._peerSessions.rotate(remoteHash, "departing");
+		expect(log._peerSessions.current(remoteHash)).to.equal(departing);
+
+		const requestSubscribers = sinon
+			.stub(session.peers[0].services.pubsub, "requestSubscribers")
+			.resolves();
+		const resume = sinon.stub(log._v2Receive, "resumeParkedRequest");
+
+		try {
+			await expect(
+				log.waitForReplicator(remote, {
+					timeout: 300,
+					eager: true,
+				}),
+			).to.be.rejectedWith(TimeoutError);
+			expect(requestSubscribers.callCount).to.equal(2);
+			expect(requestSubscribers.alwaysCalledWithExactly(log.topic, remote)).to
+				.be.true;
+			expect(resume.notCalled).to.be.true;
+		} finally {
+			resume.restore();
+			requestSubscribers.restore();
+		}
+	});
+
+	it("coalesces an in-flight V2 subscriber snapshot across wait retries", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 3,
+			},
+		});
+
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		let releaseSnapshot!: () => void;
+		const snapshot = new Promise<void>((resolve) => {
+			releaseSnapshot = resolve;
+		});
+		const requestSubscribers = sinon
+			.stub(session.peers[0].services.pubsub, "requestSubscribers")
+			.returns(snapshot);
+
+		try {
+			await expect(
+				log.waitForReplicator(remote, {
+					timeout: 300,
+					eager: true,
+				}),
+			).to.be.rejectedWith(TimeoutError);
+			expect(requestSubscribers.calledOnceWithExactly(log.topic, remote)).to.be
+				.true;
+		} finally {
+			releaseSnapshot();
+			await snapshot;
+			await delay(0);
+			requestSubscribers.restore();
+		}
+	});
+
+	it("does not request a subscriber snapshot while a V2 peer session is opening", async () => {
+		session = await TestSession.connected(2);
+		db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: {
+				timeUntilRoleMaturity: 0,
+				waitForReplicatorRequestIntervalMs: 50,
+				waitForReplicatorRequestMaxAttempts: 2,
+			},
+		});
+
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const opening = log._peerSessions.rotate(remoteHash, "opening");
+		expect(log._peerSessions.current(remoteHash)).to.equal(opening);
+
+		const requestSubscribers = sinon.stub(
+			session.peers[0].services.pubsub,
+			"requestSubscribers",
+		);
+		const resume = sinon.stub(log._v2Receive, "resumeParkedRequest");
+
+		try {
+			await expect(
+				log.waitForReplicator(remote, {
+					timeout: 300,
+					eager: true,
+				}),
+			).to.be.rejectedWith(TimeoutError);
+			expect(requestSubscribers.notCalled).to.be.true;
+			expect(resume.notCalled).to.be.true;
+		} finally {
+			resume.restore();
+			requestSubscribers.restore();
+		}
+	});
+
 	it("rejects waitForReplicators when internal leader check throws", async () => {
 		session = await TestSession.connected(1);
 		db = await session.peers[0].open(new EventStore<string, any>(), {


### PR DESCRIPTION
## Summary

- bootstrap default-V2 `waitForReplicator()` through a targeted authoritative subscriber snapshot when the target subscription is missing or departing
- keep opening sessions on their existing fenced handshake and open sessions on parked-request recovery
- coalesce slow snapshot requests so retry ticks cannot fan out overlapping discovery work
- add null, departing, opening, and in-flight retry regression coverage

## Cause

After the V2-only default cutover, `waitForReplicator()` could only resume recovery when an open PeerSession already existed. A connected/key-known peer with a missed SharedLog Subscribe therefore remained undiscoverable. The document keep-open integration reproduced this as `pending() === 0` in 2/10 focused runs.

## Validation

- post-fix keep-open integration stress: 10/10 (pre-fix: 8/10)
- wait-for-replicator focused group: 23 passing
- `@peerbit/shared-log` TypeScript build: passing
- targeted ESLint, Prettier, and `git diff --check`: passing

Release PR #1213 remains intentionally held until this follow-up merges and Changesets refreshes it.