### PR TITLE
test(document): assert the approximate count against the estimator margin

### DIFF
--- a/packages/programs/data/document/document/test/index.spec.ts
+++ b/packages/programs/data/document/document/test/index.spec.ts
@@ -20108,17 +20108,27 @@ describe("index", () => {
 				);
 
 				await waitForResolved(async () => {
-					const { estimate: approxCount1 } = await store1.docs.count({
+					const approxCount1 = await store1.docs.count({
 						approximate: true,
 					});
-					const { estimate: approxCount2 } = await store2.docs.count({
+					const approxCount2 = await store2.docs.count({
 						approximate: true,
 					});
 					const approxCount3 = await store3.docs.count({ approximate: true });
 					const localCount3 = await store3.docs.count();
 
-					expect(approxCount1).to.be.within(count * 0.9, count * 1.1);
-					expect(approxCount2).to.be.within(count * 0.9, count * 1.1);
+					// The estimator is probabilistic; use the provided 95% margin, scaled
+					// up to ~99.9% to avoid CI flakes while still detecting regressions.
+					const assertWithinMargin = (result: CountEstimate) => {
+						expect(result.errorMargin).to.not.be.undefined;
+						const margin = Math.max(0.15, result.errorMargin! * (3.29 / 1.96));
+						expect(result.estimate).to.be.within(
+							count * (1 - margin),
+							count * (1 + margin),
+						);
+					};
+					assertWithinMargin(approxCount1);
+					assertWithinMargin(approxCount2);
 					expect(approxCount3.errorMargin).to.be.undefined;
 					expect(approxCount3.estimate).to.eq(localCount3);
 				});


### PR DESCRIPTION
"index › returns approximate count" failed master CI on the release commit with `expected 1102 to be within 900..1100` — a 0.2% miss.

The count estimator reports a **95% confidence** relative margin (`1.96 * sqrt(...)`, program.ts:5578-5596), so a hardcoded ±10% band fails by construction at some rate: it is neither tied to the estimator's actual uncertainty nor wide enough to be rare. The test's own two siblings ("with query", "with deletions") already solved this — they assert against `result.errorMargin` scaled from 1.96σ to 3.29σ (~99.9%) with a 0.15 floor. This test was the straggler left on the fixed band.

This aligns it with that convention: same helper shape, same scaling, asserting the returned margin instead of a guess. It still fails on a genuine estimation regression — and now adapts if coverage changes — while removing a per-push coin flip from the release train.

Measured before changing anything: 8/8 local passes (the failure is a CI-side tail event), and the same-commit CI rerun went green. Full document `index` suite: 327 passing.