### PR TITLE
chore(dns-lease-broker): pin miniflare's undici to 7.29.0

### DIFF
--- a/apps/peerbit-org/cloudflare/dns-lease-broker/package.json
+++ b/apps/peerbit-org/cloudflare/dns-lease-broker/package.json
@@ -17,7 +17,8 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"miniflare>sharp": "0.35.3"
+			"miniflare>sharp": "0.35.3",
+			"miniflare>undici": "7.29.0"
 		}
 	},
 	"devDependencies": {

--- a/apps/peerbit-org/cloudflare/dns-lease-broker/pnpm-lock.yaml
+++ b/apps/peerbit-org/cloudflare/dns-lease-broker/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   miniflare>sharp: 0.35.3
+  miniflare>undici: 7.29.0
 
 importers:
 
@@ -463,8 +464,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -792,7 +793,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260708.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -846,7 +847,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
Closes the two open Dependabot alerts (1 high, 1 moderate) on `apps/peerbit-org/cloudflare/dns-lease-broker/pnpm-lock.yaml`: `undici >= 7.0.0, < 7.29.0`, first patched in 7.29.0.

`undici@7.28.0` arrives transitively through `miniflare`, which comes from `wrangler` — a **devDependency**, so it is local dev/deploy tooling and is not shipped to the deployed Worker. That bounds the real exposure, but the fix is a one-line override in the convention this app already uses for `sharp`, so there is no reason to carry the alert.

Adds `"miniflare>undici": "7.29.0"` to the app's `pnpm.overrides` and regenerates its isolated lockfile (`pnpm install --lockfile-only --ignore-workspace` — note this app has its own lockfile outside the root workspace; a plain `pnpm install` here silently resolves the 69-project root instead and leaves it untouched).

Validation: app test suite 30/30 passing, `tsc` clean, lockfile diff is exactly the undici resolution plus the override entry.

Not addressed here, deliberately: the two root-lockfile alerts (`image-size`, `extract-zip`) both report `fix: none` — no patched version exists upstream — so there is nothing to bump. image-size is the subtree already removed from the audited published closure in #1218.