### PR TITLE
chore(deps): override node-datachannel to a prebuilt release

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,8 @@
 			"vite>esbuild": "0.28.1",
 			"ws@6": "6.2.6",
 			"ws@7": "7.5.13",
-			"ws@8": "8.21.1"
+			"ws@8": "8.21.1",
+			"node-datachannel": "0.32.3"
 		}
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   ws@6: 6.2.6
   ws@7: 7.5.13
   ws@8: 8.21.1
+  node-datachannel: 0.32.3
 
 importers:
 
@@ -9256,8 +9257,8 @@ packages:
     resolution: {integrity: sha512-LyPuZJcI9HVwzXK1GPxWNzrr+vr8Hp/3UqlmWxxh8p54U1ZbclOqbSog9lWHaCX+dBaiGi6n/hIX+mKu74GmPA==}
     engines: {node: '>=10'}
 
-  node-datachannel@0.29.0:
-    resolution: {integrity: sha512-aCRJA5uZRqxMvQAl2QtOnCkodF1qJa1dCUVaXW9D7rku2p6F7PWe5OuRLcIgOYe+e2ZyJu0LefIQ95TtCn6xxA==}
+  node-datachannel@0.32.3:
+    resolution: {integrity: sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g==}
     engines: {node: '>=18.20.0'}
 
   node-emoji@2.2.0:
@@ -13527,7 +13528,7 @@ snapshots:
       it-stream-types: 2.0.2
       main-event: 1.0.1
       multiformats: 13.4.2
-      node-datachannel: 0.29.0
+      node-datachannel: 0.32.3
       p-defer: 4.0.1
       p-event: 7.1.0
       p-timeout: 7.0.1
@@ -14984,7 +14985,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@26.1.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@26.1.0)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -19784,7 +19785,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-datachannel@0.29.0:
+  node-datachannel@0.32.3:
     dependencies:
       prebuild-install: 7.1.3
 


### PR DESCRIPTION
Interim mitigation for the recurring Node 24 install failures, while the real fix (a libp2p stack upgrade) waits for its own project.

## The problem

`node-datachannel@0.29.0` — pulled by `@libp2p/webrtc@6.0.15` — publishes **zero** prebuilt binaries, so every install compiles it from source. That build is broken on Node 24: `prebuild`/`prebuild-install` are deprecated and their `napi-build-utils` cannot resolve NAPI v10 (upstream https://github.com/murat-dogan/node-datachannel/issues/428). CI has been surviving on pnpm's side-effects cache; **any cache miss fails**, on 24.18 as much as 24.19.

## Why an override rather than a version bump

The first `@libp2p/webrtc` carrying a prebuilt `node-datachannel` is 6.0.21, which needs `@libp2p/interface ^3.2.2`. Bumping it duplicates `@libp2p/interface`, breaking `Transport`'s branded symbol; deduping onto 3.2.5 then fails on `Libp2pWithServices`/`StreamMuxerFactory` because libp2p core and the muxers are still built for 3.1.x (that attempt was #1235, closed with the evidence). Overriding only the native package keeps webrtc at 6.0.15 and `@libp2p/interface` at 3.1.1 — **no type churn at all**, an 11-line lockfile diff.

## Compatibility evidence

`@libp2p/webrtc@6.0.15` imports exactly three symbols — `IceUdpMuxListener`, `PeerConnection`, `RTCPeerConnection` — and all three are present in both 0.29.0 and 0.32.3. Verified beyond presence: on Node 24, a clean install with this override resolves 0.32.3 and `@libp2p/webrtc` loads and exposes `webRTC`/`webRTCDirect`. In the workspace: install and full build clean, `@peerbit/stream` green, `peerbit` client 109 passing — and `transports()` puts `webRTC({})` in the default `TestSession` set, so those suites instantiate it rather than merely importing it.

## Scope — what this does NOT fix

pnpm overrides govern **our** workspace install only. The published-closure smoke installs packed tarballs with npm, which resolves `^0.29.0` on its own, so that lane stays exposed on Node 24. This fixes the workspace lane, which is where build/test/gate jobs live and where the last failure landed. Fully closing Node 24 still needs either the libp2p upgrade or dropping Node 24 from the security matrix — deliberately left as a follow-up decision rather than bundled here.

No changeset: overrides do not affect what consumers of the published packages resolve.