### PR TITLE
refactor(shared-log)!: delete the legacy inbound replication-info machinery (B12 stage 4)

### DIFF
--- a/.changeset/delete-legacy-inbound-replication-info.md
+++ b/.changeset/delete-legacy-inbound-replication-info.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Delete the dead legacy inbound replication-info machinery (B12 stage 4): the ResponseRole/All/Added/Stopped dispatch arms below the unconditional default-mode drop, the legacy apply handlers, the per-peer ordering watermark and the legacy-cutover probe. Default-mode nodes have dropped these frames before any side effect since the V2 migration, and no compatibility mode can open. The wire tombstones stay registered and exported so old frames still decode; the only surface change is the removal of the deprecated `toReplicationInfoMessage()` helper from the exported `ResponseRoleMessage` tombstone (its class, variant and fields are unchanged; the sole caller was the deleted dispatch conversion). Folds into the B12 major release train.

--- a/.changeset/delete-legacy-inbound-replication-info.md
+++ b/.changeset/delete-legacy-inbound-replication-info.md
@@ -1,5 +1,5 @@
 ---
-"@peerbit/shared-log": patch
+"@peerbit/shared-log": major
 ---
 
 Delete the dead legacy inbound replication-info machinery (B12 stage 4): the ResponseRole/All/Added/Stopped dispatch arms below the unconditional default-mode drop, the legacy apply handlers, the per-peer ordering watermark and the legacy-cutover probe. Default-mode nodes have dropped these frames before any side effect since the V2 migration, and no compatibility mode can open. The wire tombstones stay registered and exported so old frames still decode; the only surface change is the removal of the deprecated `toReplicationInfoMessage()` helper from the exported `ResponseRoleMessage` tombstone (its class, variant and fields are unchanged; the sole caller was the deleted dispatch conversion). Folds into the B12 major release train.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -17683,22 +17683,14 @@ export class SharedLog<
 				this.captureReplicationOwnershipLifecycle();
 			const receiveReplicationInfoReceiveEpoch =
 				this._peerSessions.receiveEpoch(receiveFromHash);
-			if (msg instanceof ResponseRoleMessage) {
-				msg = msg.toReplicationInfoMessage(); // migration
-			}
 			if (
-				msg instanceof AllReplicatingSegmentsMessage ||
-				msg instanceof AddedReplicationSegmentMessage ||
 				msg instanceof FullReplicationInfoV2Message ||
 				msg instanceof AddedReplicationInfoV2Message
 			) {
 				// Bound decoded untrusted vectors before per-peer/global mutation
 				// queues, trusted-replicator authorization, or liveness side effects.
 				this.validateReplicationRangeAnnouncement(msg.segments);
-			} else if (
-				msg instanceof StoppedReplicating ||
-				msg instanceof StoppedReplicationInfoV2Message
-			) {
+			} else if (msg instanceof StoppedReplicationInfoV2Message) {
 				// Bound the raw decoded vector before deduplication can hide the
 				// allocation cost, and before liveness or apply-queue side effects.
 				this.validateStoppedReplicationAnnouncement(msg.segmentIds);
@@ -17706,10 +17698,7 @@ export class SharedLog<
 			if (
 				!context.from.equals(this.node.identity.publicKey) &&
 				!(msg instanceof RequestReplicationInfoV2Message) &&
-				!isReplicationInfoV2Message(msg) &&
-				!(msg instanceof AllReplicatingSegmentsMessage) &&
-				!(msg instanceof AddedReplicationSegmentMessage) &&
-				!(msg instanceof StoppedReplicating)
+				!isReplicationInfoV2Message(msg)
 			) {
 				this._liveness.markReplicatorActivity(receiveFromHash);
 			}
@@ -19424,17 +19413,6 @@ export class SharedLog<
 					});
 				} else if (msg instanceof ReplicationPingMessage) {
 					// No-op: used as an ACKed unicast liveness probe.
-				} else if (
-					msg instanceof AllReplicatingSegmentsMessage ||
-					msg instanceof AddedReplicationSegmentMessage
-				) {
-					await this.handleReplicationInfoAnnouncement(
-						msg,
-						laneRequestContext,
-						lane,
-					);
-				} else if (msg instanceof StoppedReplicating) {
-					await this.handleStoppedReplicating(msg, laneRequestContext, lane);
 				} else {
 					throw new Error("Unexpected message");
 				}
@@ -19848,239 +19826,6 @@ export class SharedLog<
 		}
 	}
 
