### PR TITLE
ci: pin the security matrix to Node 24.18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        # 24.18.x is pinned, not floating 24.x: node-datachannel@0.32.3 (the
+        # newest release, and the Node WebRTC transport under @libp2p/webrtc)
+        # ships no N-API prebuild for Node 24.19.0 and its source-build
+        # fallback aborts with "does not support N-API version undefined", so
+        # the published-closure smoke cannot install. This is a real
+        # forward-compat break for consumers on 24.19, not a CI artifact —
+        # unpin once node-datachannel publishes a 24.19-capable build.
+        node-version: [22.x, 24.18.x]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -431,7 +431,11 @@ assert.doesNotMatch(
 );
 const securityJob = workflowJob(ciWorkflow, "security_dependency_contracts");
 assert.match(securityJob, /needs: build_workspace/);
-assert.match(securityJob, /node-version: \[22\.x, 24\.x\]/);
+// The 24 entry is pinned to a patch line on purpose (see ci.yml); this
+// contract keeps it a DELIBERATE pin rather than silent drift, and fails if
+// anyone floats it back to 24.x while node-datachannel still lacks a
+// 24.19-capable prebuild.
+assert.match(securityJob, /node-version: \[22\.x, 24\.18\.x\]/);
 assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
 assert.match(securityJob, /pnpm install --frozen-lockfile/);
 const restoreIndex = securityJob.indexOf("Restore workspace build outputs");


### PR DESCRIPTION
**The Node 24 security gate is red on every PR, and it caught a real problem rather than a CI artifact.**

GitHub's runners moved `24.x` from **v24.18.0** to **v24.19.0** midday today (the last green run used 24.18.0 at 14:53; the first red one used 24.19.0 at 21:22). On 24.19.0 the published-closure smoke cannot install:

```
node-datachannel install$ prebuild-install -r napi || (npm install --ignore-scripts && npm run _prebuild)
prebuild WARN This package does not support N-API version undefined
prebuild ERR! build TypeError: expected first argument to be an array
```

`node-datachannel@0.32.3` — the newest release (April 2026), and the Node WebRTC transport pulled in by `@libp2p/webrtc` — ships no N-API prebuild for 24.19.0, and its source-build fallback aborts. There is no newer version to upgrade to and no override in play. **A consumer installing peerbit on Node 24.19.0 hits exactly this**, so the finding is user-facing, not just ours.

Pinning the matrix entry to `24.18.x` keeps the gate running its full closure audit on a real Node 24 rather than deleting the entry or loosening what it checks. The comment records why the pin exists and the condition for removing it, and `test-release-security-contracts.mjs` — which pins the workflow's shape — is updated in the same commit to assert the pinned value, so this stays a deliberate pin instead of drifting back silently.

Follow-ups worth taking separately: report the 24.19 incompatibility upstream to node-datachannel, and decide whether peerbit wants to state a supported Node range while it stands.

Validation: `test-release-security-contracts.mjs` green against the new shape; workflow YAML parses.