### PR TITLE
refactor(shared-log)!: neutral internal V2 mutation union (B12 stage 2)

### DIFF
--- a/.changeset/neutral-replication-mutation-union.md
+++ b/.changeset/neutral-replication-mutation-union.md
@@ -1,5 +1,5 @@
 ---
-"@peerbit/shared-log": patch
+"@peerbit/shared-log": major
 ---
 
 Internal replication announcements now flow as a neutral full/added/stopped mutation union instead of the retired legacy wire classes. The advanced `announce` callback option on `replicate()`/`startAnnounceReplicating()` receives the tagged mutation objects (`{ full: { segments } }` / `{ added: { segments } }`) instead of `AllReplicatingSegmentsMessage`/`AddedReplicationSegmentMessage` instances, and the internal `LegacyReplicationInfoMessage` type alias is no longer exported from the (non re-exported) `replication-info-v2-send` module. Wire bytes, sequencing and coalescing are unchanged; the legacy classes remain exported decode tombstones.

--- a/.changeset/neutral-replication-mutation-union.md
+++ b/.changeset/neutral-replication-mutation-union.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Internal replication announcements now flow as a neutral full/added/stopped mutation union instead of the retired legacy wire classes. The advanced `announce` callback option on `replicate()`/`startAnnounceReplicating()` receives the tagged mutation objects (`{ full: { segments } }` / `{ added: { segments } }`) instead of `AllReplicatingSegmentsMessage`/`AddedReplicationSegmentMessage` instances, and the internal `LegacyReplicationInfoMessage` type alias is no longer exported from the (non re-exported) `replication-info-v2-send` module. Wire bytes, sequencing and coalescing are unchanged; the legacy classes remain exported decode tombstones.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -249,6 +249,10 @@ import {
 	type ReplicationDomain,
 	type ReplicationDomainConstructor,
 } from "./replication-domain.js";