-	private async handleReplicationInfoAnnouncement(
-		msg: AllReplicatingSegmentsMessage | AddedReplicationSegmentMessage,
-		context: ReceiveRequestContext,
-		lane: ReceiveLaneContext,
-	): Promise<void> {
-		const receiveFromHash = lane.fromHash;
-		const receiveSession = lane.session;
-		const receiveReplicationLifecycleController = lane.lifecycleController;
-		const receiveReplicationInfoReceiveEpoch = lane.receiveEpoch;
-		const peerReceiveLease = lane.lease;
-		if (context.from.equals(this.node.identity.publicKey)) {
-			return;
-		}
-
-		const replicationInfoMessage = msg as
-			| AllReplicatingSegmentsMessage
-			| AddedReplicationSegmentMessage;
-
-		// Process replication updates even if the sender isn't yet considered "ready" by
-		// `Program.waitFor()`. Dropping these messages can lead to missing replicator info
-		// (and downstream `waitForReplicator()` timeouts) under timing-sensitive joins.
-		const from = context.from!;
-		const fromHash = from.hashcode();
-		if (this._v2Receive.isLegacyCutover(receiveSession)) {
-			if (receiveSession) {
-				this._v2Receive.noteLegacyAnnouncement({
-					peerHash: fromHash,
-					peerSession: receiveSession,
-					receiveEpoch: receiveReplicationInfoReceiveEpoch,
-					senderTransportSession: context.message.header.session,
-					transportTimestamp: context.message.header.timestamp,
-					message: msg,
-				});
-			}
-			return;
-		}
-		// Pre-lane gate: lifecycle -> receive-epoch -> blocked, exactly the
-		// legacy order. isMembershipActiveFor is the unit-pinned fold of
-		// isReplicationLifecycleActive; isReceiveEpochCurrent is the
-		// relocated `===`-with-`?? null`. The DELIBERATE absence of a
-		// subscription-epoch term is preserved: the lease already validated
-		// it, and the in-lane recheck owns post-await staleness.
-		if (
-			!this._instanceLifecycle!.isMembershipActiveFor(
-				receiveReplicationLifecycleController,
-			) ||
-			!this._peerSessions.isReceiveEpochCurrent(
-				receiveFromHash,
-				receiveReplicationInfoReceiveEpoch,
-			) ||
-			this._peerSessions.isReplicationInfoBlocked(fromHash)
-		) {
-			return;
-		}
-		const messageTimestamp = context.message.header.timestamp;
-		peerReceiveLease.release();
-		await this.withReplicationInfoApplyQueue(fromHash, async () => {
-			try {
-				// The peer may have unsubscribed after this message was queued.
-				// In-lane gate: lifecycle -> subscription-epoch -> receive-epoch
-				// -> blocked, term for term as before the session migration.
-				if (
-					!this._instanceLifecycle!.isMembershipActiveFor(
-						receiveReplicationLifecycleController,
-					) ||
-					!this._peerSessions.isCurrent(fromHash, receiveSession) ||
-					!this._peerSessions.isReceiveEpochCurrent(
-						fromHash,
-						receiveReplicationInfoReceiveEpoch,
-					) ||
-					this._peerSessions.isReplicationInfoBlocked(fromHash)
-				) {
-					return;
-				}
-				if (receiveSession && this._v2Receive.isLegacyCutover(receiveSession)) {
-					this._v2Receive.noteLegacyAnnouncement({
-						peerHash: fromHash,
-						peerSession: receiveSession,
-						receiveEpoch: receiveReplicationInfoReceiveEpoch,
-						senderTransportSession: context.message.header.session,
-						transportTimestamp: context.message.header.timestamp,
-						message: msg,
-					});
-					return;
-				}
-
-				// Process in-order to avoid races where repeated reset messages arrive
-				// concurrently and trigger spurious "added" diffs / rebalancing.
-				const prev = this.latestReplicationInfoMessage.get(fromHash);
-				if (prev && prev > messageTimestamp) {
-					return;
-				}
-
-				this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-
-				if (this.closed) {
-					return;
-				}
-
-				const reset = msg instanceof AllReplicatingSegmentsMessage;
-				const result = await this.addReplicationRange(
-					replicationInfoMessage.segments.map((x) =>
-						x.toReplicationRangeIndexable(from),
-					),
-					from,
-					{
-						reset,
-						checkDuplicates: true,
-						timestamp: Number(messageTimestamp),
-						allowLegacyOrderedReplacementPairs:
-							msg instanceof AddedReplicationSegmentMessage,
-					},
-				);
-				if (result === undefined) {
-					return;
-				}
-				this._liveness.markReplicatorActivity(fromHash);
-
-				// If the peer reports any replication segments, stop re-requesting.
-				// (Empty reports can be transient during startup.)
-				if (replicationInfoMessage.segments.length > 0) {
-					this.cancelReplicationInfoRequests(fromHash);
-				}
-			} catch (e) {
-				if (isNotStartedError(e as Error)) {
-					return;
-				}
-				logger.error(
-					`Failed to apply replication settings from '${fromHash}': ${
-						(e as any)?.message ?? e
-					}`,
-				);
-			}
-		});
-	}
-
-	private async handleStoppedReplicating(
-		msg: StoppedReplicating,
-		context: ReceiveRequestContext,
-		lane: ReceiveLaneContext,
-	): Promise<void> {
-		const receiveFromHash = lane.fromHash;
-		const receiveSession = lane.session;
-		const receiveReplicationLifecycleController = lane.lifecycleController;
-		const receiveReplicationInfoReceiveEpoch = lane.receiveEpoch;
-		const peerReceiveLease = lane.lease;
-		const from = context.from!;
-		const segmentIds = msg.segmentIds;
-		if (from.equals(this.node.identity.publicKey)) {
-			return;
-		}
-		const fromHash = from.hashcode();
-		if (this._v2Receive.isLegacyCutover(receiveSession)) {
-			if (receiveSession) {
-				this._v2Receive.noteLegacyAnnouncement({
-					peerHash: fromHash,
-					peerSession: receiveSession,
-					receiveEpoch: receiveReplicationInfoReceiveEpoch,
-					senderTransportSession: context.message.header.session,
-					transportTimestamp: context.message.header.timestamp,
-					message: msg,
-				});
-			}
-			return;
-		}
-		// Same pre-lane gate shape as Added/All above (and the same
-		// intentional absence of a subscription-epoch term).
-		if (
-			!this._instanceLifecycle!.isMembershipActiveFor(
-				receiveReplicationLifecycleController,
-			) ||
-			!this._peerSessions.isReceiveEpochCurrent(
-				receiveFromHash,
-				receiveReplicationInfoReceiveEpoch,
-			) ||
-			this._peerSessions.isReplicationInfoBlocked(fromHash)
-		) {
-			return;
-		}
-		const messageTimestamp = context.message.header.timestamp;
-		peerReceiveLease.release();
-		await this.withReplicationInfoApplyQueue(fromHash, async () => {
-			if (
-				!this._instanceLifecycle!.isMembershipActiveFor(
-					receiveReplicationLifecycleController,
-				) ||
-				!this._peerSessions.isCurrent(fromHash, receiveSession) ||
-				!this._peerSessions.isReceiveEpochCurrent(
-					fromHash,
-					receiveReplicationInfoReceiveEpoch,
-				) ||
-				this._peerSessions.isReplicationInfoBlocked(fromHash)
-			) {
-				return;
-			}
-			if (receiveSession && this._v2Receive.isLegacyCutover(receiveSession)) {
-				this._v2Receive.noteLegacyAnnouncement({
-					peerHash: fromHash,
-					peerSession: receiveSession,
-					receiveEpoch: receiveReplicationInfoReceiveEpoch,
-					senderTransportSession: context.message.header.session,
-					transportTimestamp: context.message.header.timestamp,
-					message: msg,
-				});
-				return;
-			}
-
-			const previousTimestamp = this.latestReplicationInfoMessage.get(fromHash);
-			if (previousTimestamp && previousTimestamp > messageTimestamp) {
-				return;
-			}
-			this.latestReplicationInfoMessage.set(fromHash, messageTimestamp);
-			if (this.closed) {
-				return;
-			}
-
-			const rangesToRemove = await this.resolveReplicationRangesFromIdsAndKey(
-				segmentIds,
-				from,
-			);
-
-			await this.removeReplicationRanges(rangesToRemove, from);
-			this._liveness.markReplicatorActivity(fromHash);
-			const timestamp = BigInt(+new Date());
-			for (const range of rangesToRemove) {
-				this.replicationChangeDebounceFn.add({
-					range,
-					type: "removed",
-					timestamp,
-				});
-			}
-		});
-	}
 
 	async calculateTotalParticipation(options?: { sum?: boolean }) {
 		if (options?.sum) {

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2075,21 +2075,12 @@ export class SharedLog<
 	// public key hash to range id to range
 	pendingMaturity!: Map<string, Map<string, PendingMaturityRecord<R>>>; // map of peerId to timeout
 
-	// Stage-4 KEEP-OLD verdict (fence B8, split by role). The watermark's
-	// FENCING role — rejecting late replication-info across unsubscribe and
-	// eviction races — is fully subsumed by the per-peer receive epoch plus
-	// the blocked set and session identity: every unsubscribe-path `now` write
-	// is preceded in the same synchronous block by a blocked-add, so an
-	// admitted handler can never observe one. Its intra-epoch ORDERING role is
-	// NOT subsumed: within one (lifecycle, session, epoch, unblocked) regime
-	// the epoch token is constant across every message from the peer, so only
-	// the two apply-lane timestamp comparisons can drop an older reset
-	// delivered after a newer add (unordered pubsub / retransmits) — an
-	// identity token carries no order. Deletion is blocked until
-	// replication-info messages carry sender-authoritative sequence numbers
-	// (stage-5 schema change); the `receive admission replication-info
-	// ordering watermark` pins fail if the read sites are removed before then.
-	private latestReplicationInfoMessage!: Map<string, bigint>;
+	// The legacy replication-info ordering watermark (fence B8) is deleted:
+	// its FENCING role was subsumed by the per-peer receive epoch, blocked set
+	// and session identity, and its intra-epoch ORDERING role existed only for
+	// the legacy apply lanes. The V2 lane orders by sender-authoritative
+	// sequence numbers, and legacy frames are dropped unconditionally at the
+	// B1 gate before any side effect.
 	// The replication-info blocked set (fence B5) lives on the peer-session
 	// registry: unsubscribed peers whose replication-info is ignored until a
 	// reconnect barrier commits. See PeerSessionRegistry._replicationInfoBlockedPeers.
@@ -3625,7 +3616,6 @@ export class SharedLog<
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
-		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoRequestByPeer = new Map();
 		this._subscriberSnapshotRequestsByPeer = new Map();
 		this._replicationInfoApplyQueueByPeer = new Map();
@@ -14229,7 +14219,6 @@ export class SharedLog<
 		this._admittedPruneRemoves = new Set();
 		this._pendingIHave = new Map();
 		this._pendingIHaveCallbacks = new Set();
-		this.latestReplicationInfoMessage = new Map();
 		this._replicationInfoRequestByPeer = new Map();
 		this._subscriberSnapshotRequestsByPeer = new Map();
 		// Terminal close/drop drains the previous lifecycle before another open can
@@ -15856,11 +15845,8 @@ export class SharedLog<
 
 	private advanceReplicationInfoRecoveryEpoch(peerHash: string) {
 		// Handlers admitted before a successful peer removal must not restore state
-		// when they eventually reach the apply lane. Reset the sender's
-		// ordering watermark with the local epoch so a later arrival can be
-		// accepted without comparing its clock to this receiver's clock.
+		// when they eventually reach the apply lane.
 		const receiveEpoch = this._peerSessions.advanceReceiveEpoch(peerHash);
-		this.latestReplicationInfoMessage.delete(peerHash);
 		const peerSession = this._peerSessions.current(peerHash);
 		if (peerSession?.phase === "open") {
 			this._v2Receive.advanceRecovery({
@@ -16842,7 +16828,6 @@ export class SharedLog<
 		captureSync(() => {
 			this._pendingIHave?.clear();
 			this._pendingIHaveCallbacks?.clear();
-			this.latestReplicationInfoMessage?.clear();
 			this._peerSessions?.clearReceiveEpochsForClose();
 			this._peerSessions?.clearCleanupGatesForClose();
 			this._activeReceiveHandlersByPeer?.clear();
@@ -23266,10 +23251,6 @@ export class SharedLog<
 				) {
 					return;
 				}
-				// The timestamp watermark belongs to the previous subscription epoch.
-				// Sender clocks are not synchronized, so carrying a local unsubscribe
-				// timestamp forward could reject every valid announcement after reconnect.
-				this.latestReplicationInfoMessage.delete(peerHash);
 				this._pendingReplicatorLeaveByPeer.delete(peerHash);
 				const openingCapabilities =
 					this._openingSyncCapabilitiesByPeer.get(peerHash);
@@ -23322,12 +23303,6 @@ export class SharedLog<
 			const disconnectedWarmupSession =
 				this.joinWarmup._warmupSessionsByTarget.get(peerHash) ?? null;
 			this.joinWarmup.cancelJoinWarmupTarget(peerHash);
-
-			const now = BigInt(+new Date());
-			const previous = this.latestReplicationInfoMessage.get(peerHash);
-			if (!previous || previous < now) {
-				this.latestReplicationInfoMessage.set(peerHash, now);
-			}
 
 			let removed = false;
 			try {
@@ -24798,15 +24773,6 @@ export class SharedLog<
 		const subscriptionEpoch = this._peerSessions.rotate(fromHash, "departing");
 		this._peerSessions.blockReplicationInfo(fromHash);
 		this._recentRepairDispatch.delete(fromHash);
-
-		// Keep a per-peer timestamp watermark when we observe an unsubscribe. This
-		// prevents late/out-of-order replication-info messages from re-introducing
-		// stale segments for a peer that has already left the topic.
-		const now = BigInt(+new Date());
-		const prev = this.latestReplicationInfoMessage.get(fromHash);
-		if (!prev || prev < now) {
-			this.latestReplicationInfoMessage.set(fromHash, now);
-		}
 		this.invalidateSharedLogTopicSubscribersCache();
 
 		return this.handleSubscriptionChange(

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -1090,10 +1090,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		}
 	}
 
-	isLegacyCutover(peerSession: object | null): boolean {
-		return peerSession !== null && this._cutoverPeerSessions.has(peerSession);
-	}
-
 	prepare(
 		message: ReplicationInfoV2Message,
 		properties: {

--- a/packages/programs/data/shared-log/src/replication.ts
+++ b/packages/programs/data/shared-log/src/replication.ts
@@ -7,14 +7,12 @@ import {
 	variant,
 	vec,
 } from "@dao-xyz/borsh";
-import { PublicSignKey, randomBytes } from "@peerbit/crypto";
+import { PublicSignKey } from "@peerbit/crypto";
 import { type Index } from "@peerbit/indexer-interface";
 import { TransportMessage } from "./message.js";
 import {
-	ReplicationIntent,
 	type ReplicationRangeIndexable,
 	ReplicationRangeMessage,
-	ReplicationRangeMessageU32,
 } from "./ranges.js";
 import { Observer, Replicator, Role } from "./role.js";
 
@@ -62,23 +60,6 @@ export class ResponseRoleMessage extends TransportMessage {
 	constructor(properties: { role: Observer | Replicator }) {
 		super();
 		this.role = properties.role;
-	}
-
-	toReplicationInfoMessage(): AllReplicatingSegmentsMessage {
-		return new AllReplicatingSegmentsMessage({
-			segments:
-				this.role instanceof Replicator
-					? this.role.segments.map((x) => {
-							return new ReplicationRangeMessageU32({
-								id: randomBytes(32),
-								offset: x.offset,
-								factor: x.factor,
-								timestamp: x.timestamp,
-								mode: ReplicationIntent.NonStrict,
-							});
-						})
-					: [],
-		});
 	}
 }
 

--- a/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
+++ b/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import path from "path";
 import { TestSession } from "@peerbit/test-utils";
 import { expect } from "chai";
@@ -11,6 +11,7 @@ import {
 	ResponseRoleMessage,
 	StoppedReplicating,
 } from "../src/replication.js";
+import { Observer } from "../src/role.js";
 import { EventStore } from "./utils/stores/index.js";
 
 // B12 stage 3: the legacy outbound announcement machinery (primary broadcast
@@ -20,6 +21,10 @@ import { EventStore } from "./utils/stores/index.js";
 // cannot be constructed or scheduled at all, and that no legacy frame can
 // egress at the reachable seams (strengthening the migration-8-9 default
 // no-legacy-egress pin at the subscription-change seam).
+// B12 stage 4 extends the ratchet inbound: the legacy dispatch arms, apply
+// handlers and the ordering watermark are deleted, so a received legacy
+// frame must die at the unconditional B1 drop with zero side effects, and
+// no inbound apply-path symbol may reappear in src.
 describe("no legacy machinery", () => {
 	let session: TestSession | undefined;
 
@@ -120,24 +125,117 @@ describe("no legacy machinery", () => {
 		expect(sent2.filter(isLegacyFrame)).to.have.length(0);
 	});
 
+	it("applies nothing when a default-mode node receives each legacy frame", async () => {
+		// Runtime inbound ratchet: the five legacy replication-info frames die
+		// at the unconditional B1 drop, ahead of every side effect. The sender
+		// gets a live open session first, so the no-effect outcome cannot be
+		// explained by missing membership; every observation below is
+		// symbol-free (the deleted watermark, handlers and cutover probe are
+		// additionally pinned absent by name).
+		session = await TestSession.disconnected(2);
+		const db = await session.peers[0].open(new EventStore<string, any>(), {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const log = db.log as any;
+		const remote = session.peers[1].identity.publicKey;
+		const remoteHash = remote.hashcode();
+		const peerSession = log._peerSessions.rotate(remoteHash, "opening");
+		log._peerSessions.unblockReplicationInfo(remoteHash);
+		log._peerSessions.markOpen(remoteHash, peerSession);
+
+		const synchronizer = sinon
+			.stub(log.syncronizer, "onMessage")
+			.resolves(false);
+		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
+		const add = sinon.spy(log, "addReplicationRange");
+		const remove = sinon.spy(log, "removeReplicationRanges");
+		const send = sinon.spy(log.rpc, "send");
+		const acquireLease = sinon.spy(log, "acquirePeerReceiveLease");
+		const messages = [
+			new RequestReplicationInfoMessage(),
+			new ResponseRoleMessage({ role: new Observer() }),
+			new AllReplicatingSegmentsMessage({ segments: [] }),
+			new AddedReplicationSegmentMessage({ segments: [] }),
+			new StoppedReplicating({ segmentIds: [] }),
+		];
+		for (const [index, message] of messages.entries()) {
+			await db.log.onMessage(message, {
+				from: remote,
+				message: { header: { session: 1n, timestamp: BigInt(index + 1) } },
+			} as any);
+		}
+		// No lease, no synchronizer work, no liveness, no mutation, no reply,
+		// no apply-lane row and no per-peer V2 receive state: nothing applied.
+		expect(acquireLease.notCalled).to.be.true;
+		expect(synchronizer.notCalled).to.be.true;
+		expect(activity.notCalled).to.be.true;
+		expect(add.notCalled).to.be.true;
+		expect(remove.notCalled).to.be.true;
+		expect(send.notCalled).to.be.true;
+		expect(log._replicationInfoApplyQueueByPeer.has(remoteHash)).to.be.false;
+		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
+		expect(
+			await db.log.replicationIndex.count({ query: { hash: remoteHash } }),
+		).to.equal(0);
+		// The session installed above is untouched — the drop happened before
+		// any session, epoch or blocked-set transition.
+		expect(log._peerSessions.current(remoteHash)).to.equal(peerSession);
+		// The deleted inbound machinery cannot silently return: the watermark
+		// field, the apply handlers and the cutover probe stay deleted.
+		for (const member of [
+			"latestReplicationInfoMessage",
+			"handleReplicationInfoAnnouncement",
+			"handleStoppedReplicating",
+			"handleRequestReplicationInfo",
+		]) {
+			expect(log[member], member).to.equal(undefined);
+		}
+		expect((log._v2Receive as any).isLegacyCutover).to.equal(undefined);
+	});
+
 	it("has zero legacy-frame construction sites on the outbound source paths", () => {
 		// Source-level outbound ratchet: constructing a legacy announcement
-		// class is a prerequisite for sending one. After B12 stage 3 the only
-		// sanctioned constructions live in replication.ts (the ResponseRole
-		// tombstone's decode conversion) and replication-info-v2-receive.ts
-		// (byte-stable fingerprint canonicalization) — both inbound-only and
-		// scheduled for stage 4. Everything the sender stack can reach must
-		// stay clean in every open mode.
+		// class is a prerequisite for sending one. After B12 stage 4 the only
+		// sanctioned constructions in all of src live in
+		// replication-info-v2-receive.ts (byte-stable fingerprint
+		// canonicalization, whitelisted by decision Q4) — that single file is
+		// the whitelist; every other source file must stay clean in every
+		// open mode, including replication.ts now that the ResponseRole
+		// tombstone's decode conversion is deleted.
 		const forbidden =
 			/new\s+(RequestReplicationInfoMessage|ResponseRoleMessage|AllReplicatingSegmentsMessage|AddedReplicationSegmentMessage|StoppedReplicating)\s*\(/g;
-		for (const file of [
-			"src/index.ts",
-			"src/replication-announcement.ts",
-			"src/replication-info-v2-send.ts",
-		]) {
+		const whitelist = new Set(["src/replication-info-v2-receive.ts"]);
+		for (const file of listSourceFiles()) {
+			if (whitelist.has(file)) {
+				continue;
+			}
+			const source = readFileSync(path.join(process.cwd(), file), "utf8");
+			const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
+			expect(matches, file).to.deep.equal([]);
+		}
+	});
+
+	it("has zero legacy inbound apply-path symbols in src", () => {
+		// Source-level inbound ratchet: the legacy inbound dispatch arms, the
+		// All/Added/Stopped apply handlers, the request handler, the ordering
+		// watermark, the tombstone decode conversion and the legacy-cutover
+		// probe are deleted (B12 stage 4). No source file may reference their
+		// names again — the retained legacy remnants in
+		// replication-info-v2-receive.ts (the local legacy union, fingerprint
+		// canonicalization and the noteLegacyAnnouncement sidecar) do not use
+		// these names, so this leg needs no whitelist.
+		const forbidden =
+			/latestReplicationInfoMessage|handleReplicationInfoAnnouncement|handleStoppedReplicating|handleRequestReplicationInfo|toReplicationInfoMessage|isLegacyCutover/g;
+		for (const file of listSourceFiles()) {
 			const source = readFileSync(path.join(process.cwd(), file), "utf8");
 			const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
 			expect(matches, file).to.deep.equal([]);
 		}
 	});
 });
+
+const listSourceFiles = (): string[] =>
+	readdirSync(path.join(process.cwd(), "src"), { recursive: true })
+		.map((entry) => String(entry))
+		.filter((entry) => entry.endsWith(".ts"))
+		.map((entry) => path.join("src", entry));

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -306,7 +306,7 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			expect(add.notCalled).to.be.true;
 			expect(remove.notCalled).to.be.true;
 			expect(send.notCalled).to.be.true;
-			expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
+			expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
 			expect(log._peerSessions.sessions.has(remoteHash)).to.be.false;
 			expect(
 				await db.log.replicationIndex.count({ query: { hash: remoteHash } }),
@@ -467,7 +467,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			expect(acquireLease.notCalled).to.be.true;
 			expect(validateRanges.notCalled).to.be.true;
 			expect(validateStopped.notCalled).to.be.true;
-			expect(log.latestReplicationInfoMessage.has(remoteHash)).to.be.false;
 			expect(
 				await db.log.replicationIndex.count({ query: { hash: remoteHash } }),
 			).to.equal(0);

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -428,8 +428,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 		const synchronizer = sinon
 			.stub(log.syncronizer, "onMessage")
 			.resolves(false);
-		const announcement = sinon.spy(log, "handleReplicationInfoAnnouncement");
-		const stopped = sinon.spy(log, "handleStoppedReplicating");
 		const activity = sinon.spy(log._liveness, "markReplicatorActivity");
 		const add = sinon.spy(log, "addReplicationRange");
 		const remove = sinon.spy(log, "removeReplicationRanges");
@@ -462,8 +460,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			}
 
 			expect(synchronizer.notCalled).to.be.true;
-			expect(announcement.notCalled).to.be.true;
-			expect(stopped.notCalled).to.be.true;
 			expect(activity.notCalled).to.be.true;
 			expect(add.notCalled).to.be.true;
 			expect(remove.notCalled).to.be.true;
@@ -477,8 +473,6 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			).to.equal(0);
 		} finally {
 			synchronizer.restore();
-			announcement.restore();
-			stopped.restore();
 			activity.restore();
 			add.restore();
 			remove.restore();

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -840,7 +840,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		const fullAdmission = prepare(full);
 		expect(fullAdmission).to.exist;
 		expect(coordinator.commit(fullAdmission!)).to.be.true;
-		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(coordinator._cutoverPeerSessions.has(currentSession)).to.be.true;
 
 		const added = new AddedReplicationInfoV2Message({
 			receiverChallenge: state.receiverBinding!.slice(),
@@ -1002,7 +1002,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		).to.be.false;
 		expect(state.controller.signal.aborted).to.be.true;
 		expect(coordinator._receiveStates.has(peerHash)).to.be.false;
-		expect(coordinator.isLegacyCutover(currentSession)).to.be.false;
+		expect(coordinator._cutoverPeerSessions.has(currentSession)).to.be.false;
 		expect(prepare(full)).to.be.undefined;
 	});
 
@@ -1180,7 +1180,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(coordinator.commit(reserved)).to.be.true;
 		expect(state.lastSequence).to.equal(1n);
 		expect(state.phase).to.equal("resync");
-		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(coordinator._cutoverPeerSessions.has(currentSession)).to.be.true;
 		expect(state.requestTimer).to.exist;
 	});
 
@@ -1253,379 +1253,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(coordinator.commit(replacementAdmission!)).to.be.true;
 		expect(replacement.phase).to.equal("active");
 		expect(replacement.lastSequence).to.equal(1n);
-	});
-
-	it("fences legacy recovery evidence to the exact receive generation", () => {
-		expect(markLocalReady()).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch: bytes(17),
-						sequence: 1n,
-						segments: [],
-					}),
-					10n,
-				)!,
-			),
-		).to.be.true;
-		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
-		expect(
-			coordinator.noteLegacyAnnouncement({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-				senderTransportSession: senderTransportSession + 1n,
-				transportTimestamp: 100n,
-				message: legacy,
-			}),
-		).to.be.false;
-		expect(
-			coordinator.noteLegacyAnnouncement({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: {},
-				senderTransportSession,
-				transportTimestamp: 101n,
-				message: legacy,
-			}),
-		).to.be.false;
-		expect(state.phase).to.equal("active");
-		expect(state.legacyFallbackTimer).to.be.undefined;
-	});
-
-	it("lets one fresh legacy observation restart parked recovery only once", async () => {
-		const clock = sinon.useFakeTimers({ now: 1_000 });
-		coordinator = createCoordinator({
-			requestRetryMs: 1,
-			requestMaxAttempts: 1,
-		});
-		expect(markLocalReady(999)).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch: bytes(18),
-						sequence: 1n,
-						segments: [],
-					}),
-					1n,
-				)!,
-			),
-		).to.be.true;
-		currentReceiveEpoch = {};
-		expect(
-			coordinator.advanceRecovery({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-			}),
-		).to.be.true;
-		await clock.tickAsync(1);
-		expect(state.requestParked).to.be.true;
-
-		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
-		const observeLegacy = (transportTimestamp: bigint) =>
-			coordinator.noteLegacyAnnouncement({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-				senderTransportSession,
-				transportTimestamp,
-				message: legacy,
-			});
-		expect(observeLegacy(2n)).to.be.true;
-		expect(state.requestParked).to.be.false;
-		await clock.tickAsync(1);
-		expect(state.requestParked).to.be.true;
-		const refreshesAfterFreshEvidence = refreshLocalCapability.callCount;
-		for (let replay = 0; replay < 100; replay++) {
-			expect(observeLegacy(2n)).to.be.true;
-		}
-		expect(state.requestParked).to.be.true;
-		expect(state.requestTimer).to.be.undefined;
-		expect(refreshLocalCapability.callCount).to.equal(
-			refreshesAfterFreshEvidence,
-		);
-		expect(observeLegacy(3n)).to.be.true;
-		expect(state.requestParked).to.be.false;
-		expect(state.requestTimer).to.exist;
-	});
-
-	it("uses strict transport time and payload evidence for legacy coverage", () => {
-		expect(markLocalReady()).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		const senderEpoch = bytes(19);
-		const rangeA = new ReplicationRangeMessageU64({
-			id: bytes(30),
-			offset: 1n,
-			factor: 1n,
-			timestamp: 1n,
-			mode: ReplicationIntent.NonStrict,
-		});
-		const rangeB = new ReplicationRangeMessageU64({
-			id: bytes(31),
-			offset: 2n,
-			factor: 1n,
-			timestamp: 2n,
-			mode: ReplicationIntent.NonStrict,
-		});
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 1n,
-						segments: [],
-					}),
-					1n,
-				)!,
-			),
-		).to.be.true;
-		expect(
-			coordinator.commit(
-				prepare(
-					new AddedReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 2n,
-						segments: [rangeA],
-					}),
-					10n,
-				)!,
-			),
-		).to.be.true;
-		expect(
-			coordinator.commit(
-				prepare(
-					new AddedReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 3n,
-						segments: [rangeB],
-					}),
-					20n,
-				)!,
-			),
-		).to.be.true;
-		const note = (
-			message: AddedReplicationSegmentMessage,
-			transportTimestamp: bigint,
-		) =>
-			coordinator.noteLegacyAnnouncement({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-				senderTransportSession,
-				transportTimestamp,
-				message,
-			});
-		expect(
-			note(new AddedReplicationSegmentMessage({ segments: [rangeA] }), 10n),
-		).to.be.true;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 4n,
-						segments: [rangeA, rangeB],
-					}),
-					30n,
-				)!,
-			),
-		).to.be.true;
-		expect(
-			note(new AddedReplicationSegmentMessage({ segments: [rangeB] }), 29n),
-		).to.be.true;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		expect(
-			note(new AddedReplicationSegmentMessage({ segments: [rangeA] }), 30n),
-		).to.be.true;
-		expect(state.legacyFallbackTimer).to.exist;
-
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 5n,
-						segments: [rangeA, rangeB],
-					}),
-					31n,
-				)!,
-			),
-		).to.be.true;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-	});
-
-	it("keeps unmatched legacy fallback armed across unrelated V2 work", async () => {
-		const clock = sinon.useFakeTimers({ now: 1_000 });
-		expect(markLocalReady(999)).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		const senderEpoch = bytes(20);
-		const initial = new FullReplicationInfoV2Message({
-			receiverChallenge: state.receiverBinding!.slice(),
-			senderEpoch,
-			sequence: 1n,
-			segments: [],
-		});
-		expect(coordinator.commit(prepare(initial)!)).to.be.true;
-		const rangeA = new ReplicationRangeMessageU64({
-			id: bytes(21),
-			offset: 1n,
-			factor: 1n,
-			timestamp: 1n,
-			mode: ReplicationIntent.NonStrict,
-		});
-		const rangeB = new ReplicationRangeMessageU64({
-			id: bytes(22),
-			offset: 2n,
-			factor: 1n,
-			timestamp: 2n,
-			mode: ReplicationIntent.NonStrict,
-		});
-		expect(
-			coordinator.noteLegacyAnnouncement({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-				senderTransportSession,
-				transportTimestamp: 2n,
-				message: new AddedReplicationSegmentMessage({ segments: [rangeB] }),
-			}),
-		).to.be.true;
-		const unrelated = new AddedReplicationInfoV2Message({
-			receiverChallenge: state.receiverBinding!.slice(),
-			senderEpoch,
-			sequence: 2n,
-			segments: [rangeA],
-		});
-		expect(coordinator.commit(prepare(unrelated)!)).to.be.true;
-		expect(state.legacyFallbackTimer).to.exist;
-		await clock.tickAsync(10);
-		expect(state.phase).to.equal("resync");
-	});
-
-	it("cancels legacy fallback only after a matching commit", async () => {
-		const clock = sinon.useFakeTimers({ now: 1_000 });
-		expect(markLocalReady(999)).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		const senderEpoch = bytes(23);
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 1n,
-						segments: [],
-					}),
-				)!,
-			),
-		).to.be.true;
-		const range = new ReplicationRangeMessageU64({
-			id: bytes(24),
-			offset: 3n,
-			factor: 1n,
-			timestamp: 3n,
-			mode: ReplicationIntent.NonStrict,
-		});
-		const legacy = new AddedReplicationSegmentMessage({ segments: [range] });
-		coordinator.noteLegacyAnnouncement({
-			peerHash,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-			message: legacy,
-		});
-		const matching = new AddedReplicationInfoV2Message({
-			receiverChallenge: state.receiverBinding!.slice(),
-			senderEpoch,
-			sequence: 2n,
-			segments: [range],
-		});
-		const reserved = coordinator.reserve(matching, {
-			from: sender,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-		})!;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		coordinator.release(reserved);
-		expect(state.legacyFallbackTimer).to.exist;
-		const committed = coordinator.reserve(matching, {
-			from: sender,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-		})!;
-		expect(coordinator.commit(committed)).to.be.true;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		await clock.tickAsync(100);
-		expect(state.phase).to.equal("active");
-	});
-
-	it("restarts parked recovery on fresh unmatched legacy evidence", async () => {
-		const clock = sinon.useFakeTimers({ now: 1_000 });
-		coordinator = createCoordinator({
-			requestRetryMs: 2,
-			requestMaxAttempts: 1,
-		});
-		expect(markLocalReady(999)).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		const senderEpoch = bytes(25);
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 1n,
-						segments: [],
-					}),
-				)!,
-			),
-		).to.be.true;
-		currentReceiveEpoch = {};
-		expect(
-			coordinator.advanceRecovery({
-				peerHash,
-				peerSession: currentSession,
-				receiveEpoch: currentReceiveEpoch,
-			}),
-		).to.be.true;
-		await clock.tickAsync(1);
-		expect(state.requestParked).to.be.true;
-		coordinator.noteLegacyAnnouncement({
-			peerHash,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-			message: new AddedReplicationSegmentMessage({ segments: [] }),
-		});
-		expect(state.requestParked).to.be.false;
-		expect(state.capabilityRefreshRequired).to.be.true;
-		expect(state.requestTimer).to.exist;
 	});
 
 	it("backs off to a parked request state and never renews an active stream", async () => {
@@ -1975,71 +1602,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(state.lastSequence).to.equal(1n);
 	});
 
