### PR TITLE
chore: close the fence collapse and strengthen the post-B12 guards

### DIFF
--- a/.changeset/post-b12-guard-strength.md
+++ b/.changeset/post-b12-guard-strength.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Post-B12 residue cleanup. Internal only — no runtime behavior changes and nothing removed from the package's public entry.
+
+Retires the last three legacy-named symbols: `revokePeerCapability`'s `reopenLegacy` parameter (it defaulted to true, had no else-arm and no caller ever overrode it; the body it guarded now runs unconditionally), the no-op `releaseLegacyBarrier` handle method left behind by the two-phase capability barrier, and `allowLegacyOrderedReplacementPairs`, which is renamed to `allowOrderedReplacementPairs` because the relaxation is not legacy machinery but a live rolling-upgrade allowance on the V2 Added path. All three live on private methods or on types outside the `.` export map, so the emitted public `.d.ts` is unchanged.
+
+Also deletes write-only state with no readers anywhere in the repo or the native bindings: `SharedLog._replicatorsReconciled` (declaration, three writes, and the after-open guard whose entire body was one of those writes) and `PIDReplicationController.prevMemoryUsage` / `prevTotalFactor`. The PID fields differ from the rest of this change in that they ARE visible in the emitted `.d.ts` — `PIDReplicationController` is reachable through a public field — so a type-level consumer reading them would break. Patch is still the honest level for fields that were never written to be read, but the visibility is called out rather than glossed. Four inert orphan bindings in the deprecated `role.ts` (the free `overlaps` helper, which is unrelated to the `ReplicationRangeIndexable` method of the same name, and the three `*_TYPE_VARIANT` byte constants) go with them; `@variant` registration depends on the decorated classes and on `replication.ts` importing the module, not on these bindings, and `role.js` is not re-exported from the package entry.

--- a/packages/programs/data/document/document/test/operation-tombstone.spec.ts
+++ b/packages/programs/data/document/document/test/operation-tombstone.spec.ts
@@ -159,7 +159,13 @@ describe("document operation tombstones", () => {
 			});
 			const payload = await reloaded.getPayloadValue();
 			expect(payload).to.be.instanceOf(PutOperation);
-			expect(payload).to.not.be.instanceOf(PutWithKeyOperation);
+			// PutOperation and PutWithKeyOperation are @variant SIBLINGS (tags 3
+			// and 0), not a subclass relation, so `not.instanceOf` here is
+			// trivially true and pins nothing. Assert the wire tag instead: byte 0
+			// is Operation's own variant, byte 1 is the concrete operation tag.
+			// PutWithKeyOperation's frozen tag pair is [0, 0]; a default put must
+			// never produce it.
+			expect([...serialize(payload).slice(0, 2)]).to.deep.equal([0, 3]);
 		});
 
 		it("has zero deprecated-operation construction sites in src", () => {
@@ -181,6 +187,40 @@ describe("document operation tombstones", () => {
 				const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
 				expect(matches, file).to.deep.equal([]);
 			}
+		});
+
+		it("has zero deprecated-operation construction sites in test", () => {
+			// Test-side leg, mirroring shared-log's no-legacy-machinery ratchet.
+			// The src leg alone cannot stop a spec from re-teaching the codebase
+			// to write the deprecated layouts: a new test that constructs one
+			// would look like sanctioned coverage. Only THIS spec is allowed to
+			// construct them, and only to seed the old-store decode fixture.
+			const forbidden =
+				/new\s+(PutWithKeyOperation|DeleteByStringKeyOperation)\s*\(/g;
+			const whitelist = new Set([
+				path.join("test", "operation-tombstone.spec.ts"),
+			]);
+			const testFiles = readdirSync(path.join(process.cwd(), "test"), {
+				recursive: true,
+			})
+				.map((entry) => String(entry))
+				.filter((entry) => entry.endsWith(".ts"))
+				.map((entry) => path.join("test", entry));
+			expect(testFiles.length).to.be.greaterThan(0);
+			let sawWhitelistedFile = false;
+			for (const file of testFiles) {
+				const source = readFileSync(path.join(process.cwd(), file), "utf8");
+				const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
+				if (whitelist.has(file)) {
+					// The sanctioned spec must actually still construct them,
+					// otherwise the whitelist entry is stale cover for nothing.
+					expect(matches.length, file).to.be.greaterThan(0);
+					sawWhitelistedFile = true;
+					continue;
+				}
+				expect(matches, file).to.deep.equal([]);
+			}
+			expect(sawWhitelistedFile).to.be.true;
 		});
 	});
 });

--- a/packages/programs/data/shared-log/src/checked-prune.ts
+++ b/packages/programs/data/shared-log/src/checked-prune.ts
@@ -76,6 +76,14 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	readonly retries = new Map<string, CheckedPruneRetryState<T, R>>();
 	private readonly sessions = new Map<string, CheckedPruneSession<T, R>>();
 	private readonly grantSends = new Map<string, Set<Promise<void>>>();
+	// Per-peer refcount of in-flight removal fences; while non-zero the peer is
+	// withheld from the exact-replicator set (see fencePeerRemoval /
+	// isPeerRemovalFenced).
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): a concurrency-DEPTH
+	// refcount held across removal lanes that may span a peer reconnect, so
+	// neither a session token (it would reset mid-drain) nor lifecycle identity
+	// (it cannot count open lanes) can replace it.
 	private readonly peerRemovalFences = new Map<string, number>();
 	private readonly restartReservations = new Map<string, object>();
 	private readonly candidateTokens = new Map<string, object>();
@@ -88,6 +96,10 @@ export class CheckedPruneCoordinator<T, R extends "u32" | "u64"> {
 	// a fresh coordinator); deliberately NOT touched by close() — the release
 	// closures drain it, matching the legacy host counter which was reset
 	// only at open.
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): a concurrency-DEPTH
+	// counter of re-entrant removals — identity tells you which coordinator a
+	// continuation started under, never how many removals are in flight now.
 	private _checkedPruneRemoveBlocksLocalRangeMutationAdmission = 0;
 
 	/** ≡ the legacy inc / `finally`-dec pair around the admitted lower-log

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2017,7 +2017,6 @@ export class SharedLog<
 
 	uniqueReplicators!: Set<string>;
 	private _replicatorJoinEmitted!: Set<string>;
-	private _replicatorsReconciled!: boolean;
 
 	/* private _totalParticipation!: number; */
 
