### PR TITLE
fix(shared-log): bound the coordinate mutation-generation map

### DIFF
--- a/.changeset/coordinate-generation-refcount.md
+++ b/.changeset/coordinate-generation-refcount.md
@@ -1,0 +1,14 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Bound the native coordinate mutation-generation map with a hold-counted settle.
+
+The map previously grew one row per distinct entry hash ever committed or
+received and had no removal path, so it was monotone in lifetime throughput for
+the life of a SharedLog instance. Each row is now hold-counted: taking a
+rollback snapshot takes one hold per hash, and the token is settled at every
+point where it can no longer be rolled back, deleting the row at zero holds.
+Rollback semantics are unchanged - the generation gate still makes a superseded
+rollback a strict no-op - and a token that is never settled simply retains its
+row, which is the previous behavior.

--- a/packages/programs/data/shared-log/src/coordinate-persistence.ts
+++ b/packages/programs/data/shared-log/src/coordinate-persistence.ts
@@ -207,7 +207,20 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 	// roll back only while that generation is still current, so a rollback
 	// superseded by a newer mutation is a strict no-op. The map deliberately
 	// survives open/close cycles of the same instance.
-	_nativeCoordinateMutationGenerations?: Map<string, number>;
+	//
+	// Each row is hold-counted: `snapshotResidentCoordinateEntries` takes one
+	// hold per hash per token, and `settleResidentCoordinateSnapshot` releases
+	// it once the token can no longer be rolled back, deleting the row at zero
+	// holds. That bounds the map by the outstanding rollback tokens instead of
+	// by lifetime throughput. Deleting a row that still has a live token would
+	// make its rollback fail open (or, worse, ABA-clobber newer state), so
+	// eviction is refcount-driven only — never TTL, LRU or a size cap. A
+	// MISSED settle merely retains a row, which is the pre-refcount behavior
+	// and therefore never a regression.
+	_nativeCoordinateMutationGenerations?: Map<
+		string,
+		{ generation: number; holds: number }
+	>;
 
 	/**
 	 * Wall-clock watermark of the last settled native coordinate journal
@@ -567,6 +580,11 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 		} catch (error) {
 			this.rollbackBackboneOnlyReceiveCoordinateBatch(batch);
 			throw error;
+		} finally {
+			// The token cannot escape this function: both outcomes are
+			// observed here, and the catch arm has already consumed it by the
+			// time this runs.
+			this.settleResidentCoordinateSnapshot(batch.rollbackCoordinateEntries);
 		}
 	}
 
@@ -1012,8 +1030,14 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 		const mutationGenerations = (this._nativeCoordinateMutationGenerations ??=
 			new Map());
 		for (const hash of uniqueHashes) {
-			const generation = (mutationGenerations.get(hash) ?? 0) + 1;
-			mutationGenerations.set(hash, generation);
+			// `uniqueHashes` is a Set, so this is exactly one hold per token
+			// per hash; `settleResidentCoordinateSnapshot` releases it.
+			const row = mutationGenerations.get(hash);
+			const generation = (row?.generation ?? 0) + 1;
+			mutationGenerations.set(hash, {
+				generation,
+				holds: (row?.holds ?? 0) + 1,
+			});
 			generations.set(hash, generation);
 			const entry = this._residentEntryCoordinatesByHash?.get(hash);
 			if (entry) {
@@ -1021,6 +1045,43 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 			}
 		}
 		return { hashes: uniqueHashes, entries, generations };
+	}
+
+	/**
+	 * Release the holds a rollback token took on the mutation-generation map.
+	 *
+	 * Call this only where the token is TERMINAL — after the last point at
+	 * which any code path could still roll it back. A premature settle deletes
+	 * a row that a live token still needs, which silently turns that token's
+	 * rollback into a no-op (phantom coordinates) or, if the hash cycles back
+	 * to the same generation, lets it clobber newer state. A missed settle
+	 * only retains the row, which is the pre-refcount behavior.
+	 *
+	 * Idempotent by design: `settled` is set FIRST so a second settle of the
+	 * same token cannot consume another token's hold on a shared hash.
+	 */
+	settleResidentCoordinateSnapshot(
+		rollback?: NativeBackboneCoordinateRollback<R>,
+	): void {
+		if (!rollback || rollback.settled) {
+			return;
+		}
+		rollback.settled = true;
+		const mutationGenerations = this._nativeCoordinateMutationGenerations;
+		if (!mutationGenerations) {
+			return;
+		}
+		for (const hash of rollback.hashes) {
+			const row = mutationGenerations.get(hash);
+			if (!row) {
+				continue;
+			}
+			if (row.holds <= 1) {
+				mutationGenerations.delete(hash);
+			} else {
+				row.holds -= 1;
+			}
+		}
 	}
 
 	rollbackNativeBackboneCoordinateAppend(
@@ -1038,7 +1099,7 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 			const expectedGeneration = rollback?.generations.get(hash);
 			if (
 				expectedGeneration !== undefined &&
-				mutationGenerations.get(hash) !== expectedGeneration
+				mutationGenerations.get(hash)?.generation !== expectedGeneration
 			) {
 				continue;
 			}
@@ -1096,7 +1157,7 @@ export class CoordinatePersistenceCoordinator<R extends "u32" | "u64"> {
 			const expectedGeneration = rollback?.generations.get(hash);
 			if (
 				expectedGeneration !== undefined &&
-				mutationGenerations.get(hash) !== expectedGeneration
+				mutationGenerations.get(hash)?.generation !== expectedGeneration
 			) {
 				continue;
 			}

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -637,6 +637,13 @@ export type NativeBackboneCoordinateRollback<R extends "u32" | "u64"> = {
 	hashes: Set<string>;
 	entries: Map<string, ResidentCoordinateEntry<R>>;
 	generations: Map<string, number>;
+	/**
+	 * Set by `settleResidentCoordinateSnapshot` once the token's holds on the
+	 * mutation-generation map have been released. Load-bearing: it makes the
+	 * settle idempotent, so a second settle of this token cannot consume a
+	 * different token's hold on a shared hash.
+	 */
+	settled?: boolean;
 };
 
 export type RepairDispatchEntry<R extends "u32" | "u64"> =
@@ -3114,9 +3121,23 @@ export class SharedLog<
 				};
 				for (const coordinate of intent.coordinates) {
 					rollback.hashes.add(coordinate.hash);
-					const generation =
-						(mutationGenerations.get(coordinate.hash) ?? 0) + 1;
-					mutationGenerations.set(coordinate.hash, generation);
+					// Same hold-counted row shape the coordinator's own
+					// snapshot writes: one hold per hash, released by the
+					// settle after the replay consumes the token below.
+					// RELIES ON `intent.coordinates` HOLDING UNIQUE HASHES —
+					// it is built from the token's `hashes` Set (see
+					// setNativeStrictDurableTransactionOperation). Holds are
+					// taken per element here but released per unique hash by
+					// the settle, so a duplicate would take two and release
+					// one and retain that row forever. That is the safe
+					// direction (a retained row, never a fail-open rollback),
+					// but keep the source a Set.
+					const row = mutationGenerations.get(coordinate.hash);
+					const generation = (row?.generation ?? 0) + 1;
+					mutationGenerations.set(coordinate.hash, {
+						generation,
+						holds: (row?.holds ?? 0) + 1,
+					});
 					rollback.generations.set(coordinate.hash, generation);
 					if (coordinate.value) {
 						const number = (value: string) =>
@@ -3142,6 +3163,9 @@ export class SharedLog<
 					"",
 					rollback,
 				);
+				// The replay fabricated these generations itself one turn
+				// earlier and has now consumed them, so the rows are dead.
+				this._coordinates.settleResidentCoordinateSnapshot(rollback);
 			}
 			for (const document of intent.documents) {
 				this.restoreNativeBackboneDocument({
@@ -10979,12 +11003,21 @@ export class SharedLog<
 			return rollbackLowerPublication(error);
 		}
 		if (!result) {
+			// Abandon arm: the token was minted but nothing downstream can
+			// roll it back from here.
+			this._coordinates.settleResidentCoordinateSnapshot(
+				lowerPublicationRollback?.coordinateEntries,
+			);
 			return this.completeNativeStrictDurableTransaction(
 				nativeStrictTransaction,
 			).then(() => undefined);
 		}
 		return mapMaybePromise(result, async (prepared) => {
 			if (!prepared) {
+				// Abandon arm: same shape as the `!result` arm above.
+				this._coordinates.settleResidentCoordinateSnapshot(
+					lowerPublicationRollback?.coordinateEntries,
+				);
 				await this.completeNativeStrictDurableTransaction(
 					nativeStrictTransaction,
 				);
@@ -11016,6 +11049,11 @@ export class SharedLog<
 				try {
 					await this._coordinates.rollbackNativeBackboneCoordinateAppendDurably(
 						prepared.appendFacts.hash,
+						lowerPublicationRollback?.coordinateEntries,
+					);
+					// Terminal: this is the last rollback consumer for the
+					// token. A throw above leaves the row, which is safe.
+					this._coordinates.settleResidentCoordinateSnapshot(
 						lowerPublicationRollback?.coordinateEntries,
 					);
 					for (const document of lowerPublicationRollback?.documents ?? []) {
@@ -11088,6 +11126,14 @@ export class SharedLog<
 			} catch (error) {
 				return rollback(error);
 			}
+			// Success seam. The last await inside the protected try is the
+			// finalizer acknowledge; `finish()` is synchronous, so no async
+			// boundary separates the catch above from this statement and
+			// `rollback` can no longer fire. Nothing downstream rolls back
+			// (the retire below only warns), so the token is terminal here.
+			this._coordinates.settleResidentCoordinateSnapshot(
+				lowerPublicationRollback?.coordinateEntries,
+			);
 			this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
 				prepared.appendFacts,
 				prepared.removed,
@@ -11544,6 +11590,12 @@ export class SharedLog<
 				}
 				return mapMaybePromise(result, async (prepared) => {
 					if (!prepared || !backboneAppend) {
+						// Abandon arm: the token was minted inside
+						// `prepareBackboneAppend` and nothing downstream of
+						// this return can roll it back.
+						this._coordinates.settleResidentCoordinateSnapshot(
+							nativeCoordinateRollback,
+						);
 						await this.completeNativeStrictDurableTransaction(
 							nativeStrictTransaction,
 						);
@@ -11635,6 +11687,10 @@ export class SharedLog<
 								prepared.appendFacts.hash,
 								rollbackCoordinateEntries,
 							);
+							// Terminal: last rollback consumer for the token.
+							this._coordinates.settleResidentCoordinateSnapshot(
+								rollbackCoordinateEntries,
+							);
 						} catch (rollbackError) {
 							rollbackFailures.push(rollbackError);
 						}
@@ -11711,6 +11767,12 @@ export class SharedLog<
 					} catch (error) {
 						return rollback(error);
 					}
+					// Success seam: the finalizer acknowledge above is the last
+					// await inside the protected try, so `rollback` can no
+					// longer fire and the retire below only warns.
+					this._coordinates.settleResidentCoordinateSnapshot(
+						rollbackCoordinateEntries,
+					);
 					this.applyPreparedAppendFactsWithDeferredCoordinateDeletes(
 						prepared.appendFacts,
 						prepared.removed,
@@ -12630,6 +12692,10 @@ export class SharedLog<
 			throw error;
 		}
 		if (!appended || !backboneAppends) {
+			// Abandon arm: no consumer downstream of this return.
+			this._coordinates.settleResidentCoordinateSnapshot(
+				batchCoordinateRollback,
+			);
 			await this.completeNativeStrictDurableTransaction(
 				nativeStrictTransaction,
 			);
@@ -12665,6 +12731,10 @@ export class SharedLog<
 			try {
 				await this._coordinates.rollbackNativeBackboneCoordinateAppendDurably(
 					appended.appendFacts[0]?.hash ?? "",
+					batchCoordinateRollback,
+				);
+				// Terminal: last rollback consumer for the batch token.
+				this._coordinates.settleResidentCoordinateSnapshot(
 					batchCoordinateRollback,
 				);
 			} catch (rollbackError) {
@@ -12798,6 +12868,11 @@ export class SharedLog<
 		} catch (error) {
 			return rollbackBatch(error);
 		}
+		// Success seam: `rollbackBatch` has exactly one call site (the catch
+		// above), and everything from here on escapes without any rollback.
+		this._coordinates.settleResidentCoordinateSnapshot(
+			batchCoordinateRollback,
+		);
 
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			ownershipLifecycleController,
@@ -18907,292 +18982,305 @@ export class SharedLog<
 									reusableCoordinatePersistItems,
 								)
 							: undefined;
-						const nativePreparedJoinCommit = canUsePreparedAppendFacts
-							? this._coordinates.createNativeBackbonePreparedJoinCommit(
-									nativeReceiveCoordinateBatch,
-									(batch) => {
-										nativePreparedCoordinateBatch = batch;
-									},
-									nativeCommitVerifyHashes,
-									nativeCommitVerifyAllHashes,
-									syncProfile,
-									(committedHashes) => {
-										nativePreparedCommittedHashes = new Set(committedHashes);
-									},
-								)
-							: undefined;
-						const finishNativePreparedCoordinates = async (properties: {
-							nativePreparedCommitted: boolean;
-						}) => {
-							if (
-								!properties.nativePreparedCommitted ||
-								!nativePreparedCoordinateBatch
-							) {
-								return;
-							}
-							try {
-								nativeBackboneOnlyPersistedHashes =
-									await this._coordinates.finishBackboneOnlyReceiveCoordinateBatch(
-										nativePreparedCoordinateBatch,
+						try {
+							const nativePreparedJoinCommit = canUsePreparedAppendFacts
+								? this._coordinates.createNativeBackbonePreparedJoinCommit(
+										nativeReceiveCoordinateBatch,
+										(batch) => {
+											nativePreparedCoordinateBatch = batch;
+										},
+										nativeCommitVerifyHashes,
+										nativeCommitVerifyAllHashes,
 										syncProfile,
+										(committedHashes) => {
+											nativePreparedCommittedHashes = new Set(committedHashes);
+										},
+									)
+								: undefined;
+							const finishNativePreparedCoordinates = async (properties: {
+								nativePreparedCommitted: boolean;
+							}) => {
+								if (
+									!properties.nativePreparedCommitted ||
+									!nativePreparedCoordinateBatch
+								) {
+									return;
+								}
+								try {
+									nativeBackboneOnlyPersistedHashes =
+										await this._coordinates.finishBackboneOnlyReceiveCoordinateBatch(
+											nativePreparedCoordinateBatch,
+											syncProfile,
+										);
+									nativePreparedCoordinatesFinished = true;
+								} catch (error) {
+									this._coordinates.rollbackBackboneOnlyReceiveCoordinateBatch(
+										nativePreparedCoordinateBatch,
 									);
-								nativePreparedCoordinatesFinished = true;
-							} catch (error) {
-								this._coordinates.rollbackBackboneOnlyReceiveCoordinateBatch(
-									nativePreparedCoordinateBatch,
-								);
-								throw error;
+									throw error;
+								}
+							};
+							const preparedAppendCanValidateAppend =
+								canAppendAlreadyValidated ||
+								(nativeCommitCanValidateAppend && !!nativePreparedJoinCommit);
+							if (!preparedAppendCanValidateAppend) {
+								canUsePreparedAppendFacts = false;
 							}
-						};
-						const preparedAppendCanValidateAppend =
-							canAppendAlreadyValidated ||
-							(nativeCommitCanValidateAppend && !!nativePreparedJoinCommit);
-						if (!preparedAppendCanValidateAppend) {
-							canUsePreparedAppendFacts = false;
-						}
-						const nativePreparedJoinCommitValidatesPlan =
-							!!nativePreparedJoinCommit &&
-							(nativeCommitVerifyHashes && nativeCommitVerifyHashes.length > 0
-								? nativeCommitVerifyAllHashes
-									? !!this._nativeBackbone?.graph
-											.commitVerifiedAllPreparedRawReceiveJoinBatch ||
-										!!this._nativeBackbone?.graph
-											.commitVerifiedPreparedRawReceiveJoinBatch
+							const nativePreparedJoinCommitValidatesPlan =
+								!!nativePreparedJoinCommit &&
+								(nativeCommitVerifyHashes && nativeCommitVerifyHashes.length > 0
+									? nativeCommitVerifyAllHashes
+										? !!this._nativeBackbone?.graph
+												.commitVerifiedAllPreparedRawReceiveJoinBatch ||
+											!!this._nativeBackbone?.graph
+												.commitVerifiedPreparedRawReceiveJoinBatch
+										: !!this._nativeBackbone?.graph
+												.commitVerifiedPreparedRawReceiveJoinBatch
 									: !!this._nativeBackbone?.graph
-											.commitVerifiedPreparedRawReceiveJoinBatch
-								: !!this._nativeBackbone?.graph
-										.commitPreparedRawReceiveJoinBatch);
-						const trustedLowerLog = this.log as unknown as TrustedLowerLog<T>;
-						// With a program-level onChange consumer the hash-only
-						// sink is not used: the lower-log join dispatches the
-						// change event (lazy entry views over the prepared raw
-						// facts) so per-entry consumers observe every commit.
-						const joinOnAppendHashes = programOnChange
-							? undefined
-							: onAppendHashes;
-						const joinedPreparedFacts =
-							canUsePreparedAppendFacts &&
-							(await trustedLowerLog.joinPreparedAppendFactsBatch(
-								preparedAppendFacts,
-								{
+											.commitPreparedRawReceiveJoinBatch);
+							const trustedLowerLog = this.log as unknown as TrustedLowerLog<T>;
+							// With a program-level onChange consumer the hash-only
+							// sink is not used: the lower-log join dispatches the
+							// change event (lazy entry views over the prepared raw
+							// facts) so per-entry consumers observe every commit.
+							const joinOnAppendHashes = programOnChange
+								? undefined
+								: onAppendHashes;
+							const joinedPreparedFacts =
+								canUsePreparedAppendFacts &&
+								(await trustedLowerLog.joinPreparedAppendFactsBatch(
+									preparedAppendFacts,
+									{
+										__peerbitEntriesAlreadyMissing: true,
+										__peerbitCanAppendAlreadyValidated: true,
+										__peerbitDeferIndexWrite: true,
+										__peerbitOnAppendHashes: joinOnAppendHashes,
+										__peerbitProfile: syncProfile,
+										__peerbitNativePreparedJoinCommit: nativePreparedJoinCommit,
+										__peerbitNativePreparedJoinCommitValidatesPlan:
+											nativePreparedJoinCommitValidatesPlan,
+										__peerbitOnPreparedJoinCommitted: nativePreparedJoinCommit
+											? finishNativePreparedCoordinates
+											: undefined,
+									},
+								));
+							if (!joinedPreparedFacts) {
+								await trustedLowerLog.join(materializeAllToMergeEntries(), {
+									__peerbitBatchIndependent: true,
 									__peerbitEntriesAlreadyMissing: true,
-									__peerbitCanAppendAlreadyValidated: true,
+									__peerbitCanAppendAlreadyValidated:
+										fallbackCanAppendAlreadyValidated,
 									__peerbitDeferIndexWrite: true,
 									__peerbitOnAppendHashes: joinOnAppendHashes,
 									__peerbitProfile: syncProfile,
-									__peerbitNativePreparedJoinCommit: nativePreparedJoinCommit,
-									__peerbitNativePreparedJoinCommitValidatesPlan:
-										nativePreparedJoinCommitValidatesPlan,
-									__peerbitOnPreparedJoinCommitted: nativePreparedJoinCommit
-										? finishNativePreparedCoordinates
-										: undefined,
-								},
-							));
-						if (!joinedPreparedFacts) {
-							await trustedLowerLog.join(materializeAllToMergeEntries(), {
-								__peerbitBatchIndependent: true,
-								__peerbitEntriesAlreadyMissing: true,
-								__peerbitCanAppendAlreadyValidated:
-									fallbackCanAppendAlreadyValidated,
-								__peerbitDeferIndexWrite: true,
-								__peerbitOnAppendHashes: joinOnAppendHashes,
-								__peerbitProfile: syncProfile,
-							});
-						}
-						// A recursive lower-log join can resolve successfully while declining
-						// an individual top-level entry (for example, when one of its parents
-						// is temporarily unavailable). The public Log.join() API intentionally
-						// does not expose that per-entry result, so make local index presence the
-						// authority before publishing any SharedLog-side effects. A successful
-						// prepared-facts batch is atomic and already proves every input hash.
-						const admittedHashes = joinedPreparedFacts
-							? new Set(allToMergeHashes)
-							: await this.log.hasMany(allToMergeHashes);
-						admittedMergeHashes = admittedHashes;
-						const admittedShallowEntries =
-							admittedHashes.size === allToMergeShallowEntries.length
-								? allToMergeShallowEntries
-								: allToMergeShallowEntries.filter((entry) =>
+								});
+							}
+							// A recursive lower-log join can resolve successfully while declining
+							// an individual top-level entry (for example, when one of its parents
+							// is temporarily unavailable). The public Log.join() API intentionally
+							// does not expose that per-entry result, so make local index presence the
+							// authority before publishing any SharedLog-side effects. A successful
+							// prepared-facts batch is atomic and already proves every input hash.
+							const admittedHashes = joinedPreparedFacts
+								? new Set(allToMergeHashes)
+								: await this.log.hasMany(allToMergeHashes);
+							admittedMergeHashes = admittedHashes;
+							const admittedShallowEntries =
+								admittedHashes.size === allToMergeShallowEntries.length
+									? allToMergeShallowEntries
+									: allToMergeShallowEntries.filter((entry) =>
+											admittedHashes.has(entry.hash),
+										);
+							if (!joinedPreparedFacts) {
+								reusableCoordinatePersistItems =
+									reusableCoordinatePersistItems.filter((item) =>
+										admittedHashes.has(item.entry.hash),
+									);
+								coordinatePersistFallbackEntries =
+									coordinatePersistFallbackEntries.filter((entry) =>
 										admittedHashes.has(entry.hash),
 									);
-						if (!joinedPreparedFacts) {
-							reusableCoordinatePersistItems =
-								reusableCoordinatePersistItems.filter((item) =>
-									admittedHashes.has(item.entry.hash),
-								);
-							coordinatePersistFallbackEntries =
-								coordinatePersistFallbackEntries.filter((entry) =>
-									admittedHashes.has(entry.hash),
-								);
-						}
-						const reusableCoordinatePersistItemCount =
-							reusableCoordinatePersistItems.length;
-						if (syncProfile) {
-							emitSyncProfileDuration(syncProfile, lowerLogJoinStartedAt, {
-								name: "sharedLog.receive.lowerLogJoin",
-								component: "shared-log",
-								entries: allToMerge.length,
-								messages: 1,
-								details: {
-									hashOnlyEntryAdded,
-									batchHashOnlyEntryAdded,
-									programOnChange,
-									joinedPreparedFacts,
-									admittedEntries: admittedHashes.size,
-									nativePreparedCoordinatesFinished,
-								},
-							});
-						}
-						const coordinatePersistStartedAt = syncProfileStart(syncProfile);
-						if (nativePreparedCoordinatesFinished) {
-							// The lower-log prepared receive transaction already finished
-							// the native coordinate mirror/journal after entry-index commit.
-						} else if (nativePreparedCoordinateBatch) {
-							try {
-								nativeBackboneOnlyPersistedHashes =
-									await this._coordinates.finishBackboneOnlyReceiveCoordinateBatch(
-										nativePreparedCoordinateBatch,
-										syncProfile,
-									);
-							} catch (error) {
-								this._coordinates.rollbackBackboneOnlyReceiveCoordinateBatch(
-									nativePreparedCoordinateBatch,
-								);
-								throw error;
 							}
-						} else {
-							nativeBackboneOnlyPersistedHashes =
-								await this._coordinates.persistBackboneOnlyReceiveCoordinateBatch(
+							const reusableCoordinatePersistItemCount =
+								reusableCoordinatePersistItems.length;
+							if (syncProfile) {
+								emitSyncProfileDuration(syncProfile, lowerLogJoinStartedAt, {
+									name: "sharedLog.receive.lowerLogJoin",
+									component: "shared-log",
+									entries: allToMerge.length,
+									messages: 1,
+									details: {
+										hashOnlyEntryAdded,
+										batchHashOnlyEntryAdded,
+										programOnChange,
+										joinedPreparedFacts,
+										admittedEntries: admittedHashes.size,
+										nativePreparedCoordinatesFinished,
+									},
+								});
+							}
+							const coordinatePersistStartedAt = syncProfileStart(syncProfile);
+							if (nativePreparedCoordinatesFinished) {
+								// The lower-log prepared receive transaction already finished
+								// the native coordinate mirror/journal after entry-index commit.
+							} else if (nativePreparedCoordinateBatch) {
+								try {
+									nativeBackboneOnlyPersistedHashes =
+										await this._coordinates.finishBackboneOnlyReceiveCoordinateBatch(
+											nativePreparedCoordinateBatch,
+											syncProfile,
+										);
+								} catch (error) {
+									this._coordinates.rollbackBackboneOnlyReceiveCoordinateBatch(
+										nativePreparedCoordinateBatch,
+									);
+									throw error;
+								}
+							} else {
+								nativeBackboneOnlyPersistedHashes =
+									await this._coordinates.persistBackboneOnlyReceiveCoordinateBatch(
+										reusableCoordinatePersistItems,
+									);
+							}
+							if (
+								nativeBackboneOnlyPersistedHashes &&
+								nativeBackboneOnlyPersistedHashes.size > 0
+							) {
+								for (
+									let i = reusableCoordinatePersistItems.length - 1;
+									i >= 0;
+									i--
+								) {
+									if (
+										nativeBackboneOnlyPersistedHashes.has(
+											reusableCoordinatePersistItems[i]!.entry.hash,
+										)
+									) {
+										reusableCoordinatePersistItems.splice(i, 1);
+									}
+								}
+							}
+							if (reusableCoordinatePersistItems.length > 0) {
+								await this._coordinates.persistCoordinatesBatch(
 									reusableCoordinatePersistItems,
 								);
-						}
-						if (
-							nativeBackboneOnlyPersistedHashes &&
-							nativeBackboneOnlyPersistedHashes.size > 0
-						) {
-							for (
-								let i = reusableCoordinatePersistItems.length - 1;
-								i >= 0;
-								i--
-							) {
-								if (
-									nativeBackboneOnlyPersistedHashes.has(
-										reusableCoordinatePersistItems[i]!.entry.hash,
-									)
-								) {
-									reusableCoordinatePersistItems.splice(i, 1);
-								}
 							}
-						}
-						if (reusableCoordinatePersistItems.length > 0) {
-							await this._coordinates.persistCoordinatesBatch(
-								reusableCoordinatePersistItems,
-							);
-						}
-						if (coordinatePersistFallbackEntries.length > 0) {
-							await this.planEntryLeaderBatch(
-								coordinatePersistFallbackEntries.map((entry) => ({
-									entry,
-									replicas:
-										receiveReplicaCounts.get(entry.hash) ??
-										decodeReplicas(entry).getValue(this),
-									options: { roleAge: 0, persist: {} },
-								})),
-							);
-						}
-						if (syncProfile) {
-							emitSyncProfileDuration(syncProfile, coordinatePersistStartedAt, {
-								name: "sharedLog.receive.coordinatePersist",
-								component: "shared-log",
-								entries: entriesToPersist.length,
-								messages: 1,
-								details: {
-									reusedLeaderPlans: reusableCoordinatePersistItemCount,
-									nativeBackboneOnly:
-										nativeBackboneOnlyPersistedHashes?.size ?? 0,
-								},
-							});
-						}
-						for (const hash of admittedHashes) {
-							confirmedHashes.add(hash);
-						}
-						const checkedPruneStartedAt = syncProfileStart(syncProfile);
-						const ownershipChangedDuringReceive =
-							!this.isReceiveOwnershipSnapshotStable(receiveOwnershipRevision);
-						if (ownershipChangedDuringReceive) {
-							const freshAuditRevision =
-								this._instanceLifecycle?._receiveOwnershipRevision ?? 0;
-							const armFreshAuditRetry = () => {
-								for (const entry of admittedShallowEntries) {
-									this.scheduleCheckedPruneRetry(
-										{ entry, leaders: new Map() },
+							if (coordinatePersistFallbackEntries.length > 0) {
+								await this.planEntryLeaderBatch(
+									coordinatePersistFallbackEntries.map((entry) => ({
+										entry,
+										replicas:
+											receiveReplicaCounts.get(entry.hash) ??
+											decodeReplicas(entry).getValue(this),
+										options: { roleAge: 0, persist: {} },
+									})),
+								);
+							}
+							if (syncProfile) {
+								emitSyncProfileDuration(syncProfile, coordinatePersistStartedAt, {
+									name: "sharedLog.receive.coordinatePersist",
+									component: "shared-log",
+									entries: entriesToPersist.length,
+									messages: 1,
+									details: {
+										reusedLeaderPlans: reusableCoordinatePersistItemCount,
+										nativeBackboneOnly:
+											nativeBackboneOnlyPersistedHashes?.size ?? 0,
+									},
+								});
+							}
+							for (const hash of admittedHashes) {
+								confirmedHashes.add(hash);
+							}
+							const checkedPruneStartedAt = syncProfileStart(syncProfile);
+							const ownershipChangedDuringReceive =
+								!this.isReceiveOwnershipSnapshotStable(receiveOwnershipRevision);
+							if (ownershipChangedDuringReceive) {
+								const freshAuditRevision =
+									this._instanceLifecycle?._receiveOwnershipRevision ?? 0;
+								const armFreshAuditRetry = () => {
+									for (const entry of admittedShallowEntries) {
+										this.scheduleCheckedPruneRetry(
+											{ entry, leaders: new Map() },
+											receiveOwnershipLifecycleController,
+										);
+									}
+								};
+								try {
+									await this.pruneJoinedEntriesNoLongerLed(
+										admittedShallowEntries,
+										{
+											decodedReplicaCounts: receiveReplicaCounts,
+											freshReceiveOwnerAudit: true,
+											preserveExistingPruneOnLocalResult: true,
+											profile: syncProfile,
+										},
 										receiveOwnershipLifecycleController,
 									);
+									this.throwIfReplicationOwnershipLifecycleInactive(
+										receiveOwnershipLifecycleController,
+									);
+									if (
+										!this.isReceiveOwnershipSnapshotStable(freshAuditRevision)
+									) {
+										armFreshAuditRetry();
+									}
+								} catch {
+									// The lower-log and coordinate commits are already durable. A
+									// sender retry will filter these hashes as present, so retain a
+									// bounded local obligation instead of failing the admitted receive.
+									this.throwIfReplicationOwnershipLifecycleInactive(
+										receiveOwnershipLifecycleController,
+									);
+									armFreshAuditRetry();
 								}
-							};
-							try {
+							} else {
 								await this.pruneJoinedEntriesNoLongerLed(
 									admittedShallowEntries,
 									{
 										decodedReplicaCounts: receiveReplicaCounts,
-										freshReceiveOwnerAudit: true,
 										preserveExistingPruneOnLocalResult: true,
+										reusableLeaderPlans: reusableCoordinatePlans,
 										profile: syncProfile,
 									},
 									receiveOwnershipLifecycleController,
 								);
-								this.throwIfReplicationOwnershipLifecycleInactive(
-									receiveOwnershipLifecycleController,
-								);
-								if (
-									!this.isReceiveOwnershipSnapshotStable(freshAuditRevision)
-								) {
-									armFreshAuditRetry();
-								}
-							} catch {
-								// The lower-log and coordinate commits are already durable. A
-								// sender retry will filter these hashes as present, so retain a
-								// bounded local obligation instead of failing the admitted receive.
-								this.throwIfReplicationOwnershipLifecycleInactive(
-									receiveOwnershipLifecycleController,
-								);
-								armFreshAuditRetry();
 							}
-						} else {
-							await this.pruneJoinedEntriesNoLongerLed(
-								admittedShallowEntries,
-								{
-									decodedReplicaCounts: receiveReplicaCounts,
-									preserveExistingPruneOnLocalResult: true,
-									reusableLeaderPlans: reusableCoordinatePlans,
-									profile: syncProfile,
-								},
-								receiveOwnershipLifecycleController,
+							if (syncProfile) {
+								emitSyncProfileDuration(syncProfile, checkedPruneStartedAt, {
+									name: "sharedLog.receive.checkedPrune",
+									component: "shared-log",
+									entries: allToMerge.length,
+									messages: 1,
+								});
+							}
+
+							for (const plan of joinPlans) {
+								plan.toDelete
+									?.filter((entry) => admittedMergeHashes.has(entry.hash))
+									.map((entry) =>
+										this.pruneDebouncedFnAddIfNotKeeping({
+											key: entry.hash,
+											value: {
+												entry,
+												leaders: plan.leaders as Map<string, any>,
+											},
+										}),
+									);
+							}
+							this.rebalanceParticipationDebounced?.call();
+						} finally {
+							// Settle seam for the receive token. Every consumer that can
+							// roll it back runs inline before control leaves this block: the
+							// prepared-join callback resolves during the join await, and the
+							// late finish/rollback arm runs above. This `finally` is what
+							// closes the abandon arms (no prepared-join commit, a declined
+							// native commit, a downgrade to the plain join) without having
+							// to enumerate them.
+							this._coordinates.settleResidentCoordinateSnapshot(
+								nativeReceiveCoordinateBatch?.rollbackCoordinateEntries,
 							);
 						}
-						if (syncProfile) {
-							emitSyncProfileDuration(syncProfile, checkedPruneStartedAt, {
-								name: "sharedLog.receive.checkedPrune",
-								component: "shared-log",
-								entries: allToMerge.length,
-								messages: 1,
-							});
-						}
-
-						for (const plan of joinPlans) {
-							plan.toDelete
-								?.filter((entry) => admittedMergeHashes.has(entry.hash))
-								.map((entry) =>
-									this.pruneDebouncedFnAddIfNotKeeping({
-										key: entry.hash,
-										value: {
-											entry,
-											leaders: plan.leaders as Map<string, any>,
-										},
-									}),
-								);
-						}
-						this.rebalanceParticipationDebounced?.call();
 					}
 
 					for (const plan of joinPlans) {

--- a/packages/programs/data/shared-log/test/coordinate-generation-refcount-pins.spec.ts
+++ b/packages/programs/data/shared-log/test/coordinate-generation-refcount-pins.spec.ts
@@ -1,0 +1,498 @@
+// Pins G1-G6 for the hold-counted `_nativeCoordinateMutationGenerations` map.
+//
+// The map used to grow one row per distinct entry hash ever committed or
+// received, forever, with no removal path anywhere. It is now refcounted:
+// `snapshotResidentCoordinateEntries` takes one hold per hash per rollback
+// token, and `settleResidentCoordinateSnapshot` releases it at every point
+// where the token can no longer be rolled back, deleting the row at zero.
+//
+// The safety asymmetry these pins are built around: a MISSED settle only
+// retains a row (the pre-refcount behavior, never a regression), while a
+// PREMATURE settle deletes a row a live token still needs — which silently
+// turns that token's rollback into a no-op, or, once the hash's generation
+// numbering restarts from 1, lets a stale token clobber newer state (ABA).
+// So G3 and G4 carry the real weight: they assert that rollbacks that are
+// still OWED continue to fire, and that supersession is still detected.
+//
+// The rollback tokens are minted only on the native-backbone local-append and
+// receive paths. The local-append paths are reached through the prepared
+// payload commit-only entry point (`target: "none"`), which is how the
+// Documents program appends; a non-replicating log routes it to the
+// commit-only variant and a replicating log to the storage-transaction
+// variant, so both local seams are covered here.
+//
+// Every assertion below is a raw value — map `.size`, `.holds`, `.generation`,
+// coordinate-index counts, resident-mirror presence, native-backbone presence.
+// No ratios, no identity predicates. Where a leg asserts a no-op, the states
+// either side of it are made visibly different first, per the teeth rule
+// stated in coordinate-persistence-pins.spec.ts (P2).
+import { waitForResolved } from "@peerbit/time";
+import { expect } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Peerbit } from "peerbit";
+import { createRustPeerbitOptions } from "peerbit/rust";
+import { SharedLog } from "../src/index.js";
+import { EventStore } from "./utils/stores/event-store.js";
+
+type GenerationRow = { generation: number; holds: number };
+
+const coordinateInternals = (log: any): any => log._coordinates;
+
+/** Raw map. Only safe once the mechanism is known to have run. */
+const generationRows = (log: any): Map<string, GenerationRow> =>
+	coordinateInternals(log)._nativeCoordinateMutationGenerations;
+
+/** Raw row count, treating a never-created map as zero rows. */
+const generationRowCount = (log: any): number =>
+	coordinateInternals(log)._nativeCoordinateMutationGenerations?.size ?? 0;
+
+const countIndexed = async (log: any, hash: string): Promise<number> =>
+	log.entryCoordinatesIndex.count({ query: { hash } });
+
+const backboneHas = (log: any, hash: string): boolean =>
+	[...(log._nativeBackbone.getEntryCoordinateHashes() as string[])].includes(
+		hash,
+	);
+
+const payload = (value: string): Uint8Array =>
+	new TextEncoder().encode(JSON.stringify({ op: "PUT", value }));
+
+/**
+ * Drive one local append down the native-backbone prepared-payload path (the
+ * same entry point the Documents program uses).
+ *
+ * `meta.next: []` is load-bearing: the lower log only takes the native
+ * commit-only route for an entry with no explicit nexts, so without it every
+ * append after the first falls back to the generic path, mints no rollback
+ * token, and the bound pins below would assert an empty map that was never
+ * filled.
+ */
+const nativeAppend = (log: any, value: string) =>
+	log.appendLocallyPreparedPayloadCommitOnly(
+		payload(value),
+		{ target: "none", replicate: false, meta: { next: [] } },
+		undefined,
+	);
+
+/**
+ * Wrap `snapshotResidentCoordinateEntries` on a live coordinator so a pin can
+ * prove the writer actually ran (an empty map is only a bound if rows were
+ * really created) and observe the largest raw size the map ever reached.
+ */
+const instrumentSnapshots = (log: any) => {
+	const internals = coordinateInternals(log);
+	const original = internals.snapshotResidentCoordinateEntries.bind(internals);
+	const state = { calls: 0, maxSize: 0, tokens: [] as any[] };
+	internals.snapshotResidentCoordinateEntries = (hashes: Iterable<string>) => {
+		const token = original(hashes);
+		state.calls++;
+		if (token) {
+			state.tokens.push(token);
+		}
+		state.maxSize = Math.max(
+			state.maxSize,
+			internals._nativeCoordinateMutationGenerations?.size ?? 0,
+		);
+		return token;
+	};
+	return {
+		state,
+		restore: () => {
+			internals.snapshotResidentCoordinateEntries = original;
+		},
+	};
+};
+
+describe("coordinate persistence mutation-generation refcount", () => {
+	// G5 and the raw refcount mechanics need nothing but the coordinator, so
+	// they run as unit pins against a bare instance.
+	let log: any;
+
+	beforeEach(() => {
+		log = new SharedLog();
+	});
+
+	it("G5: settling a token twice is a no-op and cannot consume another token's hold", () => {
+		const internals = coordinateInternals(log);
+		const hash = "g5-shared-hash";
+
+		const tokenA = internals.snapshotResidentCoordinateEntries([hash]);
+		const tokenB = internals.snapshotResidentCoordinateEntries([hash]);
+		const rows = generationRows(log);
+		// Two tokens hold the same hash; the generation ratcheted twice.
+		expect(rows.get(hash)?.holds).to.equal(2);
+		expect(rows.get(hash)?.generation).to.equal(2);
+		expect(tokenA.generations.get(hash)).to.equal(1);
+		expect(tokenB.generations.get(hash)).to.equal(2);
+
+		internals.settleResidentCoordinateSnapshot(tokenA);
+		expect(rows.get(hash)?.holds).to.equal(1);
+		expect(rows.get(hash)?.generation).to.equal(2);
+
+		// The second settle of the SAME token must change nothing. Without the
+		// `settled` guard it would consume token B's hold and delete a row B
+		// still needs.
+		internals.settleResidentCoordinateSnapshot(tokenA);
+		expect(rows.has(hash), "token B's row must survive A's double settle").to
+			.be.true;
+		expect(rows.get(hash)?.holds).to.equal(1);
+
+		// B is the last holder: its settle is what deletes the row.
+		internals.settleResidentCoordinateSnapshot(tokenB);
+		expect(rows.has(hash)).to.be.false;
+		expect(rows.size).to.equal(0);
+	});
+
+	it("G5: settling is per-hash, so unrelated hashes keep their holds", () => {
+		const internals = coordinateInternals(log);
+		const shared = "g5-shared";
+		const onlyA = "g5-only-a";
+		const onlyB = "g5-only-b";
+
+		const tokenA = internals.snapshotResidentCoordinateEntries([shared, onlyA]);
+		internals.snapshotResidentCoordinateEntries([shared, onlyB]);
+		const rows = generationRows(log);
+		expect(rows.size).to.equal(3);
+
+		internals.settleResidentCoordinateSnapshot(tokenA);
+		expect(rows.size).to.equal(2);
+		expect(rows.has(onlyA)).to.be.false;
+		expect(rows.get(shared)?.holds).to.equal(1);
+		expect(rows.get(onlyB)?.holds).to.equal(1);
+	});
+});
+
+describe("coordinate persistence mutation-generation bounds", function () {
+	this.timeout(240_000);
+
+	let client: Peerbit | undefined;
+	let directory: string | undefined;
+	let store: EventStore<string, any> | undefined;
+
+	const openStore = async (args: any) => {
+		directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-coordinate-generation-pins-"),
+		);
+		client = await Peerbit.create({
+			directory,
+			...createRustPeerbitOptions(),
+		});
+		store = await client.open(new EventStore<string, any>(), { args });
+		const log = store.log as any;
+		// These pins are only meaningful against the native backbone coordinate
+		// stack: the rollback tokens are only minted there.
+		expect(log._nativeBackbone, "native backbone").to.exist;
+		expect(log._residentEntryCoordinatesByHash, "resident mirror").to.exist;
+		return log;
+	};
+
+	afterEach(async () => {
+		await client?.stop();
+		client = undefined;
+		store = undefined;
+		if (directory) {
+			await fs.rm(directory, { recursive: true, force: true });
+			directory = undefined;
+		}
+	});
+
+	const appendCount = 200;
+
+	const boundedLocalAppendLeg = async (replicate: any, label: string) => {
+		const log = await openStore({ replicate });
+		const probe = instrumentSnapshots(log);
+		try {
+			for (let index = 0; index < appendCount; index++) {
+				await nativeAppend(log, `${label}-${index}`);
+			}
+		} finally {
+			probe.restore();
+		}
+
+		// Teeth: every append really minted a rollback token, and the map
+		// really held rows during the run. Without this an append path that
+		// silently stopped taking the native route would leave an empty map
+		// and the bound below would pass for the wrong reason. Raw counts, not
+		// a ratio against anything.
+		expect(probe.state.calls, "snapshot tokens minted").to.be.at.least(
+			appendCount,
+		);
+		expect(probe.state.maxSize, "rows resident during the run").to.be.at.least(
+			1,
+		);
+
+		await waitForResolved(() => {
+			expect(generationRowCount(log)).to.equal(0);
+		});
+	};
+
+	it("G1: the raw map is empty again after 200 commit-only local appends", async () => {
+		// A non-replicating log defers head coordinate persistence, which routes
+		// the prepared payload append to the commit-only native variant.
+		await boundedLocalAppendLeg(false, "g1-commit-only");
+	});
+
+	it("G1: the raw map is empty again after 200 storage-transaction local appends", async () => {
+		// A replicating log takes the storage-transaction native variant.
+		await boundedLocalAppendLeg({ factor: 1 }, "g1-storage-transaction");
+	});
+
+	const owedRollbackLeg = async (replicate: any, label: string) => {
+		const log = await openStore({ replicate });
+		const probe = instrumentSnapshots(log);
+
+		// Fault injection: reject the durable lower-marker write, which runs
+		// INSIDE `nativeCommittedAppendFinalizer.acknowledge` — i.e. after the
+		// native coordinates are committed and before the success seam.
+		const originalMarker =
+			log.markNativeStrictDurableTransactionLowerMarker.bind(log);
+		let injectionsFired = 0;
+		let committedAtFailure: string[] = [];
+		let armed = true;
+		log.markNativeStrictDurableTransactionLowerMarker = async (
+			...args: any[]
+		) => {
+			if (armed) {
+				armed = false;
+				injectionsFired++;
+				// Snapshot the state the rollback is owed against: the native
+				// coordinates are live right now, so the post-rollback probes
+				// below are asserting a visibly DIFFERENT state.
+				committedAtFailure = [...tokenHashes(probe.state.tokens)].filter(
+					(hash) => backboneHas(log, hash),
+				);
+				throw new Error("pinned lower-marker durability failure");
+			}
+			return originalMarker(...args);
+		};
+
+		let error: any;
+		try {
+			await nativeAppend(log, `${label}-doomed`);
+		} catch (caught) {
+			error = caught;
+		} finally {
+			log.markNativeStrictDurableTransactionLowerMarker = originalMarker;
+			probe.restore();
+		}
+
+		// The injection must actually have fired, and it must have fired while
+		// the native coordinates were committed; a dead injection would make
+		// every assertion below pass for the wrong reason.
+		expect(injectionsFired, "fault injection fired").to.equal(1);
+		expect(error, "the append must fail").to.exist;
+		expect(
+			committedAtFailure.length,
+			"native coordinates were live when the append failed",
+		).to.be.greaterThan(0);
+
+		// The rollback was still owed and must have fully erased the append.
+		// If the settle had run one step early (before the acknowledge await),
+		// the row would be gone from the map, the generation gate would read
+		// `undefined`, the rollback would silently no-op, and these three raw
+		// probes would show phantom coordinates.
+		for (const hash of committedAtFailure) {
+			expect(await countIndexed(log, hash), `indexed ${hash}`).to.equal(0);
+			expect(
+				log._residentEntryCoordinatesByHash.has(hash),
+				`resident ${hash}`,
+			).to.be.false;
+			expect(backboneHas(log, hash), `backbone ${hash}`).to.be.false;
+		}
+		expect(generationRowCount(log)).to.equal(0);
+	};
+
+	const tokenHashes = (tokens: any[]): Set<string> => {
+		const hashes = new Set<string>();
+		for (const token of tokens) {
+			for (const hash of token.hashes as Set<string>) {
+				hashes.add(hash);
+			}
+		}
+		return hashes;
+	};
+
+	// Only the storage-transaction variant is pinned here. The commit-only
+	// variant runs with head coordinate persistence DEFERRED, so at the same
+	// injection point no coordinate row is committed yet — the leg's own
+	// "native coordinates were live when the append failed" teeth assertion
+	// fails there, which is why it is deliberately not run.
+	it("G3: an owed rollback still fires after the success seam was added", async () => {
+		await owedRollbackLeg({ factor: 1 }, "g3-storage-transaction");
+	});
+
+	it("G4: a superseded token stays a strict no-op, which plain delete would break", async () => {
+		const log = await openStore({ replicate: { factor: 1 } });
+		const internals = coordinateInternals(log);
+		const entry = (await store!.add("g4", { meta: { next: [] } })).entry;
+		const hash = entry.hash;
+		expect(await countIndexed(log, hash)).to.equal(1);
+		expect(generationRowCount(log)).to.equal(0);
+
+		// Token A captures the persisted row as its before-image.
+		const tokenA = internals.snapshotResidentCoordinateEntries([hash]);
+		expect(tokenA.entries.has(hash)).to.be.true;
+		// Token B supersedes it on the same hash.
+		const tokenB = internals.snapshotResidentCoordinateEntries([hash]);
+		const rows = generationRows(log);
+		expect(rows.get(hash)?.holds).to.equal(2);
+		expect(rows.get(hash)?.generation).to.equal(2);
+
+		// Settling B must NOT drop the row: A still holds it, and the row is
+		// what remembers that A has been superseded.
+		internals.settleResidentCoordinateSnapshot(tokenB);
+		expect(rows.has(hash), "A's hold must keep the row alive").to.be.true;
+		expect(rows.get(hash)?.holds).to.equal(1);
+		expect(rows.get(hash)?.generation).to.equal(2);
+
+		// A newer mutation on the same hash. With a hold-counted row this
+		// ratchets to generation 3; if settling had DELETED the row, numbering
+		// would restart at 1 and collide with A's stale generation (ABA), and
+		// A's rollback would fire and restore the stale row below.
+		internals.snapshotResidentCoordinateEntries([hash]);
+		expect(rows.get(hash)?.generation).to.equal(3);
+
+		// Make the newer visible state differ from A's snapshot, so a rollback
+		// that wrongly fires is observable rather than indistinguishable.
+		await internals.deleteCoordinatesForHashes([hash]);
+		expect(await countIndexed(log, hash)).to.equal(0);
+		expect(log._residentEntryCoordinatesByHash.has(hash)).to.be.false;
+		expect(backboneHas(log, hash)).to.be.false;
+
+		await internals.rollbackNativeBackboneCoordinateAppendDurably(hash, tokenA);
+
+		// A is superseded: it must restore nothing.
+		expect(await countIndexed(log, hash)).to.equal(0);
+		expect(log._residentEntryCoordinatesByHash.has(hash)).to.be.false;
+		expect(backboneHas(log, hash)).to.be.false;
+	});
+
+	it("G6: the durable-recovery replay no longer leaves rows behind", async () => {
+		const log = await openStore({ replicate: { factor: 1 } });
+		const internals = coordinateInternals(log);
+		await store!.add("g6-warmup", { meta: { next: [] } });
+		expect(generationRowCount(log)).to.equal(0);
+
+		const coordinateHashes = ["g6-a", "g6-b", "g6-c", "g6-d", "g6-e"];
+		await log.writeNativeStrictDurableTransactionIntent({
+			version: 1,
+			appendHashes: [],
+			trimHashes: [],
+			coordinateDeleteHashes: [],
+			lowerIndexRows: [],
+			coordinates: coordinateHashes.map((hash) => ({ hash })),
+			documents: [],
+		});
+
+		// Observe the replay's own token so the pin can prove the coordinate
+		// replay branch actually ran with all K hashes.
+		const originalRollback =
+			internals.rollbackNativeBackboneCoordinateAppendDurably.bind(internals);
+		let replayedGenerations = 0;
+		let replayCalls = 0;
+		internals.rollbackNativeBackboneCoordinateAppendDurably = async (
+			appendHash: string,
+			rollback: any,
+		) => {
+			replayCalls++;
+			replayedGenerations = Math.max(
+				replayedGenerations,
+				rollback?.generations?.size ?? 0,
+			);
+			return originalRollback(appendHash, rollback);
+		};
+
+		let recovered: boolean;
+		try {
+			recovered = await log.recoverNativeStrictDurableTransactionIntent(true);
+		} finally {
+			internals.rollbackNativeBackboneCoordinateAppendDurably =
+				originalRollback;
+		}
+
+		expect(recovered, "recovery completed").to.be.true;
+		expect(replayCalls, "the coordinate replay ran").to.equal(1);
+		expect(replayedGenerations, "every intent coordinate was replayed").to.equal(
+			coordinateHashes.length,
+		);
+		expect(generationRowCount(log)).to.equal(0);
+	});
+});
+
+describe("coordinate persistence mutation-generation receive bounds", function () {
+	this.timeout(240_000);
+
+	let peer1: Peerbit | undefined;
+	let peer2: Peerbit | undefined;
+	let directories: string[] = [];
+
+	const createDurablePeer = async () => {
+		// The backbone-only receive path — the only receive path that mints a
+		// rollback token — is gated on an auto-derived durable coordinate
+		// persistence adapter, which is only created when the node has a
+		// directory. A memory-only node never reaches the snapshot at all and
+		// would make this pin vacuous.
+		const directory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "peerbit-coordinate-generation-receive-pins-"),
+		);
+		directories.push(directory);
+		return Peerbit.create({ directory, ...createRustPeerbitOptions() });
+	};
+
+	afterEach(async () => {
+		await peer1?.stop();
+		await peer2?.stop();
+		peer1 = undefined;
+		peer2 = undefined;
+		for (const directory of directories) {
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+		directories = [];
+	});
+
+	it("G2: the receiver's raw map is empty again after a cold sync", async () => {
+		const entryCount = 200;
+		peer1 = await createDurablePeer();
+		peer2 = await createDurablePeer();
+
+		const store = new EventStore<string, any>();
+		const db1 = await peer1.open(store.clone(), {
+			args: { replicate: { factor: 1 } },
+		});
+		const db2 = await peer2.open(store.clone(), {
+			args: { replicate: { factor: 1 } },
+		});
+		const receiver = db2.log as any;
+		expect((db1.log as any)._nativeBackbone, "peer1 native backbone").to.exist;
+		expect(receiver._nativeBackbone, "peer2 native backbone").to.exist;
+
+		for (let index = 0; index < entryCount; index++) {
+			await db1.add(`g2-${index}`, { meta: { next: [] } });
+		}
+
+		const probe = instrumentSnapshots(receiver);
+		try {
+			await peer2.dial(peer1.getMultiaddrs());
+			await waitForResolved(
+				() => {
+					expect(db2.log.log.length).to.equal(entryCount);
+				},
+				{ timeout: 90_000, timeoutMessage: "receive-path cold sync" },
+			);
+			// Teeth: the receive path really minted tokens and the map really
+			// held rows while the batches were in flight.
+			expect(probe.state.calls, "receive tokens minted").to.be.greaterThan(0);
+			expect(
+				probe.state.maxSize,
+				"rows resident during the sync",
+			).to.be.at.least(1);
+			await waitForResolved(() => {
+				expect(generationRowCount(receiver)).to.equal(0);
+			});
+		} finally {
+			probe.restore();
+		}
+	});
+});


### PR DESCRIPTION
Fixes the largest confirmed memory leak in the package — the last open finding from the shared-log growth audit.

## The leak

`_nativeCoordinateMutationGenerations` grows **one row per distinct entry hash ever committed or received**, with no removal path of any kind — no delete, no clear, not even on close. It survives close→reopen (the coordinator is created with `??=`), so only a process restart relieves it, and the native backbone that gates it is on by default. Growth is monotone in lifetime throughput and independent of retained data, so the worst shape is a trimming replicator whose on-disk log stays small while this map tracks everything it ever saw.

## Why the obvious fixes are unsafe, and this one is not

It is a lock/ratchet table, not a cache. Evicting a row makes `get()` return `undefined`, which reads as "superseded", so an owed rollback silently no-ops and leaves phantom native coordinates. Inverting the sentinel is symmetric: eviction lets a stale token clobber a newer mutation. TTL, LRU, size caps and clear-on-close are therefore all genuinely unsafe here, and per-transaction scoping is impossible because detecting *cross*-transaction supersession is the point.

What makes a bounded design legal is that **the map is already non-authoritative across restarts**: the durable-recovery replay fabricates fresh generations and compares them against what it just wrote a turn earlier, so it cannot fail and behaves identically on a cold map; generations are never serialized into the durable intent; and cross-restart correctness rests on content CAS, not counters. The absolute value is meaningless — only *whether it changed since a token was minted* matters. So a row is dead once no live token references it.

Hence: hold-counted rows (`{ generation, holds }`, one map — two parallel maps could desynchronise) and a `settleResidentCoordinateSnapshot` that releases a token's holds and deletes at zero. The `settled` flag is load-bearing, not hygiene: without it a second settle of one token consumes another's hold on a shared hash.

## Why an incomplete site list is still safe

The failure modes are asymmetric. A **missed** settle leaves the row forever — exactly today's behaviour, no regression. Only a **premature** settle is dangerous. So correctness depends on each *placed* settle being terminal, never on enumerating them all. Every one of the 13 placements sits after the last `await` inside the try whose catch is the last rollback consumer, and each was verified independently by an adversarial reviewer who walked all 13 and found no premature settle.

Deliberately **not** settled: the shared rollback sink (`rollbackFailedNativeBackboneTransaction`). Its two callers are argued to be mutually exclusive, but "probably right" is what turns a leak into a fail-open bug, and `settled` guards double-settle, not settle-then-rollback. Those rare failure paths still leak one row each — the growth shape becomes monotone in lifetime *rollback failures* instead of lifetime throughput, which is a strict improvement.

## Validation

Pins G1–G6 assert raw values (map `.size`, `countIndexed`, the resident mirror, backbone presence). Four mutations, each red then restored:
- delete the local-append success settle → **200 leaked rows**;
- move a success settle one step early → **G3 red with a phantom coordinate surviving** — the fatal shape, caught, with its own injection teeth (`injectionsFired === 1`) passing in that run so the red is the defect and not a dead injection;
- unconditional delete instead of hold-decrement → G4 red (this is what justifies refcounting over plain delete);
- drop the `settled` guard → G5 red.

Suites: 356 + 155 + 68 (document durable-native) + 18 coordinate pins, all green; fence-ratchet 20/20; shard-coverage 71 describes covered (the new describes match the existing `^coordinate persistence` shard grep, so no root change was needed); repo lint 0 errors.

Two pin-authoring traps were found and fixed rather than papered over: G1's driver only minted a token on the *first* append of its loop until `meta: { next: [] }` routed every append down the native path (a teeth assertion now fails if that silently regresses), and a commit-only variant of G3 was **removed** because it failed its own teeth assertion — at that injection point head coordinate persistence is deferred, so there is nothing committed to roll back and the leg would have asserted nothing.

## Known gaps, stated plainly

The fatal shape is pinned at one of five settle families; the batch success seam is the one I would pin next, since it is deliberately placed early and so is most sensitive to a future edit moving a rollback consumer below it. The design's completeness gate (a create-vs-settle balance over the chaos suites) is not implemented, so *how much* of the leak is closed is unmeasured — a measurement gap, not a correctness gap.