### PR TITLE
docs(shared-log): explain why _gidPeersHistory cannot be trimmed cheaply

### DIFF
--- a/.changeset/gid-peers-history-design-note.md
+++ b/.changeset/gid-peers-history-design-note.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Document why the `_gidPeersHistory` map cannot be released from the trim path. Comment only; no behavior change. The note records the growth shape (one row per distinct gid ever held, released only by prune, last-peer-drop, an explicit cache-clearing rebalance, and close/reset), why copying prune's whole-row delete onto trim would drop a live suppression memo and pay for the freed memory in redundant delivery and repair traffic, and what a correct bound would require.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2038,7 +2038,58 @@ export class SharedLog<
 
 	/* private _totalParticipation!: number; */
 
-	// gid -> coordinate -> publicKeyHash list (of owners)
+	// gid -> set of publicKeyHashes known to hold that gid's entries.
+	//
+	// This is a suppression memo, not a source of truth. A present row lets the
+	// rebalance and repair paths skip re-sending an entry to a peer that already
+	// has it. Every read is `?.has(peer)` guarded, and a MISSING row always
+	// means "assume nothing is known", which produces strictly MORE work --
+	// redundant unchecked delivery in the rebalance loop, redundant queueing in
+	// the repair planner -- and never a wrong prune, a wrong quorum, or data
+	// loss. Losing a row costs bandwidth; keeping a stale row costs a little
+	// memory. That asymmetry is what the rest of this note turns on.
+	//
+	// GROWTH SHAPE. Rows are released by `deleteGidPeerHistory` on the two prune
+	// paths, by `removePeerFromGidPeerHistory` once a gid's last peer drops (the
+	// routine disconnect outcome), by `rebalanceAll({ clearCache: true })`, and
+	// wholesale on close/reset. Nothing on the TRIM path releases a row, so a
+	// node that bounds its log with trim rather than prune accumulates one row
+	// per distinct gid it has ever held. A gid names a graph, not an entry: an
+	// entry with `meta.next` inherits `min(next.meta.gid)` (see
+	// packages/log/src/entry-v0.ts), so document updates fold into the gid of
+	// the first put and the row count tracks distinct chain roots -- distinct
+	// document ids -- rather than entry count. Insert-only workloads mint a
+	// fresh gid per append and so do grow one row per entry. Merges are a
+	// smaller second source: when a join links two graphs the losing entries
+	// keep their own `meta.gid` on disk, and shared-log does not subscribe to
+	// the log's `onGidRemoved`, so the shadowed gid's row lingers too.
+	//
+	// WHY TRIM DOES NOT SIMPLY CALL `deleteGidPeerHistory` AS WELL. Both prune
+	// callers delete a whole row from a single entry's gid, and under the
+	// default hash domain that is correct by construction: the coordinate is a
+	// pure function of the gid (replication-domain-hash.ts sha256s
+	// `entry.meta.gid`), so identical gid => identical coordinates => identical
+	// leader set => every local sibling of that gid is prune-eligible in the
+	// same batch. The gid really is finished locally. Trim offers no such
+	// guarantee. It walks oldest-first against a length/bytelength/age bound and
+	// stops the instant the bound is met (packages/log/src/trim.ts); its only
+	// use of gid is memoizing the caller's `canTrim` verdict, never grouping
+	// deletes. So trim routinely removes the OLDEST entry of a gid while newer
+	// siblings -- same gid, same coordinates, still local, still replicated --
+	// remain. Copying the prune call onto trim would therefore delete a LIVE row
+	// on the common path, paying for the freed memory in repeated re-delivery of
+	// entries that are still here. That trade is not worth it.
+	//
+	// Bounding this correctly requires a per-gid count of locally held entries,
+	// dropping the row only when it reaches zero -- a real reverse index, not a
+	// one-line delete. Deliberately not built: the growth is bounded by distinct
+	// gids, and the cheap version is a bandwidth regression.
+	//
+	// Existing, deliberate imprecision: under the time domain the coordinate is
+	// `meta.clock.timestamp.wallTime` (replication-domain-time.ts) and is
+	// gid-independent, so siblings of one gid can carry different leader sets
+	// and prune's whole-row delete is already over-eager there. The cost is the
+	// same bounded extra traffic, never a wrong prune.
 	_gidPeersHistory!: Map<string, Set<string>>;
 
 	private _onSubscriptionFn!: (arg: any) => any;


### PR DESCRIPTION
The last of the three findings from the shared-log memory-growth audit. **The leak is real and this PR deliberately does not fix it** — comment-only, no behaviour change. Recording why, so the next person to notice the gap does not spend the afternoon rediscovering it or, worse, "fixes" it.

## The gap

`_gidPeersHistory` is cleaned on prune (two callers) and on peer disconnect, and wiped on close. Nothing on the **trim** path removes rows, so trimmed entries leave their gid rows behind. Growth tracks distinct gids ever seen, which for a document store roughly tracks entry count.

## Why the obvious fix is wrong

A gid names a **graph**, not an entry: an entry with `meta.next` inherits `min(next.meta.gid)`, and only a no-next entry mints a fresh one (`entry-v0.ts`, `log.ts`). Every subsequent version of a document therefore joins the first put's gid.

Under the hash domain the coordinate is a pure function of the gid, so identical gid ⇒ identical coordinates ⇒ identical leader set ⇒ every local sibling of a gid is prunable in the same batch. That is what makes prune's whole-row `deleteGidPeerHistory(entry.meta.gid)` correct-by-construction — the gid genuinely is finished locally.

**Trim provides no such guarantee.** It is length/bytelength/age-bounded over sort order and completely gid-blind, so it will routinely remove the oldest entry of a gid while newer siblings — same gid, same coordinates, still local, still replicated — remain. Copying prune's delete onto trim would drop a *live* row on the common path of any update-heavy store.

## What a missing row actually costs

Both consumers are pure suppression memos — a missing row means "assume nothing known", which always produces more work, never less:
- the repair planner re-queues entries to peers that already hold them (partly absorbed by the per-entry suppressor);
- the rebalance path re-delivers entry bodies to every current leader — the largest real cost.

One case looks like a safety hole and is not: a missing row skips a checked-prune receipt revocation, but the delete boundary independently re-derives ownership inside the global mutation lane and counts only confirmations whose peer is still a leader, so a stale receipt cannot pass that gate.

That the codebase already tolerates total eviction — `rebalanceAll({ clearCache: true })` wipes the whole map as a sanctioned operation — confirms the shape: **rows are an optimisation, and losing them costs network traffic, never correctness.**

So a cheap fix would trade bounded memory for redundant delivery traffic *and* delete live rows. Not a good trade for the smallest of the three findings, when the other two are already fixed and shipped.

## Also recorded

Under the **time** domain the coordinate is gid-independent, so siblings of one gid land at different coordinates — which makes prune's existing whole-row delete over-eager there. The consequence is bounded to the same redundant traffic (never a wrong prune, never data loss), so it is noted as an existing imprecision rather than raised as a bug.

A changeset is included because the touched file ships in a published package, even though only comments changed.