@@ -3658,7 +3657,6 @@ export class SharedLog<
 		this.recentlyRebalanced = new Cache<string>({ max: 1e4, ttl: 1e5 });
 		this.uniqueReplicators = new Set();
 		this._replicatorJoinEmitted = new Set();
-		this._replicatorsReconciled = false;
 		this._liveness = this.createReplicatorLivenessMonitor();
 		this._v2Receive = this.createReplicationInfoV2ReceiveCoordinator();
 		this._v2Send = this.createReplicationInfoV2SendCoordinator();
@@ -14237,7 +14235,6 @@ export class SharedLog<
 
 		this.uniqueReplicators = new Set();
 		this._replicatorJoinEmitted = new Set();
-		this._replicatorsReconciled = false;
 		// Deserialized instances never ran the constructor; create the monitor and
 		// coordinator lazily on first open. Reopens keep the SAME instances so
 		// stale async continuations observe resets via property lookup.
@@ -15515,16 +15512,8 @@ export class SharedLog<
 		const existingSubscribersPromise = this.node.services.pubsub.getSubscribers(
 			this.topic,
 		);
-		const replicationLifecycleController =
-			this._instanceLifecycle?.membershipLifecycleController;
-
 		// We do this here, because these calls requires this.closed == false
 		void this.pruneOfflineReplicators()
