### PR TITLE
ci: give every master push its own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,19 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # PRs: superseded pushes cancel the stale run. Master pushes queue instead of
-  # cancelling each other, so every master commit gets a completed CI verdict.
+  # PRs share a group per PR number so a superseded push cancels the stale run.
+  # Master pushes get a UNIQUE group (run_id) so they can never cancel or evict
+  # one another, and every master commit gets its own completed CI verdict.
+  #
+  # The previous form grouped master pushes by github.ref with
+  # cancel-in-progress false, on the theory that they would queue. They do not
+  # reliably: GitHub holds at most ONE pending run per concurrency group, and a
+  # third run CANCELS the one waiting rather than lining up behind it. On
+  # 2026-08-13, #1245/#1244/#1246 merged within 38 minutes and #1244 -- the
+  # version-bump commit that published to npm -- was cancelled with no CI
+  # verdict on master at all. A unique group per push is the only form that
+  # actually delivers the guarantee the old comment claimed.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   WASM_PACK_VERSION: 0.13.1

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -209,6 +209,17 @@ assert.doesNotMatch(
 	/\$\{\{\s*secrets\./,
 	"CI must not depend on long-lived repository secrets",
 );
+// Master pushes must land in a UNIQUE concurrency group. Grouping them by
+// github.ref does not queue them: GitHub keeps only one pending run per group
+// and cancels the waiting one when a third arrives, so a burst of merges
+// silently leaves master commits with no CI verdict (this happened to the
+// #1244 publish commit on 2026-08-13). run_id is unique per run, so no master
+// push can ever evict another.
+assert.match(
+	ciWorkflow,
+	/group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}/,
+	"CI concurrency must fall back to github.run_id, not github.ref, so master pushes cannot evict each other",
+);
 assert.doesNotMatch(
 	ciWorkflow,
 	/^\s*pull_request_target:/m,


### PR DESCRIPTION
The CI concurrency block promised something GitHub does not provide, and it cost us a CI verdict today.

## The old form

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
# PRs: superseded pushes cancel the stale run. Master pushes queue instead of
# cancelling each other, so every master commit gets a completed CI verdict.
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`cancel-in-progress` is correctly `false` for pushes, so the reasoning looks sound. But that flag only governs the **running** job. GitHub holds at most **one pending run per concurrency group** — when a third run arrives, it cancels the one that was waiting. Master pushes sharing a group by `github.ref` therefore do not queue up; they evict each other.

## It already happened

#1245, #1244 and #1246 merged within 38 minutes today. The master run for **#1244 — the version-bump commit that published to npm** — is `cancelled`, the only cancellation in the last 20 master CI runs:

```
              08-13T21:48  Merge pull request #1246 ...
cancelled     08-13T21:46  Merge pull request #1244 from dao-xyz/changeset-release/master
              08-13T21:10  Merge pull request #1245 ...
success       08-13T21:01  Merge pull request #1243 ...
success       08-13T20:09  Merge pull request #1242 ...
```

It stayed invisible until now only because merges are normally spaced far enough apart that a third never arrives while one is pending. That makes it a latent trap that fires exactly when the repo is busiest — and busiest is when semantic merge conflicts are most likely.

Release publication itself was not unguarded (`release.yml` has no concurrency block and runs the full `release:security-gate`), so this is about the lost CI verdict on the merge commit, not an unverified publish.

## The fix

Master pushes now get `github.run_id`, which is unique per run, so no push can cancel or evict another. PRs keep grouping by PR number and keep cancelling superseded runs. The comment now describes the mechanism instead of asserting a guarantee.

The cost is that concurrent master merges run concurrently instead of serially — which is the point.

## Guard

`test-release-security-contracts.mjs` now pins the `github.run_id` fallback, mutation-verified: swapping it back to `github.ref` fails the contract, restoring passes.