### PR TITLE
chore: stop auto-requesting reviews via CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @marcus-pousette


### PR DESCRIPTION
Removes the root CODEOWNERS (`* @marcus-pousette`), which auto-requests a review from marcus-pousette on every pull request and re-adds the request on every branch sync. Review requests should be made deliberately, not by default.