### PR TITLE
refactor!: retire the remaining compatibility plumbing (B12 stage 5, final)

### DIFF
--- a/.changeset/collapse-retired-compat-plumbing.md
+++ b/.changeset/collapse-retired-compat-plumbing.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": major
+---
+
+Collapse the retired compatibility plumbing (B12 stage 5, final cleanup): the always-`undefined` residual `compatibility` getter on `SharedLog` is deleted (the open option itself was removed and rejects with `CompatibilityModeRetiredError` since the B12 major), together with the permanently-false internal compat gates, the compatibility-coupled domain/synchronizer defaulting arms (defaults are now unconditionally u64 + RatelessIBLT; `ReplicationDomainTime`, `createReplicationDomainHash("u32")` and explicit `syncronizer: SimpleSyncronizer` remain first-class options), the caller-free legacy-fallback sidecar in the V2 receive coordinator, the two-phase legacy capability barrier (adverts now promote on ACK; the advertisement handle keeps `releaseLegacyBarrier()` as a no-op), the deprecated `getRoleFromReplicationSegments` helper and the announcement-session rotation shell. Wire tombstones stay registered and exported; fingerprint canonicalization still constructs the legacy canonical forms locally (byte-stable, never sent).

--- a/.changeset/delete-document-compat-internals.md
+++ b/.changeset/delete-document-compat-internals.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/document": major
+---
+
+Delete the retired internal document compatibility plumbing (B12 stage 5): the always-`undefined` residual `compatibility` fields on `Documents` and `DocumentIndex` and the `compatibility` member of the exported `OpenOptions` type are removed (the open option itself was removed and rejects with `DocumentCompatibilityRetiredError` since the B12 major), together with the compat-6 `PutWithKeyOperation` ENCODE branch at the write path and the legacy query/iteration coercion branches. Writes always encode `PutOperation`; persisted data from old compatibility-6 stores (tag-0 puts, tag-2 deletes) remains decodable and applicable forever — the operation tombstone classes, their variant registrations and delete-key coercions are unchanged and now pinned encode-dead by a source ratchet.

--- a/packages/programs/data/document/document/src/program.ts
+++ b/packages/programs/data/document/document/src/program.ts
@@ -1098,8 +1098,6 @@ export class Documents<
 	private strictHistory: boolean;
 	canOpen?: (program: T) => Promise<boolean> | boolean;
 