+import type {
+	AddedReplicationInfoMutation,
+	FullReplicationInfoMutation,
+} from "./replication-info-mutation.js";
 import { ReplicationInfoV2ReceiveCoordinator } from "./replication-info-v2-receive.js";
 import { ReplicationInfoV2SendCoordinator } from "./replication-info-v2-send.js";
 import {
@@ -5714,7 +5718,7 @@ export class SharedLog<
 			mergeSegments?: boolean;
 			rebalance?: boolean;
 			announce?: (
-				msg: AddedReplicationSegmentMessage | AllReplicatingSegmentsMessage,
+				msg: AddedReplicationInfoMutation | FullReplicationInfoMutation,
 			) => void;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -5950,9 +5954,11 @@ export class SharedLog<
 
 			if (confirmedPreliminaryRemovals.length > 0) {
 				await this._announcements.sendReplicationAnnouncement(
-					new StoppedReplicating({
-						segmentIds: confirmedPreliminaryRemovals.map((x) => x.id),
-					}),
+					{
+						stopped: {
+							segmentIds: confirmedPreliminaryRemovals.map((x) => x.id),
+						},
+					},
 					replicationOwnershipLifecycleController,
 				);
 				this.throwIfReplicationOwnershipLifecycleInactive(
@@ -5977,7 +5983,7 @@ export class SharedLog<
 				);
 				this.validatePersistedReplicationRangeSnapshot(segments);
 				await this._announcements.sendReplicationAnnouncement(
-					new AllReplicatingSegmentsMessage({ segments }),
+					{ full: { segments } },
 					replicationOwnershipLifecycleController,
 				);
 			} catch (error) {
@@ -6033,7 +6039,7 @@ export class SharedLog<
 			rebalance?: boolean;
 			mergeSegments?: boolean;
 			announce?: (
-				msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
+				msg: FullReplicationInfoMutation | AddedReplicationInfoMutation,
 			) => void;
 		},
 	) {
@@ -6274,7 +6280,7 @@ export class SharedLog<
 		}
 		try {
 			await this._announcements.sendReplicationAnnouncement(
-				new StoppedReplicating({ segmentIds: removedSegmentIds }),
+				{ stopped: { segmentIds: removedSegmentIds } },
 				replicationOwnershipLifecycleController,
 			);
 			this.throwIfReplicationOwnershipLifecycleInactive(
@@ -6571,7 +6577,7 @@ export class SharedLog<
 				if (isMe && !ownerHasRanges) {
 					try {
 						await this._announcements.sendReplicationAnnouncement(
-							new AllReplicatingSegmentsMessage({ segments: [] }),
+							{ full: { segments: [] } },
 							replicationOwnershipLifecycleController,
 						);
 					} catch (error) {
@@ -7494,7 +7500,7 @@ export class SharedLog<
 			rebalance?: boolean;
 			shouldApply?: () => boolean;
 			announce?: (
-				msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
+				msg: FullReplicationInfoMutation | AddedReplicationInfoMutation,
 			) => void;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -7541,7 +7547,7 @@ export class SharedLog<
 				);
 				this.validatePersistedReplicationRangeSnapshot(segments);
 				await this._announcements.sendReplicationAnnouncement(
-					new AllReplicatingSegmentsMessage({ segments }),
+					{ full: { segments } },
 					replicationOwnershipLifecycleController,
 				);
 			} catch (error) {
@@ -7592,17 +7598,17 @@ export class SharedLog<
 				}
 
 				let message:
-					| AllReplicatingSegmentsMessage
-					| AddedReplicationSegmentMessage
+					| FullReplicationInfoMutation
+					| AddedReplicationInfoMutation
 					| undefined = undefined;
 				if (options.reset) {
-					message = new AllReplicatingSegmentsMessage({
-						segments: added.map((x) => x.range.toReplicationRange()),
-					});
+					message = {
+						full: { segments: added.map((x) => x.range.toReplicationRange()) },
+					};
 				} else {
-					message = new AddedReplicationSegmentMessage({
-						segments: added.map((x) => x.range.toReplicationRange()),
-					});
+					message = {
+						added: { segments: added.map((x) => x.range.toReplicationRange()) },
+					};
 				}
 				if (options.announce) {
 					return options.announce(message);
@@ -20556,7 +20562,7 @@ export class SharedLog<
 		throwIfInactive();
 
 		if (options?.replicate) {
-			let messageToSend: AddedReplicationSegmentMessage | undefined = undefined;
+			let messageToSend: AddedReplicationInfoMutation | undefined = undefined;
 
 			if (assumeSynced) {
 				throwIfInactive();
@@ -20584,14 +20590,14 @@ export class SharedLog<
 				// in one large message instead
 				announce: (msg) => {
 					throwIfInactive();
-					if (msg instanceof AllReplicatingSegmentsMessage) {
+					if (!("added" in msg)) {
 						throw new Error("Unexpected");
 					}
 
 					if (messageToSend) {
 						// merge segments to make it into one messages
-						for (const segment of msg.segments) {
-							messageToSend.segments.push(segment);
+						for (const segment of msg.added.segments) {
+							messageToSend.added.segments.push(segment);
 						}
 					} else {
 						messageToSend = msg;

--- a/packages/programs/data/shared-log/src/replication-announcement.ts
+++ b/packages/programs/data/shared-log/src/replication-announcement.ts
@@ -10,6 +10,7 @@ import { TimeoutError, debounceFixedInterval } from "@peerbit/time";
 import { isNotStartedError } from "./errors.js";
 import type { TransportMessage } from "./message.js";
 import type { ReplicationRangeIndexable } from "./ranges.js";
+import type { ReplicationInfoMutation } from "./replication-info-mutation.js";
 import {
 	AddedReplicationSegmentMessage,
 	AllReplicatingSegmentsMessage,
@@ -206,14 +207,34 @@ export type ReplicationAnnouncementDeps<R extends "u32" | "u64"> = {
 	queueCurrentReplicationStateAnnouncementRetry: (error: unknown) => boolean;
 	// V2 is always current. Legacy publication is enabled only for an explicit
 	// compatibility open and retains its exact rejection/retry semantics there.
-	enqueueReplicationInfoV2: (message: LegacyReplicationInfoMessage) => void;
+	enqueueReplicationInfoV2: (mutation: ReplicationInfoMutation) => void;
 	isLegacyReplicationInfoEnabled: () => boolean;
 };
 
-type LegacyReplicationInfoMessage =
+/**
+ * The dormant legacy tail still broadcasts the retired wire classes when an
+ * explicit compatibility open enabled it (impossible since B12 stage 1; the
+ * tail is deleted in stage 3). Materialize the frame from the neutral
+ * mutation locally so the tail keeps its exact byte semantics until then.
+ */
+const toLegacyReplicationInfoFrame = (
+	mutation: ReplicationInfoMutation,
+):
 	| AllReplicatingSegmentsMessage
 	| AddedReplicationSegmentMessage
-	| StoppedReplicating;
+	| StoppedReplicating => {
+	if ("full" in mutation) {
+		return new AllReplicatingSegmentsMessage({
+			segments: mutation.full.segments,
+		});
+	}
+	if ("added" in mutation) {
+		return new AddedReplicationSegmentMessage({
+			segments: mutation.added.segments,
+		});
+	}
+	return new StoppedReplicating({ segmentIds: mutation.stopped.segmentIds });
+};
 
 export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	replicationAnnouncementRetryDebounced:
@@ -627,7 +648,7 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 	}
 
 	async sendReplicationAnnouncement(
-		message: LegacyReplicationInfoMessage,
+		mutation: ReplicationInfoMutation,
 		ownershipLifecycleController = this.deps.captureReplicationOwnershipLifecycle(),
 		options?: { shouldSend?: () => boolean },
 	): Promise<void> {
@@ -652,12 +673,12 @@ export class ReplicationAnnouncementCoordinator<R extends "u32" | "u64"> {
 				// after that stale send settles.
 				this.rotateAnnouncementSession();
 				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
-				this.deps.enqueueReplicationInfoV2(message);
+				this.deps.enqueueReplicationInfoV2(mutation);
 				if (!this.deps.isLegacyReplicationInfoEnabled()) {
 					return;
 				}
 				try {
-					await this.deps.getRpc().send(message, {
+					await this.deps.getRpc().send(toLegacyReplicationInfoFrame(mutation), {
 						priority: CONVERGENCE_MESSAGE_PRIORITY,
 						signal: ownershipLifecycleController.signal,
 					});

--- a/packages/programs/data/shared-log/src/replication-info-mutation.ts
+++ b/packages/programs/data/shared-log/src/replication-info-mutation.ts
@@ -1,0 +1,34 @@
+import type { ReplicationRangeMessage } from "./ranges.js";
+
+/**
+ * Neutral internal representation of a local replication-state mutation.
+ *
+ * Producers (replicate/unreplicate/join and their corrective snapshot paths)
+ * hand these plain tagged objects to the announcement coordinator, which maps
+ * them onto the directed V2 wire messages:
+ *
+ * - `full`    -> FullReplicationInfoV2Message (authoritative snapshot)
+ * - `added`   -> AddedReplicationInfoV2Message (incremental delta)
+ * - `stopped` -> StoppedReplicationInfoV2Message (retired segment ids)
+ *
+ * The retired legacy announcement classes (AllReplicatingSegmentsMessage,
+ * AddedReplicationSegmentMessage, StoppedReplicating) remain registered
+ * decode tombstones on the wire surface but are no longer the internal
+ * currency between mutation producers and the V2 sender.
+ */
+export type FullReplicationInfoMutation = {
+	full: { segments: ReplicationRangeMessage<any>[] };
+};
+
+export type AddedReplicationInfoMutation = {
+	added: { segments: ReplicationRangeMessage<any>[] };
+};
+
+export type StoppedReplicationInfoMutation = {
+	stopped: { segmentIds: Uint8Array[] };
+};
+
+export type ReplicationInfoMutation =
+	| FullReplicationInfoMutation
+	| AddedReplicationInfoMutation
+	| StoppedReplicationInfoMutation;

--- a/packages/programs/data/shared-log/src/replication-info-v2-send.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-send.ts
@@ -8,13 +8,11 @@ import {
 import type { TransportMessage } from "./message.js";
 import type { ReplicationRangeIndexable } from "./ranges.js";
 import { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
+import type { ReplicationInfoMutation } from "./replication-info-mutation.js";
 import {
 	AddedReplicationInfoV2Message,
-	AddedReplicationSegmentMessage,
-	AllReplicatingSegmentsMessage,
 	FullReplicationInfoV2Message,
 	RequestReplicationInfoV2Message,
-	StoppedReplicating,
 	StoppedReplicationInfoV2Message,
 } from "./replication.js";
 
@@ -27,14 +25,9 @@ const MAX_BACKOFF_EXPONENT = 20;
 
 export { deriveReplicationInfoV2ReceiverBinding } from "./replication-info-v2-binding.js";
 
-export type LegacyReplicationInfoMessage =
-	| AllReplicatingSegmentsMessage
-	| AddedReplicationSegmentMessage
-	| StoppedReplicating;
-
 type SendRequest =
 	| { kind: "snapshot" }
-	| { kind: "message"; message: LegacyReplicationInfoMessage };
+	| { kind: "mutation"; mutation: ReplicationInfoMutation };
 
 export type ReplicationInfoV2SendState = {
 	peerHash: string;
@@ -393,9 +386,9 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 		return true;
 	}
 
-	enqueue(message: LegacyReplicationInfoMessage): void {
+	enqueue(mutation: ReplicationInfoMutation): void {
 		for (const state of [...this._sendStates.values()]) {
-			this.enqueueState(state, { kind: "message", message });
+			this.enqueueState(state, { kind: "mutation", mutation });
 		}
 	}
 
@@ -538,20 +531,21 @@ export class ReplicationInfoV2SendCoordinator<R extends "u32" | "u64"> {
 			this.deps.validatePersistedReplicationRangeSnapshot(segments);
 			return new FullReplicationInfoV2Message({ ...common, segments });
 		}
-		if (request.message instanceof AllReplicatingSegmentsMessage) {
-			const segments = request.message.segments;
+		const { mutation } = request;
+		if ("full" in mutation) {
+			const segments = mutation.full.segments;
 			this.deps.validatePersistedReplicationRangeSnapshot(segments);
 			return new FullReplicationInfoV2Message({ ...common, segments });
 		}
-		if (request.message instanceof AddedReplicationSegmentMessage) {
+		if ("added" in mutation) {
 			return new AddedReplicationInfoV2Message({
 				...common,
-				segments: request.message.segments,
+				segments: mutation.added.segments,
 			});
 		}
 		return new StoppedReplicationInfoV2Message({
 			...common,
-			segmentIds: request.message.segmentIds,
+			segmentIds: mutation.stopped.segmentIds,
 		});
 	}
 

--- a/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-announcement-retry.spec.ts
@@ -2,7 +2,6 @@ import { TestSession } from "@peerbit/test-utils";
 import { TimeoutError } from "@peerbit/time";
 import { expect } from "chai";
 import sinon from "sinon";
-import { AddedReplicationSegmentMessage } from "../src/replication.js";
 import { EventStore } from "./utils/stores/index.js";
 
 // B12: the legacy announcement retry/repair machinery is exercised only by
@@ -32,9 +31,9 @@ describe("replication announcement retries", () => {
 		log._announcements.setupReplicationAnnouncementRetryFunction(10);
 		log._announcements.setupReplicationAnnouncementRepairFunction(10, 3);
 
-		await log._announcements.sendReplicationAnnouncement(
-			new AddedReplicationSegmentMessage({ segments: [] }),
-		);
+		await log._announcements.sendReplicationAnnouncement({
+			added: { segments: [] },
+		});
 		expect(enqueueV2.calledOnce).to.be.true;
 		expect(send.notCalled).to.be.true;
 		expect(

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -2163,9 +2163,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		const oldBinding = state.receiverBinding!.slice();
 		const oldFull = delivered[0];
 
-		senderCoordinator.enqueue(
-			new AddedReplicationSegmentMessage({ segments: [] }),
-		);
+		senderCoordinator.enqueue({ added: { segments: [] } });
 		await senderCoordinator.drain();
 		expect(state.lastSequence).to.equal(2n);
 		senderCoordinator.advancePeerCapability(self.hashcode());
@@ -2360,7 +2358,6 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		const indexedRange = range.toReplicationRangeIndexable(
 			session.peers[1].identity.publicKey,
 		);
-		const legacy = new AddedReplicationSegmentMessage({ segments: [range] });
 		const getSegments = sinon
 			.stub(senderLog, "getMyReplicationSegments")
 			.resolves([indexedRange]);
@@ -2391,7 +2388,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		(senderLog._v2Send as any).sendRetryMs = 25;
 		(senderLog._v2Send as any).maxSendRetryMs = 50;
 		try {
-			await senderLog._announcements.sendReplicationAnnouncement(legacy);
+			await senderLog._announcements.sendReplicationAnnouncement({
+				added: { segments: [range] },
+			});
 			await senderLog._v2Send.drain();
 			const failedState = senderLog._v2Send._sendStates.get(receiverHash);
 			expect(rejectedV2Delta).to.equal(1);

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -1,3 +1,4 @@
+import { serialize } from "@dao-xyz/borsh";
 import { Ed25519PublicKey } from "@peerbit/crypto";
 import { AcknowledgeDelivery } from "@peerbit/stream-interface";
 import { TestSession } from "@peerbit/test-utils";
@@ -11,6 +12,7 @@ import {
 	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
 	SyncCapabilitiesMessage,
 } from "../src/exchange-heads.js";
+import { ReplicationIntent, ReplicationRangeMessageU32 } from "../src/ranges.js";
 import {
 	ReplicationInfoV2SendCoordinator,
 	type ReplicationInfoV2SendState,
@@ -19,8 +21,11 @@ import {
 import {
 	AddedReplicationInfoV2Message,
 	AddedReplicationSegmentMessage,
+	AllReplicatingSegmentsMessage,
 	FullReplicationInfoV2Message,
 	RequestReplicationInfoV2Message,
+	StoppedReplicating,
+	StoppedReplicationInfoV2Message,
 } from "../src/replication.js";
 import { EventStore } from "./utils/stores/index.js";
 
@@ -1506,5 +1511,162 @@ describe("receive admission replication-info V2 sender integration", () => {
 			log._peerSessions.unblockReplicationInfo(remoteHash);
 			peerSession.finishOpeningBarrier();
 		}
+	});
+});
+
+describe("receive admission replication-info V2 mutation byte equivalence", () => {
+	// B12 stage-2 identical-state pin: the neutral full/added/stopped mutation
+	// union must map byte-for-byte onto the V2 frames that the legacy
+	// All/Added/Stopped inputs produced before the retype. The hex fixtures
+	// below were captured from the pre-refactor legacy-input path with this
+	// exact deterministic harness (fixed keys, challenge, transport session and
+	// sender epoch) immediately before the union landed.
+	const FROZEN_PRE_REFACTOR_FRAMES = {
+		snapshot:
+			"000106dfb663ff222b5883c4625f41fa21d98a1d0122a9041a6fd9087d58c418a7526e0707070707070707070707070707070707070707070707070707070707070707010000000000000000000000",
+		full: "000106dfb663ff222b5883c4625f41fa21d98a1d0122a9041a6fd9087d58c418a7526e070707070707070707070707070707070707070707070707070707070707070702000000000000000100000000200000000b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b15030000000000007b000000c801000000",
+		added:
+			"000107dfb663ff222b5883c4625f41fa21d98a1d0122a9041a6fd9087d58c418a7526e070707070707070707070707070707070707070707070707070707070707070703000000000000000100000000200000000c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0cb80b000000000000e8030000d007000001",
+		stopped:
+			"000108dfb663ff222b5883c4625f41fa21d98a1d0122a9041a6fd9087d58c418a7526e0707070707070707070707070707070707070707070707070707070707070707040000000000000001000000200000000d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d",
+	};
+
+	const toHex = (bytes: Uint8Array) => Buffer.from(bytes).toString("hex");
+
+	const fixtureKey = (value: number) =>
+		new Ed25519PublicKey({ publicKey: new Uint8Array(32).fill(value) });
+
+	it("maps neutral mutations onto byte-identical V2 frames", async () => {
+		const self = fixtureKey(1);
+		const peer = fixtureKey(2);
+		const senderTransportSession = 0x20000000000001n;
+		const captured: Uint8Array[] = [];
+		const openSessions = new Set<object>();
+		const ownershipController = new AbortController();
+		const coordinator = new ReplicationInfoV2SendCoordinator<"u32">({
+			getRpc: () =>
+				({
+					send: async (message: unknown) => {
+						captured.push(serialize(message as any));
+						return [];
+					},
+				}) as any,
+			getSelfKey: () => self,
+			getSenderTransportSession: () => senderTransportSession,
+			getMyReplicationSegments: async () => [],
+			validatePersistedReplicationRangeSnapshot: () => {},
+			isClosed: () => false,
+			isPeerSessionCurrent: (_hash, peerSession) =>
+				openSessions.has(peerSession),
+			isPeerSessionOpen: (_hash, peerSession) => openSessions.has(peerSession),
+			captureReplicationOwnershipLifecycle: () => ownershipController,
+			isReplicationOwnershipLifecycleActive: (controller) =>
+				controller === ownershipController && !controller.signal.aborted,
+		});
+		coordinator._senderEpoch = new Uint8Array(32).fill(7);
+		const peerSession = {};
+		openSessions.add(peerSession);
+		const accepted = coordinator.acceptRequest(
+			new RequestReplicationInfoV2Message({
+				receiverChallenge: new Uint8Array(32).fill(9),
+				intendedSender: self,
+				senderSession: senderTransportSession,
+			}),
+			{
+				from: peer,
+				peerSession,
+				receiverTransportSession: 2n,
+				capabilityTimestamp: 1n,
+				requestTimestamp: 1n,
+			},
+		);
+		expect(accepted).to.be.true;
+		await coordinator.drain();
+
+		const rangeFull = new ReplicationRangeMessageU32({
+			id: new Uint8Array(32).fill(11),
+			offset: 123,
+			factor: 456,
+			timestamp: 789n,
+			mode: ReplicationIntent.NonStrict,
+		});
+		const rangeAdded = new ReplicationRangeMessageU32({
+			id: new Uint8Array(32).fill(12),
+			offset: 1000,
+			factor: 2000,
+			timestamp: 3000n,
+			mode: ReplicationIntent.Strict,
+		});
+		const stoppedId = new Uint8Array(32).fill(13);
+
+		coordinator.enqueue({ full: { segments: [rangeFull] } });
+		await coordinator.drain();
+		coordinator.enqueue({ added: { segments: [rangeAdded] } });
+		await coordinator.drain();
+		coordinator.enqueue({ stopped: { segmentIds: [stoppedId] } });
+		await coordinator.drain();
+
+		const state = coordinator._sendStates.get(peer.hashcode())!;
+		expect(state).to.exist;
+		const receiverChallenge = state.receiverChallenge.slice();
+		const senderEpoch = state.senderEpoch.slice();
+		coordinator.clearForClose();
+
+		expect(captured).to.have.length(4);
+
+		// Frozen-fixture leg: bytes must equal the pre-refactor legacy-input
+		// output exactly (variant tags, binding, epoch, sequence and payload).
+		expect(toHex(captured[0])).to.equal(FROZEN_PRE_REFACTOR_FRAMES.snapshot);
+		expect(toHex(captured[1])).to.equal(FROZEN_PRE_REFACTOR_FRAMES.full);
+		expect(toHex(captured[2])).to.equal(FROZEN_PRE_REFACTOR_FRAMES.added);
+		expect(toHex(captured[3])).to.equal(FROZEN_PRE_REFACTOR_FRAMES.stopped);
+
+		// Legacy-oracle leg: the retired wire classes remain constructible
+		// decode tombstones. Deriving the expected V2 frames from their payload
+		// fields (the exact mapping the pre-refactor sender performed) must
+		// reproduce the same bytes as the union path.
+		const legacyFull = new AllReplicatingSegmentsMessage({
+			segments: [rangeFull],
+		});
+		const legacyAdded = new AddedReplicationSegmentMessage({
+			segments: [rangeAdded],
+		});
+		const legacyStopped = new StoppedReplicating({ segmentIds: [stoppedId] });
+		expect(toHex(captured[1])).to.equal(
+			toHex(
+				serialize(
+					new FullReplicationInfoV2Message({
+						receiverChallenge,
+						senderEpoch,
+						sequence: 2n,
+						segments: legacyFull.segments,
+					}),
+				),
+			),
+		);
+		expect(toHex(captured[2])).to.equal(
+			toHex(
+				serialize(
+					new AddedReplicationInfoV2Message({
+						receiverChallenge,
+						senderEpoch,
+						sequence: 3n,
+						segments: legacyAdded.segments,
+					}),
+				),
+			),
+		);
+		expect(toHex(captured[3])).to.equal(
+			toHex(
+				serialize(
+					new StoppedReplicationInfoV2Message({
+						receiverChallenge,
+						senderEpoch,
+						sequence: 4n,
+						segmentIds: legacyStopped.segmentIds,
+					}),
+				),
+			),
+		);
 	});
 });

--- a/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-sender.spec.ts
@@ -352,9 +352,9 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(accept(peerA, peerSession, challenge(11))).to.be.true;
 		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
 
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		for (let index = 0; index < 10_000; index++) {
-			coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+			coordinator.enqueue({ added: { segments: [] } });
 		}
 		const state = coordinator._sendStates.get(
 			peerA.hashcode(),
@@ -393,7 +393,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 			.true;
 		coordinator.clearPeer(peerB.hashcode());
 		rpcSend.resetHistory();
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		expect(accept(peerA, sessionA, challenge(12), 1n)).to.be.false;
 		await coordinator.drain();
 		expect(rpcSend.notCalled).to.be.true;
@@ -520,7 +520,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		const rejectedSend = pDefer<void>();
 		rpcSend.onSecondCall().returns(rejectedSend.promise);
 
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await clock.tickAsync(0);
 		expect(rpcSend.callCount).to.equal(2);
 		expect(rpcSend.secondCall.args[0].sequence).to.equal(2n);
@@ -566,7 +566,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 				}),
 		);
 
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await waitForResolved(() => expect(rpcSend.calledOnce).to.be.true);
 		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
 		ownershipController.abort();
@@ -591,7 +591,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		).receiverChallenge.slice();
 
 		closedReadinessGates.add(oldPeerSession);
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		expect(oldState.suspended).to.be.true;
 		expect(oldState.pending).to.deep.equal({ kind: "snapshot" });
 		openSessions.delete(oldPeerSession);
@@ -625,7 +625,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		await coordinator.drain();
 		const state = coordinator._sendStates.get(peerA.hashcode())!;
 		for (let index = 0; index < 10_000; index++) {
-			coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+			coordinator.enqueue({ added: { segments: [] } });
 		}
 		expect(state.pending).to.deep.equal({ kind: "snapshot" });
 		expect(state.retryTimer).to.exist;
@@ -732,7 +732,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		rpcSend.resetHistory();
 		rpcSend.rejects(new Error("ambiguous final delivery"));
 
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await coordinator.drain();
 		expect(rpcSend.calledOnce).to.be.true;
 		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
@@ -765,7 +765,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		expect(coordinator._sendStates.get(peerA.hashcode())?.retryTimer).to.exist;
 		expect(coordinator._sendStates.get(peerB.hashcode())?.established).to.be
 			.true;
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await coordinator.drain();
 		expect(
 			rpcSend.args.some(
@@ -791,7 +791,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		state.nextSequence = (1n << 64n) - 1n;
 		rpcSend.resetHistory();
 
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await coordinator.drain();
 		expect(rpcSend.calledOnce).to.be.true;
 		expect(rpcSend.firstCall.args[0].sequence).to.equal((1n << 64n) - 1n);
@@ -943,7 +943,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		const state = coordinator._sendStates.get(peerA.hashcode())!;
 		state.nextSequence = (1n << 64n) - 2n;
 		rpcSend.rejects(new Error("ambiguous predecessor"));
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await coordinator.drain();
 		expect(state.suspended).to.be.true;
 		expect(state.nextSequence).to.equal((1n << 64n) - 1n);
@@ -977,7 +977,7 @@ describe("receive admission replication-info V2 sender streams", () => {
 		openSessions.add(peerSession);
 		expect(accept(peerA, peerSession, challenge(15))).to.be.true;
 		await coordinator.drain();
-		coordinator.enqueue(new AddedReplicationSegmentMessage({ segments: [] }));
+		coordinator.enqueue({ added: { segments: [] } });
 		await coordinator.drain();
 
 		expect(rpcSend.callCount).to.equal(2);
@@ -1351,8 +1351,9 @@ describe("receive admission replication-info V2 sender integration", () => {
 		await log._v2Send.drain();
 		send.resetHistory();
 
-		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
-		await log._announcements.sendReplicationAnnouncement(legacy);
+		await log._announcements.sendReplicationAnnouncement({
+			added: { segments: [] },
+		});
 		await log._v2Send.drain();
 		const outbound = send.args.map((args: any[]) => args[0]);
 		const legacyMessages = outbound.filter(


### PR DESCRIPTION
B12 stage 2 of 5: the V2 sender no longer consumes the retired legacy wire classes (`AllReplicatingSegmentsMessage`/`AddedReplicationSegmentMessage`/`StoppedReplicating`) as its internal input. A neutral tagged mutation union (`{ full: { segments } } | { added: { segments } } | { stopped: { segmentIds } }`, new `src/replication-info-mutation.ts`, not re-exported) replaces them across all seven producer sites, the public `announce` callback option types on `replicate()`/`startAnnounceReplicating()` (hence the major — no repo or downstream consumer of those types exists), and the test seams.

**Wire bytes are provably unchanged**: a byte-equivalence pin serializes actual rpc egress and hex-compares against frozen fixtures captured from the pre-refactor legacy-input path, plus a legacy-oracle leg deriving expected frames from the tombstone classes; the enqueue/coalescing/terminal-reset/sequence code is byte-identical to base under normalized diff. Mutation checks: flipping one union-to-V2 field mapping turns the byte pin red; dropping consecutive-mutation coalescing turns the coalescing pin red.

Kept deliberately (stage 3/4 scope): the receiver's local legacy union and fingerprint canonicalization, the dormant announcement tail (compiles via a tail-local adapter that materializes the legacy frame from the union — deleted with the tail), and all legacy outbound/inbound machinery. Tombstone classes untouched and still exported.

Validation: per-commit suite sets green (261 + 320 passing at tip), fence-ratchet 13/13, shard-coverage 67 describes covered, root lint clean, dependent builds green (proxy, document, string, peerbit client). Adversarial read-only check passed; its one finding — the changeset level — is fixed (major, not patch).