### PR TITLE
ci: run the orphaned indexer, any-store and canonical suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"test:interop": "aegir run test:interop",
 		"test:docs": "aegir run test --roots ./docs -- -t node",
 		"test:part-1": "aegir run test --roots ./packages/utils/** ./packages/clients/** ./packages/log  -- -t node",
-		"test:ci:part-1": "aegir run test:cov --roots ./packages/utils/** ./packages/clients/peerbit ./packages/clients/test-utils ./packages/clients/vite ./packages/log -- --no-build && pnpm --fail-if-no-match --filter @peerbit/react run test:cov && pnpm run test:ci:react-identity && pnpm run test:ci:react-sqlite-dev",
+		"test:ci:part-1": "aegir run test:cov --roots ./packages/utils/** ./packages/utils/indexer/interface ./packages/utils/indexer/simple ./packages/utils/indexer/sqlite3 ./packages/utils/indexer/cached-index ./packages/utils/any-store/any-store ./packages/clients/peerbit ./packages/clients/test-utils ./packages/clients/vite ./packages/clients/canonical/client ./packages/clients/canonical/transport ./packages/log -- --no-build && pnpm --fail-if-no-match --filter @peerbit/react run test:cov && pnpm run test:ci:react-identity && pnpm run test:ci:react-sqlite-dev",
 		"test:react-identity": "pnpm --filter @peerbit/react-e2e-browser... build && pnpm --filter @peerbit/react-e2e-browser exec playwright test tests/identity.spec.ts",
 		"test:ci:react-identity": "pnpm --fail-if-no-match --filter @peerbit/react-e2e-browser exec playwright test tests/identity.spec.ts",
 		"test:ci:react-sqlite-dev": "PEERBIT_E2E_VITE_DEV=1 pnpm --fail-if-no-match --filter @peerbit/react-e2e-browser exec playwright test tests/sqlite3-wasm.spec.ts",

--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -59,24 +59,22 @@ console.log(`OK: ${checked} literal shared-log describes are all covered by CI s
 // the one-level --roots globs never matched them; some are exercised
 // indirectly or in the Native job instead). Shrink this list when wiring a
 // package into a shard — never grow it without a deliberate decision.
+//
+// The seven Node-runnable ones were wired into part-1 by explicit roots (the
+// glob still cannot reach them). What remains needs different infrastructure,
+// not a shard entry: the rust crates build in the Native job, the e2e suites
+// need a browser runner, and the peerbit-server pair was not verified.
 const KNOWN_UNREACHABLE = new Set([
-	"packages/clients/canonical/client",
 	"packages/clients/canonical/host",
-	"packages/clients/canonical/transport",
 	"packages/clients/peerbit-server/node",
 	"packages/clients/peerbit-server/test-lib",
 	"packages/log/rust",
 	"packages/programs/data/shared-log/proxy/e2e",
 	"packages/transport/stream/e2e/browser",
-	"packages/utils/any-store/any-store",
 	"packages/utils/any-store/proxy",
 	"packages/utils/any-store/proxy/e2e",
 	"packages/utils/any-store/rust",
-	"packages/utils/indexer/cached-index",
-	"packages/utils/indexer/interface",
 	"packages/utils/indexer/rust",
-	"packages/utils/indexer/simple",
-	"packages/utils/indexer/sqlite3",
 ]);
 
 const rootTokens = new Set();


### PR DESCRIPTION
Seven packages had test suites that **CI has never run**. This wires them in. All were already green — nothing needed fixing, they were simply invisible.

| package | tests |
|---|---|
| `@peerbit/indexer-sqlite3` | 308 |
| `@peerbit/indexer-simple` | 128 |
| `@peerbit/any-store` | 40 |
| `@peerbit/indexer-cache` | 8 |
| `@peerbit/canonical-client` | 8 |
| `@peerbit/canonical-transport` | 3 |
| `@peerbit/indexer-interface` | 2 |

**497 tests**, of which 308 cover the SQLite indexer that shared-log builds on.

## Why they were invisible

`part-1` already globs `./packages/utils/**`, which looks like it covers them — but that glob only descends **one level**, and `packages/utils/indexer` has no `package.json` of its own, so `packages/utils/indexer/sqlite3` was never matched. The coverage guard's own header documents this failure mode; these seven were sitting in its `KNOWN_UNREACHABLE` debt baseline.

Fixed by naming them as explicit roots rather than by widening the glob, since the nesting is the actual problem and a deeper glob would silently pick up future non-package directories.

## Cost

Negligible: sqlite3 is ~5s, cached-index ~6s, the rest are milliseconds. `part-1` is one of the shorter shards.

## Verified end to end, not just by the guard

The guard only checks *reachability*, which is precisely the check that would not have caught this class of bug. So I ran the shard itself — `pnpm run test:ci:part-1`, rc=0 — and confirmed each package appears in the output with its own passing count. Reachable and actually executed are different claims.

The baseline shrinks 17 → 10. The remaining ten are documented in the script as needing different infrastructure rather than a shard entry: the Rust crates build in the Native job, the e2e suites need a browser runner, and the `peerbit-server` pair I did not verify — left in the baseline rather than wired in on assumption.