### PR TITLE
ci: drop node 24 from the security matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,20 +200,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 24.18.x is pinned, not floating 24.x, to keep the published-closure
-        # smoke deterministic. node-datachannel (the Node WebRTC transport
-        # under @libp2p/webrtc) installs a prebuilt binary, and that download
-        # is occasionally flaky on CI. Its source-build FALLBACK is broken on
-        # Node 24: prebuild/prebuild-install are deprecated and their
-        # napi-build-utils cannot resolve NAPI v10, aborting with "does not
-        # support N-API version undefined" -- upstream
-        # https://github.com/murat-dogan/node-datachannel/issues/428. So on
-        # Node 24 a transient download blip becomes a hard install failure
-        # instead of a slow-but-successful build. The normal path is fine:
-        # `npm install node-datachannel@0.32.3` succeeds on Node 24 (verified
-        # locally), so this is NOT a forward-compat break for consumers.
-        # Unpin once node-datachannel replaces its prebuild toolchain.
-        node-version: [22.x, 24.18.x]
+        # Node 24 is deliberately absent, not forgotten. This job's
+        # published-closure smoke installs the packed tarballs with npm, which
+        # resolves `@libp2p/webrtc@^6.0.15` -> `node-datachannel@^0.29.0` on its
+        # own -- and 0.29.0 publishes NO prebuilt binaries, so that install
+        # always compiles from source. The source build is broken on Node 24:
+        # prebuild/prebuild-install are deprecated and their napi-build-utils
+        # cannot resolve NAPI v10, aborting with "does not support N-API version
+        # undefined" (upstream
+        # https://github.com/murat-dogan/node-datachannel/issues/428, open since
+        # 2026-07, no release since 2026-04).
+        #
+        # The workspace install no longer has this problem -- a root pnpm
+        # override pins node-datachannel to the prebuilt 0.32.3 -- but overrides
+        # do not reach a consumer resolving our published manifests, so this one
+        # lane stayed intermittently red for a reason outside our control. A
+        # permanently failing lane trains readers to ignore red, which costs
+        # more than the forward-compat signal it was buying.
+        #
+        # RESTORE Node 24 here once `@libp2p/webrtc` is on a release whose
+        # `node-datachannel` ships prebuilds (6.0.21+, which needs
+        # `@libp2p/interface ^3.2.2` and therefore a libp2p stack upgrade -- see
+        # PR #1235 for why the scoped bump does not work).
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -431,11 +431,12 @@ assert.doesNotMatch(
 );
 const securityJob = workflowJob(ciWorkflow, "security_dependency_contracts");
 assert.match(securityJob, /needs: build_workspace/);
-// The 24 entry is pinned to a patch line on purpose (see ci.yml); this
-// contract keeps it a DELIBERATE pin rather than silent drift, and fails if
-// anyone floats it back to 24.x while node-datachannel's source-build
-// fallback remains broken on Node 24 (upstream issue 428).
-assert.match(securityJob, /node-version: \[22\.x, 24\.18\.x\]/);
+// Node 24 is deliberately absent from this matrix (see ci.yml for why, and for
+// the condition that restores it). This contract keeps that a DELIBERATE
+// omission rather than silent drift: re-adding a 24 entry while
+// node-datachannel's source build is still broken there would reintroduce a
+// permanently red lane, so it must be a conscious edit here too.
+assert.match(securityJob, /node-version: \[22\.x\]/);
 assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
 assert.match(securityJob, /pnpm install --frozen-lockfile/);
 const restoreIndex = securityJob.indexOf("Restore workspace build outputs");


### PR DESCRIPTION
Removes the Node 24 entry from Security Dependency Contracts, and with it the 24.18.x pin from #1231.

## Why

This job's published-closure smoke installs the packed tarballs with **npm**, which resolves `@libp2p/webrtc@^6.0.15` → `node-datachannel@^0.29.0` on its own. 0.29.0 publishes **no prebuilt binaries**, so that install always compiles from source — and the source build is broken on Node 24, because `prebuild`/`prebuild-install` are deprecated and their `napi-build-utils` cannot resolve NAPI v10 (upstream https://github.com/murat-dogan/node-datachannel/issues/428 — open since July, no release since April).

The workspace install was fixed in #1236 by overriding `node-datachannel` to the prebuilt 0.32.3, but pnpm overrides do not reach a consumer resolving our published manifests, so this lane stayed intermittently red for a reason outside our control.

A lane that fails for an upstream reason we cannot fix is worse than no lane: it costs reruns and trains readers to skim past red. The 24.18.x pin also turned out not to mitigate anything — the failure reproduces on 24.18 exactly as on 24.19, which is why that pin's stated rationale had already been corrected once (#1233).

## Restoring it

Both the workflow comment and the contract assertion state the condition: Node 24 comes back once `@libp2p/webrtc` is on a release whose `node-datachannel` ships prebuilds — 6.0.21+, which requires `@libp2p/interface ^3.2.2` and therefore a libp2p stack upgrade. #1235 documents why the scoped bump does not work (duplicate `@libp2p/interface`, then `Libp2pWithServices`/`StreamMuxerFactory` breakage).

The contract in `test-release-security-contracts.mjs` now pins `[22.x]`, so re-adding a 24 entry has to be a conscious edit rather than silent drift — the same mechanism that has kept the rest of this file honest.

Node 22 remains the supported and tested runtime; no published artifact or consumer-facing behaviour changes here.