### PR TITLE
ci: restore node 24 in the security matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,29 +200,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 24 is deliberately absent, not forgotten. This job's
-        # published-closure smoke installs the packed tarballs with npm, which
-        # resolves `@libp2p/webrtc@^6.0.15` -> `node-datachannel@^0.29.0` on its
-        # own -- and 0.29.0 publishes NO prebuilt binaries, so that install
-        # always compiles from source. The source build is broken on Node 24:
-        # prebuild/prebuild-install are deprecated and their napi-build-utils
-        # cannot resolve NAPI v10, aborting with "does not support N-API version
-        # undefined" (upstream
-        # https://github.com/murat-dogan/node-datachannel/issues/428, open since
-        # 2026-07, no release since 2026-04).
+        # Node 24 was dropped from this matrix in #1239 and restored here after
+        # the reason given for dropping it turned out to be false. That reason
+        # was: the published-closure smoke installs packed tarballs with npm,
+        # which "resolves `@libp2p/webrtc@^6.0.15` -> `node-datachannel@^0.29.0`
+        # on its own", and 0.29.0 ships no prebuilds so the install compiles
+        # from source, which is broken on Node 24 (upstream
+        # https://github.com/murat-dogan/node-datachannel/issues/428).
         #
-        # The workspace install no longer has this problem -- a root pnpm
-        # override pins node-datachannel to the prebuilt 0.32.3 -- but overrides
-        # do not reach a consumer resolving our published manifests, so this one
-        # lane stayed intermittently red for a reason outside our control. A
-        # permanently failing lane trains readers to ignore red, which costs
-        # more than the forward-compat signal it was buying.
+        # `^6.0.15` admits 6.0.21+, and npm takes the highest match. A consumer
+        # resolving our published manifests gets `@libp2p/webrtc@6.0.29`, whose
+        # `node-datachannel` range is `^0.32.3` -- which does ship prebuilds.
+        # Verified by running the smoke itself on Node 24: exit 0.
         #
-        # RESTORE Node 24 here once `@libp2p/webrtc` is on a release whose
-        # `node-datachannel` ships prebuilds (6.0.21+, which needs
-        # `@libp2p/interface ^3.2.2` and therefore a libp2p stack upgrade -- see
-        # PR #1235 for why the scoped bump does not work).
-        node-version: [22.x]
+        # The mistake was conflating two different resolutions. Our OWN lockfile
+        # is held at webrtc 6.0.15 because the workspace cannot typecheck
+        # against 6.0.21+ (duplicate `@libp2p/interface`, see #1235), and the
+        # root pnpm override keeps that install on prebuilt node-datachannel
+        # 0.32.3. None of that constrains a consumer, who resolves the range
+        # fresh and lands on a webrtc new enough to be fine.
+        #
+        # So this lane is not "permanently red for an upstream reason"; it is
+        # exactly the forward-compat signal it looks like, and Node 24 belongs
+        # in it. If it does go red, read the failure before removing the lane.
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -431,12 +431,13 @@ assert.doesNotMatch(
 );
 const securityJob = workflowJob(ciWorkflow, "security_dependency_contracts");
 assert.match(securityJob, /needs: build_workspace/);
-// Node 24 is deliberately absent from this matrix (see ci.yml for why, and for
-// the condition that restores it). This contract keeps that a DELIBERATE
-// omission rather than silent drift: re-adding a 24 entry while
-// node-datachannel's source build is still broken there would reintroduce a
-// permanently red lane, so it must be a conscious edit here too.
-assert.match(securityJob, /node-version: \[22\.x\]/);
+// Both supported majors must stay in this matrix. Node 24 was dropped once
+// (#1239) on the incorrect premise that a consumer resolving our published
+// manifests lands on a prebuild-less node-datachannel; it does not (see the
+// ci.yml comment for the resolution walk-through). Dropping a runtime from the
+// published-closure smoke silently narrows what "we support Node 24" means, so
+// it has to be a conscious edit here too.
+assert.match(securityJob, /node-version: \[22\.x, 24\.x\]/);
 assert.match(securityJob, /node-version: \$\{\{ matrix\.node-version \}\}/);
 assert.match(securityJob, /pnpm install --frozen-lockfile/);
 const restoreIndex = securityJob.indexOf("Restore workspace build outputs");


### PR DESCRIPTION
Reverts the matrix change from #1239. **I removed that lane on a premise that is false, and I should have checked it before removing coverage.**

## The claim I made

> This job's published-closure smoke installs the packed tarballs with npm, which resolves `@libp2p/webrtc@^6.0.15` → `node-datachannel@^0.29.0` on its own. 0.29.0 publishes no prebuilt binaries, so that install always compiles from source — and the source build is broken on Node 24.

## Why it is wrong

`^6.0.15` is not a pin. It admits everything below 7.0.0, and npm takes the **highest** match:

| webrtc | published | node-datachannel range |
|---|---|---|
| 6.0.15 | 2026-03-28 | `^0.29.0` — no prebuilds |
| 6.0.20 | 2026-04-25 | `^0.29.0` |
| **6.0.21** | **2026-05-04** | **`^0.32.3` — prebuilds** |
| 6.0.29 | 2026-07-30 | `^0.32.3` |

A consumer resolving our published manifests gets 6.0.29 → node-datachannel 0.32.3 → prebuilt binary. The prebuild-less 0.29.0 never enters the picture. 6.0.21 has been out since May, which is before I wrote that comment.

## What I actually confirmed, by running it

- Clean `npm install` of `@libp2p/webrtc@^6.0.15` on Node 24 → exit 0, resolves webrtc **6.0.29** and node-datachannel **0.32.3**.
- The real thing — `node scripts/test-published-security-smoke.mjs` on Node 24 — **exit 0**: 13 security roots, all 54 publishable packages as exact local tarballs, peer-free install, zero production audit findings.

## Where the mistake came from

I conflated two different resolutions. Our **own lockfile** is held at webrtc 6.0.15 because the workspace cannot typecheck against 6.0.21+ (duplicate `@libp2p/interface`, #1235), and #1236's override keeps that install on prebuilt node-datachannel 0.32.3. I carried "we are stuck on 6.0.15" over to the consumer, who is not stuck on anything — they resolve the range fresh. The libp2p stack upgrade is still needed for our own build; it was never needed for this lane.

The knock-on effect is worth naming: #1239 argued a lane failing for an upstream reason we cannot fix is worse than no lane. That argument is sound, and it was applied to a lane that was not failing for that reason. Removing it quietly narrowed what "peerbit supports Node 24" is backed by.

## Verification limits

Local runs were macOS arm64 / Node 24.13.1. CI is linux x64 / Node 24.x. `node-abi` resolves by major and 0.32.3 publishes linux-x64 prebuilds, so I expect it to hold — but **this PR's own security lane is the actual proof**, not my local run. If it goes red, the failure gets read and reported before anything is removed again.

The contract in `test-release-security-contracts.mjs` now pins `[22.x, 24.x]` and is mutation-verified: reducing the matrix to `[22.x]` fails it, restoring passes.