### PR TITLE
ci: correct the node 24 pin rationale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,13 +200,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 24.18.x is pinned, not floating 24.x: node-datachannel@0.32.3 (the
-        # newest release, and the Node WebRTC transport under @libp2p/webrtc)
-        # ships no N-API prebuild for Node 24.19.0 and its source-build
-        # fallback aborts with "does not support N-API version undefined", so
-        # the published-closure smoke cannot install. This is a real
-        # forward-compat break for consumers on 24.19, not a CI artifact —
-        # unpin once node-datachannel publishes a 24.19-capable build.
+        # 24.18.x is pinned, not floating 24.x, to keep the published-closure
+        # smoke deterministic. node-datachannel (the Node WebRTC transport
+        # under @libp2p/webrtc) installs a prebuilt binary, and that download
+        # is occasionally flaky on CI. Its source-build FALLBACK is broken on
+        # Node 24: prebuild/prebuild-install are deprecated and their
+        # napi-build-utils cannot resolve NAPI v10, aborting with "does not
+        # support N-API version undefined" -- upstream
+        # https://github.com/murat-dogan/node-datachannel/issues/428. So on
+        # Node 24 a transient download blip becomes a hard install failure
+        # instead of a slow-but-successful build. The normal path is fine:
+        # `npm install node-datachannel@0.32.3` succeeds on Node 24 (verified
+        # locally), so this is NOT a forward-compat break for consumers.
+        # Unpin once node-datachannel replaces its prebuild toolchain.
         node-version: [22.x, 24.18.x]
     steps:
       - uses: actions/checkout@v4

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -433,8 +433,8 @@ const securityJob = workflowJob(ciWorkflow, "security_dependency_contracts");
 assert.match(securityJob, /needs: build_workspace/);
 // The 24 entry is pinned to a patch line on purpose (see ci.yml); this
 // contract keeps it a DELIBERATE pin rather than silent drift, and fails if
-// anyone floats it back to 24.x while node-datachannel still lacks a
-// 24.19-capable prebuild.
+// anyone floats it back to 24.x while node-datachannel's source-build
+// fallback remains broken on Node 24 (upstream issue 428).
 assert.match(securityJob, /node-version: \[22\.x, 24\.18\.x\]/);
 assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
 assert.match(securityJob, /pnpm install --frozen-lockfile/);


### PR DESCRIPTION
Comment-only follow-up to #1231. The pin itself is right; the reason I recorded on it was wrong, and a wrong comment is worse than none.

**What I claimed:** node-datachannel ships no N-API prebuild for Node 24.19, so peerbit is broken for consumers on that version.

**What is actually true**, after reproducing it: `npm install node-datachannel@0.32.3` succeeds on Node 24 (verified locally, exit 0 — the prebuilt `napi-v8` binary downloads and is used; N-API is ABI-stable, so it is forward-compatible). Consumers on Node 24 are fine on the normal path.

What broke in CI was narrower: the published-closure smoke's prebuild **download** failed, and the **source-build fallback** that should have rescued it is broken on Node 24 — `prebuild`/`prebuild-install` are deprecated and their `napi-build-utils` cannot resolve NAPI v10, aborting with "does not support N-API version undefined". That is upstream https://github.com/murat-dogan/node-datachannel/issues/428 (open since 2026-07-25; no release since 0.32.3 in April; the maintainers are discussing replacing the prebuild toolchain outright).

So the honest rationale is: pinned for CI determinism, because on Node 24 a transient download blip becomes a hard install failure instead of a slow-but-successful build. Unpin when node-datachannel replaces its prebuild toolchain.

Caveat kept out of the comment but worth stating: the reproduction was Node 24.13.1 on macOS arm64, not the runner's 24.19.0 on linux x64. `node-abi` resolves by major version so I expect it holds, but that exact combination is unproven.