-			.then(() => {
-				if (this.isReplicationLifecycleActive(replicationLifecycleController)) {
-					this._replicatorsReconciled = true;
-				}
-			})
 			.catch((error) => {
 				if (isNotStartedError(error as Error)) {
 					return;

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -6779,7 +6779,7 @@ export class SharedLog<
 			rebalance?: boolean;
 			checkDuplicates?: boolean;
 			timestamp?: number;
-			allowLegacyOrderedReplacementPairs?: boolean;
+			allowOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
 			onDurableApplyCommitted?: () => boolean | void;
 			shouldApply?: () => boolean;
@@ -6821,7 +6821,7 @@ export class SharedLog<
 			checkDuplicates,
 			timestamp: ts,
 			rebalance,
-			allowLegacyOrderedReplacementPairs,
+			allowOrderedReplacementPairs,
 			onConfirmedDurableStateChanged,
 			onDurableApplyCommitted,
 			shouldApply,
@@ -6830,7 +6830,7 @@ export class SharedLog<
 			rebalance?: boolean;
 			checkDuplicates?: boolean;
 			timestamp?: number;
-			allowLegacyOrderedReplacementPairs?: boolean;
+			allowOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
 			onDurableApplyCommitted?: () => boolean | void;
 			shouldApply?: () => boolean;
@@ -6869,17 +6869,19 @@ export class SharedLog<
 			incomingRangeCountsById.set(range.idString, count);
 			if (
 				count > 1 &&
-				(!allowLegacyOrderedReplacementPairs || reset === true || count > 2)
+				(!allowOrderedReplacementPairs || reset === true || count > 2)
 			) {
 				throw new Error(
 					`Duplicate replication range id in announcement: ${range.idString}`,
 				);
 			}
-			// Released peers represented a non-reset replacement as the retired
-			// geometry followed by the current geometry under the same id. The
-			// sender is already authorized to replace that id with the final item,
-			// so collapsing an exact two-item incremental pair to its last item
-			// preserves rolling-upgrade compatibility without broadening authority.
+			// Rolling-upgrade relaxation on the live V2 Added path: a peer may
+			// still express a non-reset replacement as the retired geometry
+			// followed by the current geometry under one id. The sender is already
+			// authorized to replace that id with the final item, so collapsing an
+			// EXACT two-item incremental pair to its last item accepts the older
+			// wire shape without broadening authority. Deliberately narrow — reset
+			// announcements and any run longer than two still fail as duplicates.
 			incomingRangesById.set(range.idString, range);
 		}
 		const incomingRanges = [...incomingRangesById.values()];
@@ -19652,7 +19654,7 @@ export class SharedLog<
 								reset: msg instanceof FullReplicationInfoV2Message,
 								checkDuplicates: true,
 								timestamp: Number(context.message.header.timestamp),
-								allowLegacyOrderedReplacementPairs:
+								allowOrderedReplacementPairs:
 									msg instanceof AddedReplicationInfoV2Message,
 								shouldApply: () => {
 									mutationGateChecked = true;
@@ -19760,7 +19762,6 @@ export class SharedLog<
 			this._v2Receive.release(admission);
 		}
 	}
-
 
 	async calculateTotalParticipation(options?: { sum?: boolean }) {
 		if (options?.sum) {
@@ -23063,7 +23064,11 @@ export class SharedLog<
 			}
 			const receiveEpoch = this._peerSessions.receiveEpoch(peerHash);
 			if (
-				!this._v2Receive.isRequestParked({ peerHash, peerSession, receiveEpoch })
+				!this._v2Receive.isRequestParked({
+					peerHash,
+					peerSession,
+					receiveEpoch,
+				})
 			) {
 				// Active, or a bounded request cycle is still running its own
 				// exponential retries. Keep polling for the next park.

--- a/packages/programs/data/shared-log/src/instance-lifecycle.ts
+++ b/packages/programs/data/shared-log/src/instance-lifecycle.ts
@@ -66,10 +66,19 @@ export class InstanceLifecycle {
 	// code. Incremented synchronously with leader-cache invalidation so the
 	// handler can detect whether its pre-join plan needs one fresh
 	// post-persist audit.
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): a sub-generation
+	// WITHIN one lifecycle — it advances while the lifecycle identity is
+	// deliberately unchanged, so an identity/session token cannot tell a
+	// pre-invalidation plan from a post-invalidation one.
 	public _receiveOwnershipRevision = 0;
 	// Count of ownership-changing range mutations from queue admission
 	// through settlement, including mutations already pending when a receive
 	// starts.
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): a concurrency-DEPTH
+	// refcount, not a staleness token — identity answers "which generation
+	// started this?", never "how many mutation lanes are open right now?".
 	public _receiveOwnershipMutationAdmissions = 0;
 
 	// ---- stage 4: physically owned controllers (moved from SharedLog) ----

--- a/packages/programs/data/shared-log/src/peer-session.ts
+++ b/packages/programs/data/shared-log/src/peer-session.ts
@@ -131,6 +131,11 @@ export class PeerSessionRegistry {
 	// peer stays subscribed), and it must also fence a peer that never had a
 	// session. Unlike sessions this map IS cleared at _close (see
 	// clearReceiveEpochsForClose) and replaced at open.
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): the per-PEER lifetime
+	// above is the whole mechanism — a session token would rotate at exactly
+	// the moments this map must survive, and could not fence a session-less
+	// peer at all.
 	_replicationInfoReceiveEpochByPeer!: Map<string, object>;
 	// Moved from SharedLog (fence B6, same name — the sanctioned file-to-file
 	// ratchet move). Refcount of in-flight destructive peer cleanups: while
@@ -140,6 +145,10 @@ export class PeerSessionRegistry {
 	// reconnect may rotate the session; a fresh session with a zero gate
 	// would reopen receive admission mid-drain. The map instance is replaced
 	// only at open (resetForOpen) and cleared in place at _close.
+	//
+	// PERMANENT (fence census closed NO-GO 2026-08-12): both structural
+	// reasons at once — a concurrency-DEPTH refcount whose per-PEER lifetime
+	// deliberately spans the session rotation a reconnect causes mid-drain.
 	_receiveCleanupGateByPeer!: Map<string, number>;
 	// Moved from SharedLog (fence B5, same name). Peers whose replication-info
 	// is fenced: added when a departure/unsubscribe rotation or a reconnect

--- a/packages/programs/data/shared-log/src/pid.ts
+++ b/packages/programs/data/shared-log/src/pid.ts
@@ -3,8 +3,6 @@ const MIN_MEMORY_HEADROOM_BALANCE_SCALER = 0.25;
 export class PIDReplicationController {
 	integral!: number;
 	prevError!: number;
-	prevMemoryUsage!: number;
-	prevTotalFactor!: number;
 	kp: number;
 	ki: number;
 	kd: number;
@@ -41,9 +39,6 @@ export class PIDReplicationController {
 	}) {
 		let { memoryUsage, totalFactor, peerCount, cpuUsage, currentFactor } =
 			properties;
-
-		this.prevTotalFactor = totalFactor;
-		this.prevMemoryUsage = memoryUsage;
 
 		const estimatedTotalSize =
 			currentFactor > 0 ? memoryUsage / currentFactor : 1e5;
@@ -238,6 +233,5 @@ export class PIDReplicationController {
 	reset() {
 		this.prevError = 0;
 		this.integral = 0;
-		this.prevMemoryUsage = 0;
 	}
 }

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -84,12 +84,6 @@ type LocalCapabilityReadyProperties = {
 
 export type ReplicationInfoV2LocalCapabilityAdvertisementHandle = {
 	firstAttempt: Promise<void>;
-	/**
-	 * B12: the two-phase legacy barrier is retired — an ACKed advert promotes
-	 * readiness immediately. Retained as a no-op so the handle shape (and the
-	 * tests that drive it) stay stable.
-	 */
-	releaseLegacyBarrier(): void;
 };
 
 export type ReplicationInfoV2LocalCapabilityContext = {
@@ -203,6 +197,14 @@ export type ReplicationInfoV2ReceiveDeps = {
  */
 export class ReplicationInfoV2ReceiveCoordinator {
 	_receiveStates!: Map<string, ReplicationInfoV2ReceiveState>;
+	/**
+	 * Post-B12 V2 resync memory: sessions that have already taken one full
+	 * replication-info snapshot. Two load-bearing reads, both in
+	 * observeCapability: phase selection (a remembered session opens in
+	 * "resync" instead of "awaiting-full"), and capability refresh (the
+	 * preserveCutover decision, which keeps the memory only when a re-advert
+	 * arrives under the same session with a ready sender).
+	 */
 	_cutoverPeerSessions!: WeakSet<object>;
 	_localCapabilityReadyBySession!: WeakMap<object, LocalCapabilityReady>;
 	_localCapabilityContextBySession!: WeakMap<
@@ -292,15 +294,17 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	}
 
 	/** Revoke an unauthenticated or downgraded capability generation. */
-	revokePeerCapability(peerHash: string, reopenLegacy = true): void {
+	revokePeerCapability(peerHash: string): void {
 		const state = this._receiveStates.get(peerHash);
 		if (!state) {
 			return;
 		}
 		this.clearState(state);
-		if (reopenLegacy) {
-			this._cutoverPeerSessions.delete(state.peerSession);
-		}
+		// Unconditional: the revoked session must lose its resync memory so a
+		// re-advert starts from the first phase again. (This used to sit behind
+		// an opt-out parameter that defaulted to true, had no else-arm, and that
+		// no caller ever overrode.)
+		this._cutoverPeerSessions.delete(state.peerSession);
 	}
 
 	private clearState(state: ReplicationInfoV2ReceiveState): void {
@@ -531,7 +535,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		) {
 			return {
 				firstAttempt: Promise.resolve(),
-				releaseLegacyBarrier: () => {},
 			};
 		}
 		let context = this._localCapabilityContextBySession.get(
@@ -545,7 +548,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		) {
 			return {
 				firstAttempt: Promise.resolve(),
-				releaseLegacyBarrier: () => {},
 			};
 		}
 		if (!context) {
@@ -584,7 +586,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		) {
 			return {
 				firstAttempt: Promise.resolve(),
-				releaseLegacyBarrier: () => {},
 			};
 		}
 		if (!state) {
@@ -619,7 +620,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			(state.firstAttempt = this.runLocalCapabilityAdvertisement(state));
 		return {
 			firstAttempt,
-			releaseLegacyBarrier: () => {},
 		};
 	}
 

--- a/packages/programs/data/shared-log/src/role.ts
+++ b/packages/programs/data/shared-log/src/role.ts
@@ -6,18 +6,9 @@
 import { field, variant, vec } from "@dao-xyz/borsh";
 import { MAX_U32, denormalizer } from "./integers.js";
 
-export const overlaps = (x1: number, x2: number, y1: number, y2: number) => {
-	if (x1 <= y2 && y1 <= x2) {
-		return true;
-	}
-	return false;
-};
-
 export abstract class Role {
 	abstract equals(other: Role): boolean;
 }
-
-export const NO_TYPE_VARIANT = new Uint8Array([0]);
 
 @variant(0)
 export class NoType extends Role {
@@ -26,16 +17,12 @@ export class NoType extends Role {
 	}
 }
 
-export const OBSERVER_TYPE_VARIANT = new Uint8Array([1]);
-
 @variant(1)
 export class Observer extends Role {
 	equals(other: Role) {
 		return other instanceof Observer;
 	}
 }
-
-export const REPLICATOR_TYPE_VARIANT = new Uint8Array([2]);
 
 const denormalizeru32 = denormalizer("u32");
 export class RoleReplicationSegment {

--- a/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
+++ b/packages/programs/data/shared-log/test/no-legacy-machinery.spec.ts
@@ -1,7 +1,7 @@
-import { readFileSync, readdirSync } from "fs";
-import path from "path";
 import { TestSession } from "@peerbit/test-utils";
 import { expect } from "chai";
+import { readFileSync, readdirSync } from "fs";
+import path from "path";
 import sinon from "sinon";
 import {
 	AddedReplicationSegmentMessage,
@@ -118,8 +118,9 @@ describe("no legacy machinery", () => {
 
 		// Positive control: the subscription-change seam announced the
 		// replicator's state through the V2 lane...
-		expect(sent1.some((message) => message instanceof FullReplicationInfoV2Message))
-			.to.be.true;
+		expect(
+			sent1.some((message) => message instanceof FullReplicationInfoV2Message),
+		).to.be.true;
 		// ...and no legacy frame crossed the wire from either side.
 		expect(sent1.filter(isLegacyFrame)).to.have.length(0);
 		expect(sent2.filter(isLegacyFrame)).to.have.length(0);
@@ -254,15 +255,75 @@ describe("no legacy machinery", () => {
 		// needs no whitelist. Stage 5 extends the list with the deleted compat
 		// getters (legacyReplicationInfoEnabled, v8Behaviour), the legacy
 		// fallback sidecar (noteLegacyAnnouncement and every legacyFallback
-		// field/timer) and the two-phase barrier state (legacyBarrierReleased);
-		// the surviving no-op handle method releaseLegacyBarrier is the ONLY
-		// sanctioned legacy-named symbol left in src.
+		// field/timer) and the two-phase barrier state (legacyBarrierReleased).
+		// Names without a "legacy" segment are what make this leg irreducible;
+		// the legacy-NAMED ones are also covered by the identifier scan below.
 		const forbidden =
 			/latestReplicationInfoMessage|handleReplicationInfoAnnouncement|handleStoppedReplicating|handleRequestReplicationInfo|toReplicationInfoMessage|isLegacyCutover|legacyReplicationInfoEnabled|v8Behaviour|noteLegacyAnnouncement|legacyFallback|LegacyFallback|LEGACY_FALLBACK|legacyBarrierReleased/g;
 		for (const file of listSourceFiles()) {
 			const source = readFileSync(path.join(process.cwd(), file), "utf8");
 			const matches = [...source.matchAll(forbidden)].map((m) => m[0]);
 			expect(matches, file).to.deep.equal([]);
+		}
+	});
+
+	it("has zero legacy-named identifiers in src", () => {
+		// This used to be a prose claim in the comment above ("the surviving
+		// no-op handle method releaseLegacyBarrier is the ONLY sanctioned
+		// legacy-named symbol left in src"), and it was wrong — three survived.
+		// A claim about which names remain has to be enforced, not asserted, so
+		// here it is as a scan with an EMPTY allowlist: no shared-log source
+		// file may declare or reference ANY identifier carrying a legacy
+		// segment. Retiring one is now the only way to keep this green.
+		//
+		// Identifier-level on purpose. The alternatives cover every casing the
+		// retired symbols actually used:
+		//   xxxLegacyYyy  camel/Pascal with an interior or trailing segment
+		//                 (releaseLegacyBarrier, isLegacyCutover, reopenLegacy)
+		//   LegacyYyy     Pascal STARTING with the segment (LegacyFallback) —
+		//                 a leading-char-required pattern alone would miss it
+		//   legacyYyy     lower camel (legacyFallback, legacy_fallback)
+		//   LEGACY_YYY    screaming snake (LEGACY_FALLBACK)
+		// The bare prose word "legacy"/"Legacy" is deliberately NOT matched:
+		// every alternative requires an adjacent identifier segment. That is
+		// what makes the empty allowlist achievable — src comments discuss
+		// legacy behavior freely, they just may not name a legacy symbol.
+		const legacyIdentifier =
+			/\b[A-Za-z0-9_$]+Legacy[A-Za-z0-9_$]*|\bLegacy[A-Za-z0-9_$]+|\blegacy[A-Z_$][A-Za-z0-9_$]*|\bLEGACY_[A-Z0-9_$]+/g;
+		const allowlist = new Set<string>();
+		expect(allowlist.size, "the allowlist must stay empty").to.equal(0);
+		let scanned = 0;
+		for (const file of listSourceFiles()) {
+			const source = readFileSync(path.join(process.cwd(), file), "utf8");
+			const matches = [...source.matchAll(legacyIdentifier)]
+				.map((m) => m[0])
+				.filter((name) => !allowlist.has(name));
+			expect(matches, file).to.deep.equal([]);
+			scanned++;
+		}
+		expect(scanned).to.be.greaterThan(0);
+
+		// The scan must be able to fail: prove the pattern catches each shape
+		// (and that prose does not trip it) rather than trusting the empty
+		// result above.
+		const matchesOf = (probe: string) =>
+			[...probe.matchAll(legacyIdentifier)].map((m) => m[0]);
+		for (const shape of [
+			"releaseLegacyBarrier",
+			"reopenLegacy",
+			"allowLegacyOrderedReplacementPairs",
+			"LegacyFallback",
+			"legacyFallback",
+			"LEGACY_FALLBACK",
+		]) {
+			expect(matchesOf(shape), shape).to.deep.equal([shape]);
+		}
+		for (const prose of [
+			"legacy",
+			"the legacy receive path is retired",
+			"Legacy requests used to bootstrap the map",
+		]) {
+			expect(matchesOf(prose), prose).to.deep.equal([]);
 		}
 	});
 });

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -166,7 +166,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 		]);
 	});
 
-	it("promotes an ACKed advert immediately and keeps the release handle a no-op", async () => {
+	it("promotes an ACKed advert immediately and holds the grant stable", async () => {
 		const clock = sinon.useFakeTimers({ now: 1_000 });
 		coordinator = createCoordinator({ requestRetryMs: 5 });
 		const lifecycle = new AbortController();
@@ -184,18 +184,19 @@ describe("receive admission replication-info V2 receiver state", () => {
 		// B12: there is no legacy barrier — the ACK promotes readiness at once.
 		expect(advertisement.acknowledgedReady).to.exist;
 		expect(advertisement.ready).to.be.true;
-		const ready = coordinator._localCapabilityReadyBySession.get(currentSession);
+		const ready =
+			coordinator._localCapabilityReadyBySession.get(currentSession);
 		expect(ready).to.exist;
 
-		// The retained handle method is a stable no-op: repeated release calls
-		// neither rotate nor invalidate the promoted grant.
-		handle.releaseLegacyBarrier();
-		handle.releaseLegacyBarrier();
+		// Once promoted the grant is stable: draining the timer queue neither
+		// re-arms the advert worker nor rotates the ready record.
+		await clock.tickAsync(1);
+		expect(refreshLocalCapability.calledOnce).to.be.true;
+		expect(advertisement.timer).to.be.undefined;
 		expect(
 			coordinator._localCapabilityReadyBySession.get(currentSession),
 		).to.equal(ready);
 		expect(advertisement.ready).to.be.true;
-		await clock.tickAsync(1);
 		expect(sendRequest.calledOnce).to.be.true;
 	});
 
@@ -286,7 +287,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: lifecycle.signal,
 		});
 		await handle.firstAttempt;
-		handle.releaseLegacyBarrier();
 		const advertisement =
 			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
 
@@ -416,13 +416,11 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: newLifecycle.signal,
 		});
 		await replacementHandle.firstAttempt;
-		replacementHandle.releaseLegacyBarrier();
 		const replacement =
 			coordinator._localCapabilityAdvertisementsByPeer.get(peerHash)!;
 		expect(replacement.peerSession).to.equal(replacementSession);
 		expect(replacement.ready).to.be.true;
 
-		oldHandle.releaseLegacyBarrier();
 		oldAck.resolve({
 			receiverTransportSession,
 			requestNotBeforeMs: Date.now(),
@@ -474,7 +472,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		await replacement.firstAttempt;
 		expect(replacement.acknowledgedReady).to.exist;
 
-		oldHandle.releaseLegacyBarrier();
 		expect(replacement.ready).to.be.true;
 		const replacementReady =
 			coordinator._localCapabilityReadyBySession.get(peerSession);
@@ -517,7 +514,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: oldLifecycle.signal,
 		});
 		oldLifecycle.abort();
-		staleHandle.releaseLegacyBarrier();
 		pending.resolve({
 			receiverTransportSession,
 			requestNotBeforeMs: Date.now(),
@@ -537,7 +533,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: currentLifecycle.signal,
 		});
 		await currentHandle.firstAttempt;
-		currentHandle.releaseLegacyBarrier();
 		expect(coordinator._localCapabilityReadyBySession.has(currentSession)).to.be
 			.true;
 	});
@@ -613,7 +608,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(stale.timer).to.exist;
 
 		localTransportSession++;
-		handle.releaseLegacyBarrier();
 		await clock.tickAsync(5);
 		expect(refreshLocalCapability.calledOnce).to.be.true;
 		expect(stale.controller.signal.aborted).to.be.true;
@@ -737,7 +731,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: lifecycle.signal,
 		});
 		await openingHandle.firstAttempt;
-		openingHandle.releaseLegacyBarrier();
 
 		currentReceiveEpoch = {};
 		expect(
@@ -785,7 +778,6 @@ describe("receive admission replication-info V2 receiver state", () => {
 			signal: lifecycle.signal,
 		});
 		await openingHandle.firstAttempt;
-		openingHandle.releaseLegacyBarrier();
 		expect(observeSender()).to.be.true;
 		const state = coordinator._receiveStates.get(peerHash)!;
 		const full = new FullReplicationInfoV2Message({

--- a/packages/programs/data/shared-log/test/replication-tombstone-registration.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-tombstone-registration.spec.ts
@@ -16,12 +16,28 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-// Frozen wire bytes. Identical literals to the codec suite's tombstone pin
-// ("keeps every legacy replication-info variant tag byte-identical"); the
-// bytes must never change again.
+// Frozen wire bytes. The ResponseRoleMessage/Observer row is the identical
+// literal to the codec suite's tombstone pin ("keeps every legacy
+// replication-info variant tag byte-identical"); the bytes must never change
+// again.
+//
+// ResponseRoleMessage carries a nested Role, so ONE message row does not cover
+// its decode surface: each Role variant is separately @variant-registered and
+// separately reachable from persisted frames. NoType in particular has zero
+// references anywhere outside its own declaration — an unpinned decode path is
+// the only thing that keeps it registered, which is exactly the state in which
+// a class quietly disappears. All three variants are pinned here.
+//
+// Third tuple element = expected nested Role class, where the row has one.
 const FROZEN_TOMBSTONES = [
 	["000100", "RequestReplicationInfoMessage"],
-	["0001010101", "ResponseRoleMessage"],
+	["0001010100", "ResponseRoleMessage", "NoType"],
+	["0001010101", "ResponseRoleMessage", "Observer"],
+	[
+		"00010101020100000000000000000000000000000000000000",
+		"ResponseRoleMessage",
+		"Replicator",
+	],
 	["00010200000000", "AllReplicatingSegmentsMessage"],
 	["00010300000000", "AddedReplicationSegmentMessage"],
 	["00010400000000", "StoppedReplicating"],
@@ -44,7 +60,8 @@ const entry = await import("@peerbit/shared-log");
 // import so this stays a pure package-entry consumer.
 const TransportMessage = Object.getPrototypeOf(entry.RequestReplicationInfoMessage);
 const cases = ${JSON.stringify(FROZEN_TOMBSTONES)};
-for (const [hex, expectedName] of cases) {
+for (const [hex, expectedName, expectedRoleName] of cases) {
+	const label = expectedRoleName ? expectedName + "/" + expectedRoleName : expectedName;
 	const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
 	const decoded = deserialize(bytes, TransportMessage);
 	if (decoded.constructor.name !== expectedName) {
@@ -52,13 +69,18 @@ for (const [hex, expectedName] of cases) {
 			"tombstone " + hex + " decoded to " + decoded.constructor.name,
 		);
 	}
+	if (expectedRoleName && decoded.role?.constructor?.name !== expectedRoleName) {
+		throw new Error(
+			"tombstone " + hex + " decoded role " + decoded.role?.constructor?.name,
+		);
+	}
 	const reserialized = Buffer.from(serialize(decoded)).toString("hex");
 	if (reserialized !== hex) {
 		throw new Error(
-			"tombstone " + expectedName + " reserialized to " + reserialized,
+			"tombstone " + label + " reserialized to " + reserialized,
 		);
 	}
-	console.log(expectedName + " OK");
+	console.log(label + " OK");
 }
 `;
 		const { stdout } = await execFileAsync(
@@ -66,8 +88,10 @@ for (const [hex, expectedName] of cases) {
 			["--input-type=module", "-e", script],
 			{ cwd: packageRoot, timeout: 45_000 },
 		);
-		for (const [, expectedName] of FROZEN_TOMBSTONES) {
-			expect(stdout).to.include(`${expectedName} OK`);
+		for (const [, expectedName, expectedRoleName] of FROZEN_TOMBSTONES) {
+			expect(stdout).to.include(
+				`${expectedRoleName ? `${expectedName}/${expectedRoleName}` : expectedName} OK`,
+			);
 		}
 	});
 });

--- a/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
+++ b/packages/programs/data/shared-log/test/replicator-liveness.spec.ts
@@ -4,10 +4,7 @@ import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
 import pDefer from "p-defer";
 import sinon from "sinon";
-import {
-	ReplicationPingMessage,
-	RequestReplicationInfoMessage,
-} from "../src/replication.js";
+import { ReplicationPingMessage } from "../src/replication.js";
 import { EventStore } from "./utils/stores/index.js";
 
 type LivenessTestStore = EventStore<string, any>;
@@ -110,29 +107,33 @@ describe("waitForReplicator liveness", () => {
 		const hooks = getLivenessTestHooks(db0);
 		const originalSend = db0.log.rpc.send.bind(db0.log.rpc);
 		let pingFailuresLeft = 1;
-		let failRecoveryRequests = true;
 		db0.log.rpc.send = async (...args: Parameters<typeof originalSend>) => {
 			const [message] = args;
 			if (message instanceof ReplicationPingMessage && pingFailuresLeft-- > 0) {
 				throw new Error("synthetic ping miss");
 			}
-			if (
-				failRecoveryRequests &&
-				message instanceof RequestReplicationInfoMessage
-			) {
-				throw new Error("synthetic replication-info miss");
-			}
 			return originalSend(...args);
 		};
+		// The single missed ping must be absorbed by the subscriber-presence
+		// check, ahead of the failure counter and the recovery lane. Spying the
+		// escalation proves WHICH mechanism keeps the replicator: if presence
+		// confirmation ever stopped covering this, the probe would fall through
+		// to scheduleReplicationInfoRequests and this pin would catch it.
+		const log = db0.log as any;
+		const scheduleRecovery = sinon.spy(log, "scheduleReplicationInfoRequests");
 
 		try {
 			await hooks.probeReplicatorLiveness(peerHash);
 			expect((await db0.log.getReplicators()).size).to.equal(2);
+			expect(scheduleRecovery.notCalled).to.be.true;
+			expect(log._liveness._replicatorLivenessFailures.has(peerHash)).to.be
+				.false;
 
-			failRecoveryRequests = false;
 			await hooks.probeReplicatorLiveness(peerHash);
 			expect((await db0.log.getReplicators()).size).to.equal(2);
+			expect(scheduleRecovery.notCalled).to.be.true;
 		} finally {
+			scheduleRecovery.restore();
 			db0.log.rpc.send = originalSend;
 		}
 	});
@@ -349,10 +350,7 @@ describe("waitForReplicator liveness", () => {
 			hooks.confirmReplicatorSubscriberPresence.bind(hooks);
 		db0.log.rpc.send = async (...args: Parameters<typeof originalSend>) => {
 			const [message] = args;
-			if (
-				message instanceof ReplicationPingMessage ||
-				message instanceof RequestReplicationInfoMessage
-			) {
+			if (message instanceof ReplicationPingMessage) {
 				throw new Error("synthetic liveness miss");
 			}
 			return originalSend(...args);
@@ -488,7 +486,6 @@ describe("waitForReplicator liveness", () => {
 			subscriberHooks._getTopicSubscribers.bind(subscriberHooks);
 		const originalSend = db0.log.rpc.send.bind(db0.log.rpc);
 		let pingFailuresLeft = 2;
-		let failRecoveryRequests = true;
 		pubsub.getSubscribers = (topic: string) => {
 			if (topic === db0.log.rpc.topic) {
 				return [];
@@ -506,14 +503,14 @@ describe("waitForReplicator liveness", () => {
 			if (message instanceof ReplicationPingMessage && pingFailuresLeft-- > 0) {
 				throw new Error("synthetic ping miss");
 			}
-			if (
-				failRecoveryRequests &&
-				message instanceof RequestReplicationInfoMessage
-			) {
-				throw new Error("synthetic replication-info miss");
-			}
 			return originalSend(...args);
 		};
+		// Both missed pings must be absorbed by the broader subscriber view —
+		// that is the mechanism this test is named for. Spying the escalation
+		// pins it: were the wider view to stop counting, the second probe would
+		// hit the eviction threshold via scheduleReplicationInfoRequests.
+		const log = db0.log as any;
+		const scheduleRecovery = sinon.spy(log, "scheduleReplicationInfoRequests");
 
 		try {
 			hooks.markReplicatorActivity(peerHash, Date.now() - 60_000);
@@ -521,9 +518,12 @@ describe("waitForReplicator liveness", () => {
 			hooks.markReplicatorActivity(peerHash, Date.now() - 60_000);
 			await hooks.probeReplicatorLiveness(peerHash);
 
-			failRecoveryRequests = false;
 			expect((await db0.log.getReplicators()).size).to.equal(2);
+			expect(scheduleRecovery.notCalled).to.be.true;
+			expect(log._liveness._replicatorLivenessFailures.has(peerHash)).to.be
+				.false;
 		} finally {
+			scheduleRecovery.restore();
 			pubsub.getSubscribers = originalGetSubscribers;
 			subscriberHooks._getTopicSubscribers = originalGetTopicSubscribers;
 			db0.log.rpc.send = originalSend;
@@ -690,6 +690,10 @@ describe("waitForReplicator liveness", () => {
 		const originalResumeParkedRequest = (
 			db0.log as any
 		)._v2Receive.resumeParkedRequest.bind((db0.log as any)._v2Receive);
+		// Recovery-request failure is expressed HERE, at the parked-request
+		// resume, not at rpc.send: the request lane retries itself and swallows
+		// its own send errors, so a send-level injection would never reach the
+		// liveness path.
 		const resumeParkedRequest = sinon
 			.stub((db0.log as any)._v2Receive, "resumeParkedRequest")
 			.callsFake((properties) =>
@@ -699,12 +703,6 @@ describe("waitForReplicator liveness", () => {
 			const [message] = args;
 			if (message instanceof ReplicationPingMessage && pingFailuresLeft-- > 0) {
 				throw new Error("synthetic ping miss");
-			}
-			if (
-				failRecoveryRequests &&
-				message instanceof RequestReplicationInfoMessage
-			) {
-				throw new Error("synthetic replication-info miss");
 			}
 			return originalSend(...args);
 		};

--- a/scripts/ci/check-fence-ratchet.mjs
+++ b/scripts/ci/check-fence-ratchet.mjs
@@ -10,17 +10,30 @@
 // adding a NEW fence-pattern field fails CI unless a `design-note:` comment
 // in the comment block above the declaration justifies it, and removing one
 // requires shrinking the baseline (the intended direction).
-import { readFileSync } from "node:fs";
+//
+// 2026-08-12 — CLOSED NO-GO: the "stage 5 fence collapse" (folding the
+// remaining ratcheted fields into session/lifecycle identity) was censused
+// after the B12 legacy retirement landed and is not going to happen. Do not
+// redo the census. Every remaining baseline field is structurally permanent
+// for one of exactly two reasons:
+//   1. It is a concurrency-DEPTH counter (a refcount of in-flight lanes),
+//      not a staleness token. Identity answers "is this continuation from
+//      the generation that started it?"; a depth counter answers "how many
+//      lanes are open right now?" — a question identity cannot express.
+//   2. Its lifetime is deliberately per-PEER, not per-session. The token is
+//      set under one session and read (or cleared) under a LATER one, so
+//      rotating identity would reset exactly the state that must survive the
+//      rotation.
+// Each such declaration carries a one-line permanence marker at its site;
+// keep those markers with the fields if they ever move again.
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
 // Per-file frozen baselines. Fence fields drained out of index.ts into
 // modules stay ratcheted in their new homes; TARGETS grows when an
 // extraction creates a module holding fence-pattern fields.
 const TARGETS = new Map([
-	[
-		"packages/programs/data/shared-log/src/index.ts",
-		["_instanceLifecycle"],
-	],
+	["packages/programs/data/shared-log/src/index.ts", ["_instanceLifecycle"]],
 	[
 		"packages/programs/data/shared-log/src/coordinate-persistence.ts",
 		// The index.ts _nativeCoordinateMutationGenerations entry moved
@@ -59,6 +72,41 @@ const TARGETS = new Map([
 	[
 		"packages/programs/data/shared-log/src/peer-session.ts",
 		["_receiveCleanupGateByPeer", "_replicationInfoReceiveEpochByPeer"],
+	],
+	[
+		"packages/programs/data/shared-log/src/replication-info-v2-send.ts",
+		// _senderEpoch predates this file's TARGETS entry; it entered the
+		// baseline as existing inventory when the completeness leg below started
+		// enumerating every src file, not as fence growth.
+		["_senderEpoch"],
+	],
+	[
+		"packages/programs/data/shared-log/src/replication-info-v2-receive.ts",
+		// _reservedAdmissionsByPeer predates this file's TARGETS entry; it
+		// entered the baseline as existing inventory when the completeness leg
+		// below started enumerating every src file, not as fence growth.
+		["_reservedAdmissionsByPeer"],
+	],
+	[
+		"packages/programs/data/shared-log/src/sync/simple.ts",
+		// These three predate this file's TARGETS entry; they entered the
+		// baseline as existing inventory when the completeness leg below started
+		// enumerating every src file, not as fence growth.
+		[
+			"syncDispatchLifecycleController",
+			"syncDispatchTargetEpochCounter",
+			"syncDispatchTargetEpochs",
+		],
+	],
+	[
+		"packages/programs/data/shared-log/src/sync/rateless-iblt.ts",
+		// Both predate this file's TARGETS entry; they entered the baseline as
+		// existing inventory when the completeness leg below started enumerating
+		// every src file, not as fence growth.
+		[
+			"incomingRatelessProcessAdmissions",
+			"ratelessDispatchLifecycleController",
+		],
 	],
 	["packages/programs/data/shared-log/src/join-warmup.ts", []],
 	["packages/programs/data/shared-log/src/replication-announcement.ts", []],
@@ -108,11 +156,9 @@ const errors = [];
 let totalFound = 0;
 let totalBaseline = 0;
 
-for (const [target, baselineList] of TARGETS) {
-	const baseline = new Set(baselineList);
-	totalBaseline += baseline.size;
+// Fence-pattern declarations in one file, keyed by field name.
+const scanFile = (target) => {
 	const lines = readFileSync(path.join(root, target), "utf8").split("\n");
-
 	const found = new Map();
 	for (let i = 0; i < lines.length; i++) {
 		const m = lines[i].match(DECL);
@@ -134,6 +180,13 @@ for (const [target, baselineList] of TARGETS) {
 			.some((l) => l.includes("design-note:"));
 		found.set(name, { line: i + 1, hasDesignNote });
 	}
+	return found;
+};
+
+for (const [target, baselineList] of TARGETS) {
+	const baseline = new Set(baselineList);
+	totalBaseline += baseline.size;
+	const found = scanFile(target);
 	totalFound += found.size;
 
 	for (const [name, info] of found) {
@@ -158,6 +211,43 @@ for (const [target, baselineList] of TARGETS) {
 			);
 		}
 	}
+}
+
+// COMPLETENESS leg. The header claims this script freezes THE inventory, so a
+// hand-maintained TARGETS list is not enough: a fence-pattern field added in a
+// file nobody listed would be invisible. Enumerate every src file and require
+// that each one is either a TARGETS key or genuinely fence-free.
+//
+// Intended workflow: a new file with a fence joins TARGETS in the same commit,
+// or the declaration carries a `design-note:` marker. Declarations carrying
+// that marker are exempt here too, so the two escape hatches cannot contradict
+// each other (the per-file leg above already accepts a design-note in place of
+// a baseline entry).
+const SRC_ROOT = "packages/programs/data/shared-log/src";
+const walkTs = (dir) =>
+	readdirSync(path.join(root, dir))
+		.sort()
+		.flatMap((entry) => {
+			const rel = `${dir}/${entry}`;
+			if (statSync(path.join(root, rel)).isDirectory()) return walkTs(rel);
+			return rel.endsWith(".ts") ? [rel] : [];
+		});
+
+for (const file of walkTs(SRC_ROOT)) {
+	if (TARGETS.has(file)) continue;
+	const unlisted = [...scanFile(file)].filter(
+		([, info]) => !info.hasDesignNote,
+	);
+	if (unlisted.length === 0) continue;
+	errors.push(
+		`UNLISTED file with fence-pattern fields: ${file}. This script freezes ` +
+			`the whole shared-log/src inventory, so the file must be a TARGETS key ` +
+			`in scripts/ci/check-fence-ratchet.mjs (or every declaration must ` +
+			`carry a \`design-note:\` marker). Baseline these declarations:\n` +
+			unlisted
+				.map(([name, info]) => `    "${name}", // ${file}:${info.line}`)
+				.join("\n"),
+	);
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
A post-B12 census asked whether the long-planned "stage 5 fence collapse" was still worth doing. **It is not, and this PR closes it** — plus lands the genuinely valuable things the census found instead. Net source deletion is ~40 lines and deliberately not the point.

## Why the fence collapse is closed (commit 1)

All 13 ratcheted fence fields are structurally permanent, and none of their blockers were legacy-coupled. Four are concurrency-**depth** refcounts — "depth > 0" is not expressible as "which token is current". `_receiveOwnershipRevision` is a sub-lifecycle snapshot-equality counter whose token redesign would silently change its `?? 0` fallback semantics (a behavior change dressed as a rename). `_receiveCleanupGateByPeer` and `_replicationInfoReceiveEpochByPeer` are deliberately per-**peer**, not per-session: a session-identity flag would wrongly reopen receive admission on reconnect. B12 removed readers from exactly one field and left twelve behind.

The supposed "shim pile" also did not survive contact with the code: the ~123 `_coordinates` call sites are direct property hops, not a delegator layer, and the sync accessors have real cross-package consumers — including a raw `.mjs` test worker, a benchmark, and members of the exported `Syncronizer` interface.

So the closing act records the reasoning **where a future reader stands**: a dated NO-GO note in the ratchet header, plus a one-line permanence marker at each of the six previously-unexplained declarations (`peerRemovalFences` had no comment at all).

## The guard that was not guarding (commit 1)

`check-fence-ratchet.mjs` claimed to freeze the fence inventory while only scanning hand-listed files. Seven pre-existing fence fields sat in four unwatched files — including both sync modules, where new fences are most likely to appear. It reported 13; the truth was 20. This adds a completeness leg (exempting the script's own design-note escape hatch, so the two mechanisms no longer contradict) and baselines the seven as existing inventory. It now reports **20 across 17 files**, and a new fence in an unlisted file fails CI.

## Legacy naming, enforced (commit 2)

Three legacy-named symbols outlived the retirement. `reopenLegacy` was a parameter with no false-arm; `releaseLegacyBarrier` was a no-op handle; `allowLegacyOrderedReplacementPairs` is a **live** V2 rolling-upgrade relaxation whose name invited deletion — renamed to `allowOrderedReplacementPairs` (both host methods are private, so no typed surface changes). The "no legacy machinery" spec asserted in prose that only one remained, which was false; it now enforces an identifier scan over `src` with an empty allowlist, and the regex matches leading-`Legacy` PascalCase identifiers — the exact shape a prefix-requiring pattern would have missed.

## Dead fault injections (commit 3)

Four liveness tests injected failures keyed on `RequestReplicationInfoMessage`, which nothing has constructed since B12. Each site was resolved individually rather than blanket-retargeted: two vacuous flips became positive pins asserting *which* mechanism absorbs a missed ping (spying that recovery escalation is never reached), one kept its live `ReplicationPingMessage` disjunct, and the one that already stubs `resumeParkedRequest` now documents why send-level injection can never reach the liveness path — the request lane retries and swallows its own send errors, so the "obvious" retarget would have made these pass for an unrelated reason.

## Pins and dead state (commit 4)

Decode-tombstone coverage went from one Role variant to all three (`NoType` had no reference anywhere but its declaration). Document's retirement ratchet gained a test-side leg — with a whitelist that fails if it ever becomes stale cover — and a vacuous `not.instanceOf` between `@variant` *siblings* became a wire-tag assertion. Deleted: `_replicatorsReconciled` and its dead lifecycle guard, and `PIDReplicationController.prevMemoryUsage`/`prevTotalFactor` (write-only, though `.d.ts`-visible — patch is honest for fields nobody can meaningfully read), plus four orphan bindings in `role.ts` (`@variant` registration depends on the decorated classes and the module import, not these).

## Validation

Node 22: build clean; liveness/PID/guard suites 34 passing; document tombstone + durable-native 74 passing; both ratchet scripts green (fence 20/20, shard 67 describes); repo lint 0 errors. Zero references repo-wide to every deleted symbol.