-	compatibility: 6 | 7 | undefined;
-
 	constructor(properties?: {
 		id?: Uint8Array;
 		immutable?: boolean;
@@ -1241,9 +1239,6 @@ export class Documents<
 		}
 		if (options.domain) {
 			unsupported.push("custom domain");
-		}
-		if ((options as any).compatibility != null) {
-			unsupported.push("legacy compatibility");
 		}
 		if (options.strictHistory) {
 			unsupported.push("strict history");
@@ -1473,9 +1468,6 @@ export class Documents<
 		}
 		if (this.strictHistory) {
 			unsupported.push("strict history");
-		}
-		if (this.compatibility === 6) {
-			unsupported.push("legacy compatibility");
 		}
 		if (Program.isPrototypeOf(this._clazz)) {
 			unsupported.push("program-valued document type");
@@ -1823,9 +1815,6 @@ export class Documents<
 		if (this.strictHistory) {
 			unsupported.push("strict history");
 		}
-		if (this.compatibility === 6) {
-			unsupported.push("legacy compatibility");
-		}
 		if (Program.isPrototypeOf(this._clazz)) {
 			unsupported.push("program-valued document type");
 		}
@@ -1850,9 +1839,6 @@ export class Documents<
 		}
 		if (this.strictHistory) {
 			unsupported.push("strict history");
-		}
-		if (this.compatibility === 6) {
-			unsupported.push("legacy compatibility");
 		}
 		if (Program.isPrototypeOf(this._clazz)) {
 			unsupported.push("program-valued document type");
@@ -2300,9 +2286,6 @@ export class Documents<
 						indexerTypes.extractFieldValue(obj, idProperty as string[]));
 
 		this.idResolver = idResolver;
-		// B12: permanently undefined (the option rejects above); the field and
-		// its residual gates die in a later cleanup stage.
-		this.compatibility = (options as any).compatibility;
 		this.strictHistory = options.strictHistory ?? false;
 		this._hasLogTrim = options.log?.trim != null;
 
@@ -2315,7 +2298,6 @@ export class Documents<
 			documentType: this._clazz,
 			transform: options.index,
 			indexBy: idProperty,
-			compatibility: (options as any).compatibility,
 			cache: options?.index?.cache,
 			replicate: async (query, results) => {
 				// here we arrive for all the results we want to persist.
@@ -3009,24 +2991,14 @@ export class Documents<
 		}
 
 		const key = indexerTypes.toId(keyValue);
-		let operation: PutOperation | PutWithKeyOperation;
-		let encodedOperation: Uint8Array | undefined;
-		if (this.compatibility === 6) {
-			if (typeof keyValue === "string") {
-				operation = new PutWithKeyOperation({
-					key: keyValue,
-					data: encodedDocument,
-				});
-			} else {
-				throw new Error("Key must be a string in compatibility mode v6");
-			}
-		} else {
-			encodedOperation = encodePutOperationPayload(encodedDocument);
-			encodedDocument = encodedOperation.subarray(PUT_OPERATION_PREFIX_LENGTH);
-			operation = new PutOperation({
-				data: encodedDocument,
-			});
-		}
+		// B12: writes always encode PutOperation. The compatibility-6
+		// PutWithKeyOperation ENCODE branch is retired; the tag-0 DECODE stays
+		// forever (see operation-tombstone pins).
+		const encodedOperation = encodePutOperationPayload(encodedDocument);
+		encodedDocument = encodedOperation.subarray(PUT_OPERATION_PREFIX_LENGTH);
+		const operation = new PutOperation({
+			data: encodedDocument,
+		});
 		return {
 			document: doc,
 			encodedDocument,
@@ -3038,9 +3010,6 @@ export class Documents<
 	}
 
 	private preparePlainPut(doc: T): PreparedPlainPut<T> {
-		if (this.compatibility === 6) {
-			throw new Error("Plain put preparation is not supported in v6 mode");
-		}
 		const keyValue = this.idResolver(doc);
 		indexerTypes.checkId(keyValue);
 		const documentBytes = serialize(doc);
@@ -3230,7 +3199,6 @@ export class Documents<
 			this.canPerformAllowsPlainPutFastPath(doc) &&
 			!this.immutable &&
 			!this.strictHistory &&
-			this.compatibility !== 6 &&
 			!Program.isPrototypeOf(this._clazz) &&
 			!options?.canAppend &&
 			!options?.onChange &&

--- a/packages/programs/data/document/document/src/search.ts
+++ b/packages/programs/data/document/document/src/search.ts
@@ -538,7 +538,6 @@ const coerceQuery = <Resolve extends boolean | undefined>(
 		| types.IterationRequest
 		| QueryLike,
 	options?: QueryOptions<any, any, any, Resolve>,
-	compatibility?: number,
 ):
 	| types.SearchRequest
 	| types.SearchRequestIndexed
@@ -546,7 +545,6 @@ const coerceQuery = <Resolve extends boolean | undefined>(
 	const replicate =
 		typeof options?.remote !== "boolean" ? options?.remote?.replicate : false;
 	const shouldResolve = options?.resolve !== false;
-	const useLegacyRequests = compatibility != null && compatibility <= 9;
 
 	if (
 		query instanceof types.SearchRequestIndexed &&
@@ -565,39 +563,10 @@ const coerceQuery = <Resolve extends boolean | undefined>(
 	}
 
 	if (query instanceof types.IterationRequest) {
-		if (useLegacyRequests) {
-			if (query.resolve === false) {
-				return new types.SearchRequestIndexed({
-					query: query.query,
-					sort: query.sort,
-					fetch: query.fetch,
-					replicate: query.replicate ?? replicate,
-				});
-			}
-			return new types.SearchRequest({
-				query: query.query,
-				sort: query.sort,
-				fetch: query.fetch,
-			});
-		}
 		return query;
 	}
 
 	const queryObject = query as QueryLike;
-
-	if (useLegacyRequests) {
-		if (shouldResolve) {
-			return new types.SearchRequest({
-				query: indexerTypes.toQuery(queryObject.query),
-				sort: indexerTypes.toSort(queryObject.sort),
-			});
-		}
-		return new types.SearchRequestIndexed({
-			query: indexerTypes.toQuery(queryObject.query),
-			sort: indexerTypes.toSort(queryObject.sort),
-			replicate,
-		});
-	}
 
 	return new types.IterationRequest({
 		query: indexerTypes.toQuery(queryObject.query),
@@ -859,7 +828,6 @@ export type OpenOptions<
 		resolver?: number;
 		query?: QueryCacheOptions;
 	};
-	compatibility: 6 | 7 | 8 | 9 | undefined;
 	maybeOpen: (value: T & Program) => Promise<T & Program>;
 	prefetch?: boolean | Partial<PrefetchOptions>;
 	includeIndexed?: boolean; // if true, indexed representations will always be included in the search results
@@ -1099,8 +1067,6 @@ export class DocumentIndex<
 	private _prefetch?: PrefetchOptions | undefined;
 	private includeIndexed: boolean | undefined = undefined;
 	private immutable: boolean = false;
-
-	compatibility: 6 | 7 | 8 | 9 | undefined;
 
 	// Transformation, indexer
 	/* fields: IndexableFields<T, I>; */
@@ -1555,10 +1521,6 @@ export class DocumentIndex<
 		const previousEvents = this.documentEvents;
 		this.documentEvents =
 			properties.documentEvents ?? previousEvents ?? (this.events as any);
-		this.compatibility =
-			properties.compatibility !== undefined
-				? properties.compatibility
-				: this.compatibility;
 
 		let prefectOptions =
 			typeof properties.prefetch === "object"
@@ -3479,11 +3441,7 @@ export class DocumentIndex<
 			coercedOptions?.remote &&
 			typeof coercedOptions.remote !== "boolean" &&
 			coercedOptions.remote.replicate;
-		if (
-			resolve &&
-			wantsReplication &&
-			(this.compatibility == null || this.compatibility > 8)
-		) {
+		if (resolve && wantsReplication) {
 			// SearchRequest cannot carry entries, so a replicated resolved get would
 			// fetch the value and then fetch the entry again during sync.
 			requestClazz = types.SearchRequestIndexed;
@@ -4502,11 +4460,7 @@ export class DocumentIndex<
 		options?: O,
 	): Promise<ValueTypeFromRequest<Resolve, T, I>[]> {
 		// Set fetch to search size, or max value (default to max u32 (4294967295))
-		const coercedRequest = coerceQuery(
-			queryRequest,
-			options,
-			this.compatibility,
-		);
+		const coercedRequest = coerceQuery(queryRequest, options);
 		coercedRequest.fetch = coercedRequest.fetch ?? 0xffffffff;
 
 		const searchOptions =
@@ -4617,11 +4571,7 @@ export class DocumentIndex<
 			throw new Error("Cannot use resolve=false with SearchRequest"); // TODO make this work
 		}
 
-		let queryRequestCoerced = coerceQuery(
-			queryRequest ?? {},
-			options,
-			this.compatibility,
-		);
+		let queryRequestCoerced = coerceQuery(queryRequest ?? {}, options);
 
 		const self = this;
 		function normalizeUpdatesOption(u?: UpdateOptions<T, I, Resolve>): {
@@ -4760,12 +4710,7 @@ export class DocumentIndex<
 			!(queryRequestCoerced instanceof types.IterationRequest) &&
 			pushUpdates
 		) {
-			// Push streaming only works on IterationRequest; reject legacy compat and upgrade other callers.
-			if (this.compatibility !== undefined) {
-				throw new Error(
-					"updates.push requires IterationRequest support; not available when compatibility is set",
-				);
-			}
+			// Push streaming only works on IterationRequest; upgrade other callers.
 			queryRequestCoerced = new types.IterationRequest({
 				query: queryRequestCoerced.query,
 				sort: queryRequestCoerced.sort,
@@ -4782,11 +4727,7 @@ export class DocumentIndex<
 			options?.resolve !== false
 		) {
 			// Legacy requests can't carry replicate=true; swap to indexed search so replication intent is preserved.
-			if (
-				(queryRequest instanceof types.SearchRequestIndexed === false &&
-					this.compatibility == null) ||
-				(this.compatibility != null && this.compatibility > 8)
-			) {
+			if (queryRequest instanceof types.SearchRequestIndexed === false) {
 				queryRequestCoerced = new types.SearchRequestIndexed({
 					query: queryRequestCoerced.query,
 					fetch: queryRequestCoerced.fetch,

--- a/packages/programs/data/document/document/test/compatibility-rejection.spec.ts
+++ b/packages/programs/data/document/document/test/compatibility-rejection.spec.ts
@@ -59,7 +59,8 @@ describe("document compatibility retirement", () => {
 			// was never opened.
 			expect((store.docs.log as any).syncronizer).to.be.undefined;
 			expect((store.docs.log as any).domain).to.be.undefined;
-			expect(store.docs.compatibility).to.be.undefined;
+			// B12 stage 5: the residual compatibility field is deleted outright.
+			expect((store.docs as any).compatibility).to.be.undefined;
 		});
 	}
 
@@ -71,7 +72,7 @@ describe("document compatibility retirement", () => {
 			args: { replicate: false, compatibility: undefined } as any,
 		});
 		try {
-			expect(store.docs.compatibility).to.be.undefined;
+			expect((store.docs as any).compatibility).to.be.undefined;
 			expect((store.docs.log as any).syncronizer).to.exist;
 		} finally {
 			await store.close();

--- a/packages/programs/data/document/document/test/operation-tombstone.spec.ts
+++ b/packages/programs/data/document/document/test/operation-tombstone.spec.ts
@@ -6,13 +6,17 @@
 // coercions are permanent decode tombstones. These pins freeze the wire bytes
 // and prove a store containing tag-0/tag-2 entries opens and reads back
 // WITHOUT any compatibility option.
+import { readFileSync, readdirSync } from "fs";
+import path from "path";
 import { deserialize, serialize } from "@dao-xyz/borsh";
+import { Entry } from "@peerbit/log";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import {
 	DeleteByStringKeyOperation,
 	Operation,
+	PutOperation,
 	PutWithKeyOperation,
 } from "../src/operation.js";
 import { Documents } from "../src/program.js";
@@ -118,6 +122,65 @@ describe("document operation tombstones", () => {
 			expect(readBack!.id).to.equal(keep.id);
 			expect(readBack!.name).to.equal("kept name");
 			expect(await store.docs.index.get(removed.id)).to.equal(undefined);
+		});
+	});
+
+	describe("encode retirement", () => {
+		// B12 stage 5: the compatibility-6 ENCODE branch (PutWithKeyOperation
+		// construction at the document write path) is deleted. Writes are
+		// always PutOperation; the deprecated layouts are decode-only.
+		let session: TestSession;
+		let store: TestStore;
+
+		before(async () => {
+			session = await TestSession.connected(1);
+		});
+
+		afterEach(async () => {
+			await store?.close();
+		});
+
+		after(async () => {
+			await session.stop();
+		});
+
+		it("writes PutOperation for a default put, never PutWithKeyOperation", async () => {
+			store = new TestStore({ docs: new Documents<Document>() });
+			await session.peers[0].open(store);
+			const doc = new Document({ id: "encode-default", name: "current" });
+			const { entry } = await store.docs.put(doc);
+			const reloaded = await Entry.fromMultihash<Operation>(
+				store.docs.log.log.blocks,
+				entry.hash,
+			);
+			reloaded.init({
+				encoding: store.docs.log.log.encoding,
+				keychain: store.docs.log.log.keychain,
+			});
+			const payload = await reloaded.getPayloadValue();
+			expect(payload).to.be.instanceOf(PutOperation);
+			expect(payload).to.not.be.instanceOf(PutWithKeyOperation);
+		});
+
+		it("has zero deprecated-operation construction sites in src", () => {
+			// Source ratchet: the deprecated layouts are encode-dead. Any
+			// re-added `new PutWithKeyOperation(`/`new DeleteByStringKeyOperation(`
+			// in src is a retirement regression (decode registration in
+			// operation.ts uses only decorators, not construction).
+			const forbidden =
+				/new\s+(PutWithKeyOperation|DeleteByStringKeyOperation)\s*\(/g;
+			const sourceFiles = readdirSync(path.join(process.cwd(), "src"), {
+				recursive: true,
+			})
+				.map((entry) => String(entry))
+				.filter((entry) => entry.endsWith(".ts"))
+				.map((entry) => path.join("src", entry));
+			expect(sourceFiles.length).to.be.greaterThan(0);
+			for (const file of sourceFiles) {
+				const source = readFileSync(path.join(process.cwd(), file), "utf8");
+				const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
+				expect(matches, file).to.deep.equal([]);
+			}
 		});
 	});
 });

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -274,7 +274,6 @@ import {
 	maxReplicas,
 } from "./replication.js";
 import { ReplicatorLivenessMonitor } from "./replicator-liveness.js";
-import { Observer, Replicator } from "./role.js";
 import { createSyncronizer } from "./sync/factory.js";
 import type {
 	SharedLogNativeWireSync,
@@ -2084,16 +2083,17 @@ export class SharedLog<
 	// The replication-info blocked set (fence B5) lives on the peer-session
 	// registry: unsubscribed peers whose replication-info is ignored until a
 	// reconnect barrier commits. See PeerSessionRegistry._replicationInfoBlockedPeers.
+	// V2 recovery scheduler state, one row per open peer session (B12: the
+	// legacy request scheduler that shared this map is deleted).
 	private _replicationInfoRequestByPeer!: Map<
 		string,
 		{
-			// Legacy scheduler: sends issued (bounded by maxAttempts). V2 recovery
-			// scheduler: consecutive fruitless unparks — the escalation exponent
-			// for the next unpark delay, reset on any applied V2 progress.
+			// Consecutive fruitless unparks — the escalation exponent for the
+			// next unpark delay, reset on any applied V2 progress.
 			attempts: number;
 			timer?: ReturnType<typeof setTimeout>;
-			peerSession?: PeerSession;
-			// V2 recovery scheduler only: when the current park was first observed.
+			peerSession: PeerSession;
+			// When the current park was first observed.
 			parkedSinceMs?: number;
 		}
 	>;
@@ -3726,27 +3726,8 @@ export class SharedLog<
 		this._nativeStrictDurableTransactionsClosing ??= false;
 	}
 
-	get compatibility(): number | undefined {
-		// B12: the open option was removed and any defined value rejects at
-		// open(); this is permanently undefined and dies with the residual
-		// gates in a later cleanup stage.
-		return (this._logProperties as any)?.compatibility;
-	}
-
-	/**
-	 * Legacy replication-info is an explicit compatibility fallback. Current
-	 * logs never infer or re-enable it from a remote peer's capabilities.
-	 */
-	private get legacyReplicationInfoEnabled(): boolean {
-		return this.compatibility !== undefined && this.compatibility < 10;
-	}
-
 	get isAdaptiveReplicating() {
 		return this._isAdaptiveReplicating;
-	}
-
-	private get v8Behaviour() {
-		return (this.compatibility ?? Number.MAX_VALUE) < 9;
 	}
 
 	private getFanoutChannelOptions(
@@ -4653,8 +4634,7 @@ export class SharedLog<
 			(leaders.size === 0 || (leaders.size === 1 && leaders.has(selfHash)))
 		) {
 			const allowSubscriberFallback =
-				this.syncronizer instanceof SimpleSyncronizer ||
-				(this.compatibility ?? Number.MAX_VALUE) < 10;
+				this.syncronizer instanceof SimpleSyncronizer;
 			if (!allowSubscriberFallback) {
 				return;
 			}
@@ -4803,8 +4783,7 @@ export class SharedLog<
 			const set = new Set(leaders.keys());
 			let hasRemotePeers = set.has(selfHash) ? set.size > 1 : set.size > 0;
 			const allowSubscriberFallback =
-				this.syncronizer instanceof SimpleSyncronizer ||
-				(this.compatibility ?? Number.MAX_VALUE) < 10;
+				this.syncronizer instanceof SimpleSyncronizer;
 			if (!hasRemotePeers && allowSubscriberFallback) {
 				try {
 					const subscribers = await this._getTopicSubscribers(this.topic);
@@ -5265,28 +5244,6 @@ export class SharedLog<
 			expiresAt: Date.now() + LEADER_SELECTION_CONTEXT_CACHE_TTL_MS,
 			context: this.cloneLeaderSelectionContext(context),
 		};
-	}
-
-	// @deprecated
-	private getRoleFromReplicationSegments(
-		segments: ReplicationRangeIndexable<R>[],
-	) {
-		if (segments.length > 1) {
-			throw new Error(
-				"More than one replication segment found. Can only use one segment for compatbility with v8",
-			);
-		}
-
-		if (segments.length > 0) {
-			const segment = segments[0].toReplicationRange();
-			return new Replicator({
-				factor: (segment.factor as number) / MAX_U32,
-				offset: (segment.offset as number) / MAX_U32,
-			});
-		}
-
-		// TODO this is not accurate but might be good enough
-		return new Observer();
 	}
 
 	private isTerminating() {
@@ -14204,12 +14161,7 @@ export class SharedLog<
 
 		this.domain = options?.domain
 			? (options.domain(this) as unknown as D)
-			: (createReplicationDomainHash(
-					(options as any)?.compatibility !== undefined &&
-						(options as any).compatibility < 10
-						? "u32"
-						: "u64",
-				)(this) as unknown as D);
+			: (createReplicationDomainHash("u64")(this) as unknown as D);
 		this.indexableDomain = createIndexableDomainFromResolution(
 			this.domain.resolution,
 		);
@@ -14291,7 +14243,6 @@ export class SharedLog<
 		this._liveness.resetForOpen();
 		this._lastLocalAppendAt = 0;
 		this._announcements ??= this.createReplicationAnnouncementCoordinator();
-		this._announcements.resetForOpen();
 		this._v2Receive ??= this.createReplicationInfoV2ReceiveCoordinator();
 		this._v2Receive.resetForOpen();
 		this._v2Send ??= this.createReplicationInfoV2SendCoordinator();
@@ -14809,7 +14760,6 @@ export class SharedLog<
 				sendOptions?: { priority?: number; signal?: AbortSignal },
 			) => this.trySendFusedRawExchangeHeads(hashes, to, sendOptions),
 			warn,
-			compatibility: (this._logProperties as any)?.compatibility,
 			resolution: this.domain.resolution,
 			sync: options?.sync,
 			syncronizer: options?.syncronizer,
@@ -17618,16 +17568,16 @@ export class SharedLog<
 				throw new Error("Missing from in update role message");
 			}
 			if (
-				!this.legacyReplicationInfoEnabled &&
-				(msg instanceof RequestReplicationInfoMessage ||
-					msg instanceof ResponseRoleMessage ||
-					msg instanceof AllReplicatingSegmentsMessage ||
-					msg instanceof AddedReplicationSegmentMessage ||
-					msg instanceof StoppedReplicating)
+				msg instanceof RequestReplicationInfoMessage ||
+				msg instanceof ResponseRoleMessage ||
+				msg instanceof AllReplicatingSegmentsMessage ||
+				msg instanceof AddedReplicationSegmentMessage ||
+				msg instanceof StoppedReplicating
 			) {
-				// These variants remain registered decode tombstones, but current logs
-				// fail closed before leases, synchronizer work, liveness, watermarks or
-				// mutations. Only an explicit pre-v10 compatibility open admits them.
+				// These variants remain registered decode tombstones, but logs fail
+				// closed unconditionally before leases, synchronizer work, liveness,
+				// watermarks or mutations (B12: the compatibility opens that once
+				// admitted them reject at open()).
 				return;
 			}
 			// Snapshot receive ownership before any async handler gets a chance to
@@ -23030,7 +22980,7 @@ export class SharedLog<
 	 */
 	private resetReplicationInfoV2RecoveryEscalation(peerHash: string) {
 		const state = this._replicationInfoRequestByPeer.get(peerHash);
-		if (!state || state.peerSession === undefined) {
+		if (!state) {
 			return;
 		}
 		state.attempts = 0;
@@ -23358,17 +23308,15 @@ export class SharedLog<
 		// This keeps capability ACK latency off the subscription callback's
 		// critical path.
 		const receiveEpoch = this._peerSessions.receiveEpoch(peerHash);
-		const localCapabilityAdvertisement =
-			this._v2Receive.advertiseLocalCapability({
-				target: publicKey,
-				peerSession: expectedSubscriptionEpoch,
-				receiveEpoch,
-				signal: replicationLifecycleController.signal,
-			});
-		// Current logs have no legacy startup work to order ahead of RequestV2.
-		// Releasing is synchronous and exact-session fenced; the ACK may still
-		// arrive later and promote readiness through the coordinator.
-		localCapabilityAdvertisement.releaseLegacyBarrier();
+		// B12: there is no legacy startup work to order ahead of RequestV2, so
+		// the two-phase legacy barrier is gone — an ACKed advert promotes
+		// readiness through the coordinator as soon as it lands.
+		this._v2Receive.advertiseLocalCapability({
+			target: publicKey,
+			peerSession: expectedSubscriptionEpoch,
+			receiveEpoch,
+			signal: replicationLifecycleController.signal,
+		});
 		this.scheduleReplicationInfoV2Recovery(
 			publicKey,
 			replicationLifecycleController,

--- a/packages/programs/data/shared-log/src/replication-announcement.ts
+++ b/packages/programs/data/shared-log/src/replication-announcement.ts
@@ -1,17 +1,5 @@
 import type { ReplicationInfoMutation } from "./replication-info-mutation.js";
 
-/**
- * One session per announcement window — rotated at exactly the sites that
- * bumped the legacy retry-generation counter: construction, resetForOpen and
- * the pre-send bump in sendReplicationAnnouncement. Identity comparison
- * replaced every numeric generation compare while the legacy retry/repair
- * workers existed; the workers are gone (B12 stage 3) and the rotation sites
- * are kept-old until stage 5 verifies no consumer pins session identity.
- */
-export class AnnouncementWorkerSession {
-	readonly createdAt = Date.now(); // diagnostics only
-}
-
 export type ReplicationAnnouncementDeps = {
 	captureReplicationOwnershipLifecycle: () => AbortController;
 	throwIfReplicationOwnershipLifecycleInactive: (
@@ -19,37 +7,21 @@ export type ReplicationAnnouncementDeps = {
 	) => void;
 	// V2 is always current: every committed local mutation feeds the V2
 	// sender. The legacy broadcast tail this fed in parallel was deleted in
-	// B12 stage 3.
+	// B12 stage 3, and the announcement-session/repair-generation rotation
+	// that ordered the legacy retry/repair workers folded away in stage 5
+	// once no consumer pinned session identity.
 	enqueueReplicationInfoV2: (mutation: ReplicationInfoMutation) => void;
 };
 
 export class ReplicationAnnouncementCoordinator {
-	_announcementSession!: AnnouncementWorkerSession;
 	// Publish local ownership announcements in committed mutation order. This
 	// prevents an older Added message with a delayed transport completion from
 	// overtaking a newer authoritative empty snapshot.
 	_replicationAnnouncementSendTails?: WeakMap<AbortController, Promise<void>>;
 
 	constructor(private readonly deps: ReplicationAnnouncementDeps) {
-		this._announcementSession = new AnnouncementWorkerSession();
 		this._replicationAnnouncementSendTails = new WeakMap();
 	}
-
-	private rotateAnnouncementSession(): AnnouncementWorkerSession {
-		return (this._announcementSession = new AnnouncementWorkerSession());
-	}
-
-	resetForOpen(): void {
-		this.rotateAnnouncementSession();
-	}
-
-	/**
-	 * KEEP-OLD (B12 stage 3): the repair binding this advanced was deleted
-	 * with the legacy repair worker. The pre-send call shape below is
-	 * preserved until stage 5 verifies no surviving test pins announcement
-	 * session identity, then the rotation/advance pair folds together.
-	 */
-	private advanceCurrentReplicationStateAnnouncementRepairGeneration(): void {}
 
 	async sendReplicationAnnouncement(
 		mutation: ReplicationInfoMutation,
@@ -71,12 +43,6 @@ export class ReplicationAnnouncementCoordinator {
 				if (options?.shouldSend && !options.shouldSend()) {
 					return;
 				}
-				// Advance before every post-mutation send, including successful ones. An
-				// authoritative retry already in flight may have captured the previous
-				// local state; the session mismatch forces one more current snapshot
-				// after that stale send settles.
-				this.rotateAnnouncementSession();
-				this.advanceCurrentReplicationStateAnnouncementRepairGeneration();
 				this.deps.enqueueReplicationInfoV2(mutation);
 			});
 		// Keep the ordering barrier usable after a caller-observed send rejection.

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -23,7 +23,6 @@ const REQUIRED_SENDER_CAPABILITIES =
 const DEFAULT_REQUEST_RETRY_MS = 1_000;
 const DEFAULT_MAX_REQUEST_RETRY_MS = 30_000;
 const DEFAULT_REQUEST_MAX_ATTEMPTS = 7;
-const DEFAULT_LEGACY_FALLBACK_DELAY_MS = 5_000;
 const MAX_U64 = (1n << 64n) - 1n;
 const MAX_BACKOFF_EXPONENT = 20;
 
@@ -39,13 +38,12 @@ const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
 	return true;
 };
 
-type LegacyReplicationInfoMessage =
-	| AllReplicatingSegmentsMessage
-	| AddedReplicationSegmentMessage
-	| StoppedReplicating;
-
+// Q4 (B12): fingerprints keep constructing the legacy-class canonical forms.
+// They are byte-stable local-only hash inputs, never sent; these are the only
+// sanctioned legacy-frame construction sites in src (see the no-legacy-
+// machinery source ratchet's narrowed whitelist).
 const replicationInfoPayloadFingerprint = (
-	message: ReplicationInfoV2Message | LegacyReplicationInfoMessage,
+	message: ReplicationInfoV2Message,
 ): Uint8Array => {
 	const canonical =
 		message instanceof FullReplicationInfoV2Message
@@ -86,6 +84,11 @@ type LocalCapabilityReadyProperties = {
 
 export type ReplicationInfoV2LocalCapabilityAdvertisementHandle = {
 	firstAttempt: Promise<void>;
+	/**
+	 * B12: the two-phase legacy barrier is retired — an ACKed advert promotes
+	 * readiness immediately. Retained as a no-op so the handle shape (and the
+	 * tests that drive it) stay stable.
+	 */
 	releaseLegacyBarrier(): void;
 };
 
@@ -93,7 +96,6 @@ export type ReplicationInfoV2LocalCapabilityContext = {
 	peerHash: string;
 	target: PublicSignKey;
 	lifecycleSignal: AbortSignal;
-	legacyBarrierReleased: boolean;
 };
 
 export type ReplicationInfoV2LocalCapabilityAdvertisement = {
@@ -141,18 +143,6 @@ export type ReplicationInfoV2ReceiveState = {
 	requestsSinceCapabilityRefresh: number;
 	requestParked: boolean;
 	capabilityRefreshRequired: boolean;
-	legacyFallbackTimer?: ReturnType<typeof setTimeout>;
-	legacyFallbackFingerprint?: Uint8Array;
-	legacyFallbackTimestamp?: bigint;
-	legacyFallbackAmbiguous: boolean;
-	lastCommittedTransportTimestamp?: bigint;
-	recentCommittedPayloads: Array<{
-		fingerprint: Uint8Array;
-		transportTimestamp: bigint;
-	}>;
-	lastLegacyObservationTimestamp?: bigint;
-	lastLegacyObservationFingerprint?: Uint8Array;
-	lastLegacyObservationAmbiguous: boolean;
 	reservedAdmission?: ReplicationInfoV2ReceiveAdmission;
 };
 
@@ -204,7 +194,6 @@ export type ReplicationInfoV2ReceiveDeps = {
 	requestRetryMs?: number;
 	maxRequestRetryMs?: number;
 	requestMaxAttempts?: number;
-	legacyFallbackDelayMs?: number;
 };
 
 /**
@@ -230,7 +219,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	private readonly requestRetryMs: number;
 	private readonly maxRequestRetryMs: number;
 	private readonly requestMaxAttempts: number;
-	private readonly legacyFallbackDelayMs: number;
 
 	constructor(private readonly deps: ReplicationInfoV2ReceiveDeps) {
 		this.now = deps.now ?? Date.now;
@@ -245,10 +233,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		this.requestMaxAttempts = Math.max(
 			1,
 			Math.floor(deps.requestMaxAttempts ?? DEFAULT_REQUEST_MAX_ATTEMPTS),
-		);
-		this.legacyFallbackDelayMs = Math.max(
-			this.requestRetryMs,
-			deps.legacyFallbackDelayMs ?? DEFAULT_LEGACY_FALLBACK_DELAY_MS,
 		);
 		this._receiveStates = new Map();
 		this._cutoverPeerSessions = new WeakSet();
@@ -323,10 +307,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (state.requestTimer) {
 			clearTimeout(state.requestTimer);
 			state.requestTimer = undefined;
-		}
-		if (state.legacyFallbackTimer) {
-			clearTimeout(state.legacyFallbackTimer);
-			state.legacyFallbackTimer = undefined;
 		}
 		state.controller.abort();
 		state.version++;
@@ -422,9 +402,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (state.timer || state.inFlight || state.ready) {
 			return;
 		}
-		if (state.acknowledgedReady && !state.context.legacyBarrierReleased) {
-			return;
-		}
 		if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
 			this.clearLocalCapabilityAdvertisement(state);
 			return;
@@ -468,9 +445,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			return;
 		}
 		if (state.acknowledgedReady) {
-			if (state.context.legacyBarrierReleased) {
-				this.promoteLocalCapabilityAdvertisement(state);
-			}
+			this.promoteLocalCapabilityAdvertisement(state);
 			return;
 		}
 		if (!this.isLocalCapabilityAdvertisementReadyOpen(state)) {
@@ -528,9 +503,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 					this.isLocalCapabilityAdvertisementGenerationCurrent(state) &&
 					!state.ready
 				) {
-					if (!state.acknowledgedReady || state.context.legacyBarrierReleased) {
-						this.armLocalCapabilityAdvertisement(state);
-					}
+					this.armLocalCapabilityAdvertisement(state);
 				}
 			});
 		state.inFlight = operation;
@@ -538,10 +511,9 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	}
 
 	/**
-	 * Start local authenticated-apply advertisement independently of the legacy
-	 * join path. ACK and legacy publication are a two-phase barrier: the first
-	 * attempt always settles independently, while readiness is promoted only
-	 * after the host releases the legacy barrier. Failed attempts leave one
+	 * Start local authenticated-apply advertisement. Readiness is promoted as
+	 * soon as the ACK lands (B12: the legacy publication this once ordered
+	 * behind a two-phase barrier is retired). Failed attempts leave one
 	 * exact-session worker retrying with capped exponential backoff.
 	 */
 	advertiseLocalCapability(properties: {
@@ -581,7 +553,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 				peerHash,
 				target: properties.target,
 				lifecycleSignal: properties.signal,
-				legacyBarrierReleased: false,
 			};
 			this._localCapabilityContextBySession.set(
 				properties.peerSession,
@@ -646,43 +617,10 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		const firstAttempt =
 			state.firstAttempt ??
 			(state.firstAttempt = this.runLocalCapabilityAdvertisement(state));
-		const advertisement = state;
 		return {
 			firstAttempt,
-			releaseLegacyBarrier: () =>
-				this.releaseLocalCapabilityLegacyBarrier(
-					advertisement.peerSession,
-					context,
-				),
+			releaseLegacyBarrier: () => {},
 		};
-	}
-
-	private releaseLocalCapabilityLegacyBarrier(
-		peerSession: object,
-		context: ReplicationInfoV2LocalCapabilityContext,
-	): void {
-		if (context.legacyBarrierReleased) {
-			return;
-		}
-		if (
-			this._localCapabilityContextBySession.get(peerSession) !== context ||
-			context.lifecycleSignal.aborted ||
-			this.deps.isClosed() ||
-			!this.deps.isPeerSessionCurrent(context.peerHash, peerSession)
-		) {
-			return;
-		}
-		context.legacyBarrierReleased = true;
-		const state = this._localCapabilityAdvertisementsByPeer.get(
-			context.peerHash,
-		);
-		if (state?.peerSession === peerSession && state.context === context) {
-			if (!this.isLocalCapabilityAdvertisementOwnerCurrent(state)) {
-				this.clearLocalCapabilityAdvertisement(state);
-				return;
-			}
-			this.promoteLocalCapabilityAdvertisement(state);
-		}
 	}
 
 	private promoteLocalCapabilityAdvertisement(
@@ -691,7 +629,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		const ready = state.acknowledgedReady;
 		if (
 			state.ready ||
-			!state.context.legacyBarrierReleased ||
 			!ready ||
 			ready.receiveEpoch !== state.receiveEpoch ||
 			ready.advertisement !== state ||
@@ -725,9 +662,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 
 	/**
 	 * Re-advertise one exact current recovery epoch from the stable membership
-	 * context captured during opening. The opening handle owns barrier release;
-	 * recovery never bypasses a legacy snapshot or role publication still in
-	 * progress.
+	 * context captured during opening.
 	 */
 	reAdvertiseLocalCapabilityForRecovery(properties: {
 		peerHash: string;
@@ -946,9 +881,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			requestsSinceCapabilityRefresh: 0,
 			requestParked: false,
 			capabilityRefreshRequired: retainedCutover,
-			legacyFallbackAmbiguous: false,
-			recentCommittedPayloads: [],
-			lastLegacyObservationAmbiguous: false,
 		};
 		this._receiveStates.set(peerHash, state);
 		const ready = this._localCapabilityReadyBySession.get(peerSession);
@@ -1231,10 +1163,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			clearTimeout(state.requestTimer);
 			state.requestTimer = undefined;
 		}
-		if (state.legacyFallbackTimer) {
-			clearTimeout(state.legacyFallbackTimer);
-			state.legacyFallbackTimer = undefined;
-		}
 		return admission;
 	}
 
@@ -1269,156 +1197,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			// worker so the exact current generation cannot become stranded.
 			this.armRequest(state, 0);
 		}
-		if (
-			currentState === state &&
-			this.isStateCurrent(state) &&
-			state.phase === "active" &&
-			state.legacyFallbackFingerprint !== undefined
-		) {
-			// A reservation also pauses compat sidecar recovery. Matching commits
-			// clear the evidence; an uncommitted or non-matching frame restores its
-			// bounded fallback without invalidating work in the host apply lane.
-			this.armLegacyFallback(state);
-		}
-	}
-
-	/**
-	 * B9 can lose its sender grant while keeping the topic session open. Its
-	 * unmatched legacy sidecar is the compatibility signal to re-handshake; a
-	 * matching V2 payload before or after the legacy copy suppresses the timer.
-	 */
-	noteLegacyAnnouncement(properties: {
-		peerHash: string;
-		peerSession: object;
-		receiveEpoch: object | null;
-		senderTransportSession: bigint;
-		transportTimestamp: bigint;
-		message: LegacyReplicationInfoMessage;
-	}): boolean {
-		const state = this._receiveStates.get(properties.peerHash);
-		if (
-			!state ||
-			state.peerSession !== properties.peerSession ||
-			state.receiveEpoch !== properties.receiveEpoch ||
-			state.senderTransportSession !== properties.senderTransportSession ||
-			!this._cutoverPeerSessions.has(properties.peerSession) ||
-			!this.isStateCurrent(state)
-		) {
-			return false;
-		}
-		const fingerprint = replicationInfoPayloadFingerprint(properties.message);
-		if (
-			state.lastCommittedTransportTimestamp !== undefined &&
-			properties.transportTimestamp < state.lastCommittedTransportTimestamp
-		) {
-			return true;
-		}
-		if (
-			state.recentCommittedPayloads.some(
-				(committed) =>
-					properties.transportTimestamp <= committed.transportTimestamp &&
-					bytesEqual(committed.fingerprint, fingerprint),
-			)
-		) {
-			return true;
-		}
-		if (state.lastLegacyObservationTimestamp !== undefined) {
-			if (
-				properties.transportTimestamp < state.lastLegacyObservationTimestamp
-			) {
-				return true;
-			}
-			if (
-				properties.transportTimestamp === state.lastLegacyObservationTimestamp
-			) {
-				if (
-					state.lastLegacyObservationAmbiguous ||
-					(state.lastLegacyObservationFingerprint !== undefined &&
-						bytesEqual(state.lastLegacyObservationFingerprint, fingerprint))
-				) {
-					return true;
-				}
-				state.lastLegacyObservationAmbiguous = true;
-			} else {
-				state.lastLegacyObservationTimestamp = properties.transportTimestamp;
-				state.lastLegacyObservationFingerprint = fingerprint.slice();
-				state.lastLegacyObservationAmbiguous = false;
-			}
-		} else {
-			state.lastLegacyObservationTimestamp = properties.transportTimestamp;
-			state.lastLegacyObservationFingerprint = fingerprint.slice();
-			state.lastLegacyObservationAmbiguous = false;
-		}
-		const reserved = this._reservedAdmissionsByPeer.get(properties.peerHash);
-		if (
-			reserved?.state === state &&
-			!bytesEqual(reserved.payloadFingerprint, fingerprint)
-		) {
-			// A legacy sidecar observed while a different V2 payload is applying
-			// cannot be erased by that commit. The transport has already ACKed the
-			// sidecar, so require one authoritative successor after release.
-			reserved.resyncAfterRelease = true;
-		}
-		if (!state.legacyFallbackFingerprint) {
-			state.legacyFallbackFingerprint = fingerprint;
-			state.legacyFallbackTimestamp = properties.transportTimestamp;
-			state.legacyFallbackAmbiguous = false;
-		} else {
-			if (!bytesEqual(state.legacyFallbackFingerprint, fingerprint)) {
-				state.legacyFallbackAmbiguous = true;
-			}
-			if (
-				state.legacyFallbackTimestamp === undefined ||
-				properties.transportTimestamp > state.legacyFallbackTimestamp
-			) {
-				state.legacyFallbackTimestamp = properties.transportTimestamp;
-			}
-		}
-		if (state.phase !== "active") {
-			if (state.requestParked) {
-				this.transitionToResync(state, {
-					force: true,
-					refreshCapability: true,
-				});
-			}
-			return true;
-		}
-		if (state.legacyFallbackTimer) {
-			return true;
-		}
-		this.armLegacyFallback(state);
-		return true;
-	}
-
-	private armLegacyFallback(state: ReplicationInfoV2ReceiveState): void {
-		if (
-			state.legacyFallbackTimer ||
-			state.phase !== "active" ||
-			state.legacyFallbackFingerprint === undefined ||
-			this._reservedAdmissionsByPeer.has(state.peerHash)
-		) {
-			return;
-		}
-		state.legacyFallbackTimer = setTimeout(() => {
-			state.legacyFallbackTimer = undefined;
-			if (this.isStateCurrent(state) && state.phase === "active") {
-				this.transitionToResync(state, {
-					force: true,
-					refreshCapability: true,
-				});
-			}
-		}, this.legacyFallbackDelayMs);
-		state.legacyFallbackTimer.unref?.();
-	}
-
-	private clearLegacyFallback(state: ReplicationInfoV2ReceiveState): void {
-		if (state.legacyFallbackTimer) {
-			clearTimeout(state.legacyFallbackTimer);
-			state.legacyFallbackTimer = undefined;
-		}
-		state.legacyFallbackFingerprint = undefined;
-		state.legacyFallbackTimestamp = undefined;
-		state.legacyFallbackAmbiguous = false;
 	}
 
 	isAdmissionCurrent(admission: ReplicationInfoV2ReceiveAdmission): boolean {
@@ -1460,26 +1238,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		state.requestsSinceCapabilityRefresh = 0;
 		state.requestParked = false;
 		state.capabilityRefreshRequired = false;
-		state.lastCommittedTransportTimestamp = admission.transportTimestamp;
-		state.recentCommittedPayloads.push({
-			fingerprint: admission.payloadFingerprint.slice(),
-			transportTimestamp: admission.transportTimestamp,
-		});
-		if (state.recentCommittedPayloads.length > 8) {
-			state.recentCommittedPayloads.shift();
-		}
-		if (
-			(state.legacyFallbackTimestamp !== undefined &&
-				admission.transportTimestamp > state.legacyFallbackTimestamp) ||
-			(!state.legacyFallbackAmbiguous &&
-				state.legacyFallbackFingerprint !== undefined &&
-				bytesEqual(
-					state.legacyFallbackFingerprint,
-					admission.payloadFingerprint,
-				))
-		) {
-			this.clearLegacyFallback(state);
-		}
 		if (state.requestTimer) {
 			clearTimeout(state.requestTimer);
 			state.requestTimer = undefined;

--- a/packages/programs/data/shared-log/src/sync/factory.ts
+++ b/packages/programs/data/shared-log/src/sync/factory.ts
@@ -14,7 +14,6 @@ import type {
 	Syncronizer,
 } from "./index.js";
 import { RatelessIBLTSynchronizer } from "./rateless-iblt.js";
-import { SimpleSyncronizer } from "./simple.js";
 
 export type CreateSyncronizerProps<R extends "u32" | "u64"> = {
 	// pass-through refs (snapshotted at open() time; stable post-open)
@@ -39,7 +38,6 @@ export type CreateSyncronizerProps<R extends "u32" | "u64"> = {
 	sendRawExchangeHeads: RawExchangeHeadsSender;
 	warn: (message: string) => void;
 	// construction-time scalars
-	compatibility?: number;
 	resolution: R;
 	sync?: SyncOptions<R>;
 	syncronizer?: SynchronizerConstructor<R>;
@@ -113,42 +111,30 @@ export function createSyncronizer<R extends "u32" | "u64">(
 			peerSupportsRawExchangeHeads: props.peerSupportsRawExchangeHeads,
 			sendRawExchangeHeads: props.sendRawExchangeHeads,
 		});
-	} else {
-		if (props.compatibility !== undefined && props.compatibility < 10) {
-			return new SimpleSyncronizer({
-				log: props.log,
-				rpc: props.rpc,
-				entryIndex: props.entryIndex,
-				coordinateToHash: props.coordinateToHash,
-				resolveHashesForSymbols,
-				resolveHashListForSymbols,
-				sync: props.sync,
-				isEntryRecentlyKnownByPeer: props.isEntryRecentlyKnownByPeer,
-				peerSupportsRawExchangeHeads: props.peerSupportsRawExchangeHeads,
-				sendRawExchangeHeads: props.sendRawExchangeHeads,
-			});
-		} else {
-			if (props.resolution === "u32") {
-				props.warn(
-					"u32 resolution is not recommended for RatelessIBLTSynchronizer",
-				);
-			}
-
-			return new RatelessIBLTSynchronizer<R>({
-				numbers: props.numbers,
-				entryIndex: props.entryIndex,
-				log: props.log,
-				rangeIndex: props.rangeIndex,
-				rpc: props.rpc,
-				coordinateToHash: props.coordinateToHash,
-				resolveHashesForSymbols,
-				resolveHashListForSymbols,
-				resolveHashNumbersInRange,
-				sync: props.sync,
-				isEntryRecentlyKnownByPeer: props.isEntryRecentlyKnownByPeer,
-				peerSupportsRawExchangeHeads: props.peerSupportsRawExchangeHeads,
-				sendRawExchangeHeads: props.sendRawExchangeHeads,
-			}) as Syncronizer<R>;
-		}
 	}
+
+	// Default synchronizer. SimpleSyncronizer stays a first-class explicit
+	// choice via the `syncronizer` option above; only the retired
+	// compatibility-coupled defaulting arm that once selected it is gone (B12).
+	if (props.resolution === "u32") {
+		props.warn(
+			"u32 resolution is not recommended for RatelessIBLTSynchronizer",
+		);
+	}
+
+	return new RatelessIBLTSynchronizer<R>({
+		numbers: props.numbers,
+		entryIndex: props.entryIndex,
+		log: props.log,
+		rangeIndex: props.rangeIndex,
+		rpc: props.rpc,
+		coordinateToHash: props.coordinateToHash,
+		resolveHashesForSymbols,
+		resolveHashListForSymbols,
+		resolveHashNumbersInRange,
+		sync: props.sync,
+		isEntryRecentlyKnownByPeer: props.isEntryRecentlyKnownByPeer,
+		peerSupportsRawExchangeHeads: props.peerSupportsRawExchangeHeads,
+		sendRawExchangeHeads: props.sendRawExchangeHeads,
+	}) as Syncronizer<R>;
 }

--- a/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
+++ b/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
@@ -193,20 +193,49 @@ describe("no legacy machinery", () => {
 		expect((log._v2Receive as any).isLegacyCutover).to.equal(undefined);
 	});
 
-	it("has zero legacy-frame construction sites on the outbound source paths", () => {
-		// Source-level outbound ratchet: constructing a legacy announcement
-		// class is a prerequisite for sending one. After B12 stage 4 the only
-		// sanctioned constructions in all of src live in
-		// replication-info-v2-receive.ts (byte-stable fingerprint
-		// canonicalization, whitelisted by decision Q4) — that single file is
-		// the whitelist; every other source file must stay clean in every
-		// open mode, including replication.ts now that the ResponseRole
-		// tombstone's decode conversion is deleted.
+	it("confines legacy-frame construction to the fingerprint sites and sanctioned pins", () => {
+		// Source+test construction ratchet (B12 stage 5, final form).
+		// Constructing a legacy announcement class is a prerequisite for
+		// sending one. The Q4 whitelist is narrowed from a whole file to the
+		// exact fingerprint-canonicalization sites: in ALL of src the only
+		// sanctioned constructions are the three byte-stable canonical
+		// mappings inside replication-info-v2-receive.ts (Full -> All,
+		// Added -> Added, Stopped -> Stopped) — never a Request or Role, and
+		// never a fourth site. Every other source file stays clean in every
+		// open mode, including replication.ts.
 		const forbidden =
 			/new\s+(RequestReplicationInfoMessage|ResponseRoleMessage|AllReplicatingSegmentsMessage|AddedReplicationSegmentMessage|StoppedReplicating)\s*\(/g;
-		const whitelist = new Set(["src/replication-info-v2-receive.ts"]);
+		const fingerprintFile = path.join("src", "replication-info-v2-receive.ts");
+		let sawFingerprintFile = false;
 		for (const file of listSourceFiles()) {
-			if (whitelist.has(file)) {
+			const source = readFileSync(path.join(process.cwd(), file), "utf8");
+			const matches = [...source.matchAll(forbidden)].map((m) => m[1]);
+			if (file === fingerprintFile) {
+				sawFingerprintFile = true;
+				expect([...matches].sort(), file).to.deep.equal([
+					"AddedReplicationSegmentMessage",
+					"AllReplicatingSegmentsMessage",
+					"StoppedReplicating",
+				]);
+				continue;
+			}
+			expect(matches, file).to.deep.equal([]);
+		}
+		expect(sawFingerprintFile).to.be.true;
+
+		// Test-side leg: tombstone constructions in test files are confined to
+		// the sanctioned codec byte pins, the sender byte-equivalence pins,
+		// the migration-8-9 legacy-injection fixture and this spec's own
+		// no-effect probes. Any other spec constructing a legacy frame is a
+		// retirement regression.
+		const testWhitelist = new Set([
+			path.join("test", "migration.spec.ts"),
+			path.join("test", "no-legacy-machinery.spec.ts"),
+			path.join("test", "replication-info-v2-codec.spec.ts"),
+			path.join("test", "replication-info-v2-sender.spec.ts"),
+		]);
+		for (const file of listTestFiles()) {
+			if (testWhitelist.has(file)) {
 				continue;
 			}
 			const source = readFileSync(path.join(process.cwd(), file), "utf8");
@@ -243,3 +272,9 @@ const listSourceFiles = (): string[] =>
 		.map((entry) => String(entry))
 		.filter((entry) => entry.endsWith(".ts"))
 		.map((entry) => path.join("src", entry));
+
+const listTestFiles = (): string[] =>
+	readdirSync(path.join(process.cwd(), "test"), { recursive: true })
+		.map((entry) => String(entry))
+		.filter((entry) => entry.endsWith(".ts"))
+		.map((entry) => path.join("test", entry));

--- a/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
+++ b/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
@@ -220,12 +220,16 @@ describe("no legacy machinery", () => {
 		// All/Added/Stopped apply handlers, the request handler, the ordering
 		// watermark, the tombstone decode conversion and the legacy-cutover
 		// probe are deleted (B12 stage 4). No source file may reference their
-		// names again — the retained legacy remnants in
-		// replication-info-v2-receive.ts (the local legacy union, fingerprint
-		// canonicalization and the noteLegacyAnnouncement sidecar) do not use
-		// these names, so this leg needs no whitelist.
+		// names again — the retained fingerprint canonicalization in
+		// replication-info-v2-receive.ts does not use these names, so this leg
+		// needs no whitelist. Stage 5 extends the list with the deleted compat
+		// getters (legacyReplicationInfoEnabled, v8Behaviour), the legacy
+		// fallback sidecar (noteLegacyAnnouncement and every legacyFallback
+		// field/timer) and the two-phase barrier state (legacyBarrierReleased);
+		// the surviving no-op handle method releaseLegacyBarrier is the ONLY
+		// sanctioned legacy-named symbol left in src.
 		const forbidden =
-			/latestReplicationInfoMessage|handleReplicationInfoAnnouncement|handleStoppedReplicating|handleRequestReplicationInfo|toReplicationInfoMessage|isLegacyCutover/g;
+			/latestReplicationInfoMessage|handleReplicationInfoAnnouncement|handleStoppedReplicating|handleRequestReplicationInfo|toReplicationInfoMessage|isLegacyCutover|legacyReplicationInfoEnabled|v8Behaviour|noteLegacyAnnouncement|legacyFallback|LegacyFallback|LEGACY_FALLBACK|legacyBarrierReleased/g;
 		for (const file of listSourceFiles()) {
 			const source = readFileSync(path.join(process.cwd(), file), "utf8");
 			const matches = [...source.matchAll(forbidden)].map((m) => m[0]);

--- a/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-codec.spec.ts
@@ -352,9 +352,14 @@ describe("receive admission replication-info V2 decode-only codec", () => {
 			await capabilityAdvertisement.firstAttempt;
 			const remoteHash = remote.hashcode();
 			const peerSession = log._peerSessions.current(remoteHash);
+			// B12: no legacy barrier — the startup advert is promoted ready as
+			// soon as its ACK lands.
 			expect(
-				log._v2Receive._localCapabilityContextBySession.get(peerSession)
-					.legacyBarrierReleased,
+				log._v2Receive._localCapabilityAdvertisementsByPeer.get(remoteHash)
+					?.ready,
+			).to.be.true;
+			expect(
+				log._v2Receive._localCapabilityContextBySession.has(peerSession),
 			).to.be.true;
 			expect(markReady.calledOnce).to.be.true;
 			const capability = sent.find(

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -53,7 +53,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		requestRetryMs?: number;
 		maxRequestRetryMs?: number;
 		requestMaxAttempts?: number;
-		legacyFallbackDelayMs?: number;
 	}) =>
 		new ReplicationInfoV2ReceiveCoordinator({
 			getSelfKey: () => self,
@@ -74,7 +73,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			requestRetryMs: options?.requestRetryMs ?? 5,
 			maxRequestRetryMs: options?.maxRequestRetryMs ?? 20,
 			requestMaxAttempts: options?.requestMaxAttempts ?? 7,
-			legacyFallbackDelayMs: options?.legacyFallbackDelayMs ?? 10,
 		});
 
 	const markLocalReady = (requestNotBeforeMs = Date.now()) =>
@@ -168,7 +166,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		]);
 	});
 
-	it("holds an ACK behind the legacy barrier and releases idempotently", async () => {
+	it("promotes an ACKed advert immediately and keeps the release handle a no-op", async () => {
 		const clock = sinon.useFakeTimers({ now: 1_000 });
 		coordinator = createCoordinator({ requestRetryMs: 5 });
 		const lifecycle = new AbortController();
@@ -183,15 +181,15 @@ describe("receive admission replication-info V2 receiver state", () => {
 		await handle.firstAttempt;
 		const advertisement =
 			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
+		// B12: there is no legacy barrier — the ACK promotes readiness at once.
 		expect(advertisement.acknowledgedReady).to.exist;
-		expect(advertisement.ready).to.be.false;
-		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
-			.false;
-		expect(sendRequest.notCalled).to.be.true;
+		expect(advertisement.ready).to.be.true;
+		const ready = coordinator._localCapabilityReadyBySession.get(currentSession);
+		expect(ready).to.exist;
 
+		// The retained handle method is a stable no-op: repeated release calls
+		// neither rotate nor invalidate the promoted grant.
 		handle.releaseLegacyBarrier();
-		const ready =
-			coordinator._localCapabilityReadyBySession.get(currentSession);
 		handle.releaseLegacyBarrier();
 		expect(
 			coordinator._localCapabilityReadyBySession.get(currentSession),
@@ -201,7 +199,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(sendRequest.calledOnce).to.be.true;
 	});
 
-	it("promotes when the ACK arrives after the legacy barrier release", async () => {
+	it("promotes when a deferred ACK finally settles", async () => {
 		const clock = sinon.useFakeTimers({ now: 1_100 });
 		const pending = pDefer<{
 			receiverTransportSession: bigint;
@@ -218,7 +216,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			receiveEpoch: currentReceiveEpoch,
 			signal: lifecycle.signal,
 		});
-		handle.releaseLegacyBarrier();
 		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
 			.false;
 		pending.resolve({
@@ -233,7 +230,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(sendRequest.calledOnce).to.be.true;
 	});
 
-	it("stops retrying after an ACK while the legacy barrier remains closed", async () => {
+	it("stops retrying once a retried ACK promotes readiness", async () => {
 		const clock = sinon.useFakeTimers({ now: 1_200 });
 		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
 		refreshLocalCapability.onSecondCall().callsFake(async () => ({
@@ -259,16 +256,18 @@ describe("receive admission replication-info V2 receiver state", () => {
 		await clock.tickAsync(5);
 		expect(refreshLocalCapability.callCount).to.equal(2);
 		expect(advertisement.acknowledgedReady).to.exist;
-		expect(advertisement.ready).to.be.false;
-		expect(advertisement.timer).to.be.undefined;
-		await clock.tickAsync(100);
-		expect(refreshLocalCapability.callCount).to.equal(2);
-		expect(sendRequest.notCalled).to.be.true;
-
-		handle.releaseLegacyBarrier();
-		await clock.tickAsync(0);
+		// B12: the retried ACK promotes immediately — no barrier holds it back,
+		// and the bounded capability worker stops retrying once ready.
 		expect(advertisement.ready).to.be.true;
+		expect(advertisement.timer).to.be.undefined;
+		await clock.tickAsync(1);
 		expect(sendRequest.calledOnce).to.be.true;
+		// The capability advert worker never restarts after promotion (the
+		// bounded REQUEST worker may still refresh a stale grant later; that
+		// path is covered by the unpark tests).
+		expect(refreshLocalCapability.callCount).to.equal(2);
+		expect(advertisement.ready).to.be.true;
+		expect(advertisement.timer).to.be.undefined;
 	});
 
 	it("parks one failed worker across a temporary receive gate closure", async () => {
@@ -307,7 +306,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(advertisement.timer).to.be.undefined;
 	});
 
-	it("keeps independent bounded capability workers and barriers for two peers", async () => {
+	it("keeps independent bounded capability workers for two peers", async () => {
 		const clock = sinon.useFakeTimers({ now: 2_000 });
 		const secondSender = key(3);
 		const sessionByPeer = new Map<string, object>();
@@ -364,16 +363,16 @@ describe("receive admission replication-info V2 receiver state", () => {
 
 		await clock.tickAsync(5);
 		expect([...attemptsByPeer.values()]).to.deep.equal([2, 2]);
+		// B12: each retried ACK promotes its own peer immediately; the workers
+		// stay per-peer bounded and independent.
 		expect(
 			[...coordinator._localCapabilityAdvertisementsByPeer.values()].every(
 				(state) =>
 					state.acknowledgedReady !== undefined &&
-					!state.ready &&
+					state.ready &&
 					state.timer === undefined,
 			),
 		).to.be.true;
-
-		handles[0].releaseLegacyBarrier();
 		expect(
 			coordinator._localCapabilityReadyBySession.has(
 				sessionByPeer.get(peerHash)!,
@@ -382,12 +381,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(
 			coordinator._localCapabilityReadyBySession.has(
 				sessionByPeer.get(secondSender.hashcode())!,
-			),
-		).to.be.false;
-		handles[1].releaseLegacyBarrier();
-		expect(
-			[...coordinator._localCapabilityAdvertisementsByPeer.values()].every(
-				(state) => state.ready,
 			),
 		).to.be.true;
 	});
@@ -630,8 +623,13 @@ describe("receive admission replication-info V2 receiver state", () => {
 			.false;
 	});
 
-	it("clears an ACKed advert when transport rotates before barrier release", async () => {
+	it("clears an advert when transport rotates before its ACK settles", async () => {
 		let localTransportSession = receiverTransportSession;
+		const pendingAck = pDefer<{
+			receiverTransportSession: bigint;
+			requestNotBeforeMs: number;
+		}>();
+		refreshLocalCapability.callsFake(() => pendingAck.promise);
 		coordinator = new ReplicationInfoV2ReceiveCoordinator({
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => localTransportSession,
@@ -654,13 +652,19 @@ describe("receive admission replication-info V2 receiver state", () => {
 			receiveEpoch: currentReceiveEpoch,
 			signal: lifecycle.signal,
 		});
-		await handle.firstAttempt;
 		const stale =
 			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
-		expect(stale.acknowledgedReady).to.exist;
 
+		// The local transport rotates while the ACK is still in flight: the
+		// settled ACK must not promote a grant bound to the rotated-away
+		// transport, and the stale advert clears instead of retrying.
 		localTransportSession++;
-		handle.releaseLegacyBarrier();
+		pendingAck.resolve({
+			receiverTransportSession,
+			requestNotBeforeMs: Date.now(),
+		});
+		await handle.firstAttempt;
+		expect(stale.acknowledgedReady).to.be.undefined;
 		expect(stale.controller.signal.aborted).to.be.true;
 		expect(coordinator._localCapabilityAdvertisementsByPeer.size).to.equal(0);
 		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
@@ -669,7 +673,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 			.be.false;
 	});
 
-	it("recovers before remote capability without bypassing the opening barrier", async () => {
+	it("recovers before remote capability and promotes on the recovery ACK", async () => {
 		const clock = sinon.useFakeTimers({ now: 5_100 });
 		refreshLocalCapability.onFirstCall().rejects(new Error("advert failed"));
 		refreshLocalCapability.onSecondCall().callsFake(async () => ({
@@ -703,6 +707,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(replacement).not.to.equal(openingAdvertisement);
 		expect(replacement.context).to.equal(openingAdvertisement.context);
 		expect(replacement.receiveEpoch).to.equal(currentReceiveEpoch);
+		// The receive gate is closed: no ACK can land, so no promotion yet.
 		expect(replacement.ready).to.be.false;
 		expect(refreshLocalCapability.calledOnce).to.be.true;
 
@@ -710,13 +715,9 @@ describe("receive admission replication-info V2 receiver state", () => {
 		await clock.tickAsync(5);
 		expect(refreshLocalCapability.callCount).to.equal(2);
 		expect(replacement.acknowledgedReady).to.exist;
-		expect(replacement.ready).to.be.false;
-		expect(observeSender()).to.be.true;
-		expect(coordinator._receiveStates.get(peerHash)?.receiverBinding).to.be
-			.undefined;
-
-		openingHandle.releaseLegacyBarrier();
+		// B12: the recovery ACK promotes immediately once the gate reopens.
 		expect(replacement.ready).to.be.true;
+		expect(observeSender()).to.be.true;
 		expect(coordinator._receiveStates.get(peerHash)?.receiverBinding).to.exist;
 		await clock.tickAsync(1);
 		expect(sendRequest.calledOnce).to.be.true;


### PR DESCRIPTION
B12 stage 5 of 5 — the cleanup that ends the legacy replication-info retirement.

**shared-log** (major — the residual always-undefined `compatibility` getter was public-reachable): the permanently-false compat getters/gates collapse to their V2/u64 branches; the caller-free legacy-fallback sidecar (`noteLegacyAnnouncement`, timers, state, and its now write-only companions) is deleted; the B8 two-phase barrier becomes a documented always-released no-op handle with its ACK/ready-gating tests converted in place; the announcement-session rotation shell is deleted outright (verified pinned by zero tests). `u32` domains and `SimpleSynchronizer` remain first-class explicit choices — the 220 parameterized sims prove it — only the compat-coupled defaulting died.

**document** (major — `Documents.compatibility`/`DocumentIndex.compatibility` and the OpenOptions member were public): internal compatibility plumbing and the compat-6 `PutWithKeyOperation` ENCODE branch are gone; DECODE is untouched (hunk-verified) and old stores stay openable, pinned by the operation-tombstone spec.

**End-state invariants, each walked by the adversarial check**: wire tombstones `[1,0]`–`[1,4]` registered and exported; `ReplicationPing` live; the dispatch-level drop block byte-identical and first; rejection-at-open intact at both layers (including value 10 and untyped callers); `allowLegacyOrderedReplacementPairs` with its live V2 caller; `_cutoverPeerSessions` retained as V2 resync memory. The source-scan ratchet now forbids legacy construction everywhere except the three whitelisted fingerprint-canonicalization sites, and gained the stage-5 symbol tokens — re-adding a compat-6 encode or a legacy-fallback timer turns it red (both verified, plus a runtime default-write pin).

Repo-wide: exactly two functional `.compatibility` readers remain — the two sanctioned rejection reads. Validation: per-commit sets green, final tip 334 + 220 + 325 passing, fence-ratchet 13/13, shard-coverage 67 describes, root lint clean.