-	it("pauses compat sidecar recovery while its matching V2 frame is applying", async () => {
-		const clock = sinon.useFakeTimers({ now: 1_000 });
-		coordinator = createCoordinator({ legacyFallbackDelayMs: 10 });
-		expect(markLocalReady(999)).to.be.true;
-		expect(observeSender()).to.be.true;
-		const state = coordinator._receiveStates.get(peerHash)!;
-		const senderEpoch = bytes(19);
-		expect(
-			coordinator.commit(
-				prepare(
-					new FullReplicationInfoV2Message({
-						receiverChallenge: state.receiverBinding!.slice(),
-						senderEpoch,
-						sequence: 1n,
-						segments: [],
-					}),
-				)!,
-			),
-		).to.be.true;
-		const legacy = new AddedReplicationSegmentMessage({ segments: [] });
-		coordinator.noteLegacyAnnouncement({
-			peerHash,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-			message: legacy,
-		});
-		expect(state.legacyFallbackTimer).to.exist;
-		const matching = new AddedReplicationInfoV2Message({
-			receiverChallenge: state.receiverBinding!.slice(),
-			senderEpoch,
-			sequence: 2n,
-			segments: [],
-		});
-		const first = coordinator.reserve(matching, {
-			from: sender,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-		})!;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		coordinator.release(first);
-		expect(state.legacyFallbackTimer).to.exist;
-
-		const committed = coordinator.reserve(matching, {
-			from: sender,
-			peerSession: currentSession,
-			receiveEpoch: currentReceiveEpoch,
-			senderTransportSession,
-			transportTimestamp: 2n,
-		})!;
-		const version = state.version;
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		await clock.tickAsync(100);
-		expect(state.version).to.equal(version);
-		expect(coordinator.isAdmissionCurrent(committed)).to.be.true;
-		expect(coordinator.commit(committed)).to.be.true;
-		expect(state.phase).to.equal("active");
-		expect(state.lastSequence).to.equal(2n);
-		expect(state.legacyFallbackTimer).to.be.undefined;
-		expect(state.legacyFallbackFingerprint).to.be.undefined;
-	});
-
 	it("treats MAX_U64 as terminal for the current receiver grant", async () => {
 		const clock = sinon.useFakeTimers({ now: 1_000 });
 		expect(markLocalReady(999)).to.be.true;
@@ -2180,7 +1742,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(state.phase).to.equal("active");
 		expect(state.lastSequence).to.equal(1n);
 		expect([...state.receiverBinding!]).not.to.deep.equal([...oldBinding]);
-		expect(coordinator.isLegacyCutover(currentSession)).to.be.true;
+		expect(coordinator._cutoverPeerSessions.has(currentSession)).to.be.true;
 		expect(
 			coordinator.prepare(oldFull, {
 				from: sender,
@@ -2248,7 +1810,7 @@ describe("receive admission replication-info V2 receiver integration", () => {
 				expect(capabilityTimestamp).to.not.equal(undefined);
 				expect(sendState.lastRequestTimestamp > capabilityTimestamp).to.be.true;
 				expect(
-					receiver._v2Receive.isLegacyCutover(
+					receiver._v2Receive._cutoverPeerSessions.has(
 						receiver._peerSessions.current(senderHash),
 					),
 				).to.be.true;
@@ -2472,7 +2034,7 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			segments: [],
 		});
 		await log.onMessage(full, context(senderSessionA, 11n));
-		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+		expect(log._v2Receive._cutoverPeerSessions.has(peerSession)).to.be.true;
 
 		await log.onMessage(
 			new SyncCapabilitiesMessage({
@@ -2482,7 +2044,7 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		);
 		expect(state.controller.signal.aborted).to.be.true;
 		expect(log._v2Receive._receiveStates.has(remoteHash)).to.be.false;
-		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.false;
+		expect(log._v2Receive._cutoverPeerSessions.has(peerSession)).to.be.false;
 		expect(log._peerSyncCapabilitySessions.get(remoteHash)).to.equal(
 			senderSessionB,
 		);
@@ -2575,7 +2137,7 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		).to.equal(1);
 		expect(state.lastSequence).to.equal(1n);
 		expect(state.phase).to.equal("resync");
-		expect(log._v2Receive.isLegacyCutover(peerSession)).to.be.true;
+		expect(log._v2Receive._cutoverPeerSessions.has(peerSession)).to.be.true;
 		await waitForResolved(() => expect(send.called).to.be.true);
 
 		await log.onMessage(


### PR DESCRIPTION
B12 stage 4 of 5: deletes the dead legacy inbound machinery below the dispatch-level drop — the ResponseRole/All/Added/Stopped dispatch arms and apply handlers, the legacy ordering watermark (`latestReplicationInfoMessage`, all 14 sites), the `isLegacyCutover` probe, and `toReplicationInfoMessage` (a method on the exported `ResponseRoleMessage` tombstone — hence the major; the class, its wire variant, and its fields are untouched).

Retained verbatim, each proven: the unconditional early drop block (byte-identical, still ahead of lease/session/liveness/mutation — moving it below the lease turns the retained codec drop pin red, verified), eager tombstone registration, `ReplicationPing`, `allowLegacyOrderedReplacementPairs` with its live V2 Added caller, `_cutoverPeerSessions` (KEEP-OLD as V2 resync memory — its V2 feeders and readers are intact), and v2-receive's fingerprint canonicalization (the single whitelisted file in the widened source-scan ratchet).

New guards: an inbound no-effect leg (a live default-mode node receiving each of the five legacy frames applies nothing — no lease, no synchronizer, no liveness, no mutation, no reply; a re-added watermark-like write turns it red, verified) and an inbound apply-path symbol scan over all of src with no exemptions.

Validation: per-commit suite sets green (311–318 passing), final tip set 321 passing, shard-coverage 67 describes, fence-ratchet 13/13, root lint clean, repo-wide zero references to every deleted symbol. Flagged for stage 5: the legacy-fallback machinery in v2-receive is now caller-free and will be deleted there.