### PR TITLE
ci: serialize release runs so concurrent merges cannot race npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,27 @@ on:
 permissions:
   contents: read
 
+# Releases must never run concurrently. Two master merges close together each
+# start a Release run; both check out a tree carrying the same pending version
+# bumps, both call `changeset publish`, and they race package by package. The
+# loser gets `E403 You cannot publish over the previously published versions`
+# and the whole run fails -- exactly what happened on 2026-08-13 when #1244 and
+# #1246 merged two minutes apart (#1244's run died on
+# @peerbit/identity-access-controller@6.0.90, which #1246's run had just
+# published; the packages themselves all landed, so the damage was a false-red
+# run rather than a partial publish, but a partial publish is the failure mode
+# this invites).
+#
+# cancel-in-progress MUST stay false: interrupting a run mid-publish is the one
+# way to actually leave npm half-updated. A queued run being superseded by a
+# newer one is harmless here -- `changeset publish` publishes whatever versions
+# are missing from the registry, so the newest run subsumes any it evicts. This
+# is the opposite trade-off from ci.yml, where each push needs its own verdict
+# and so each push gets its own group.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 name: Release
 jobs:
   # Stable release flow. On push to master, changesets/action opens/updates a

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -197,6 +197,16 @@ assert.doesNotMatch(
 	/run: pnpm run --if-present release(?::rc)?/,
 	"release workflows must not silently skip a missing guarded script",
 );
+// Release runs must serialize. Without a concurrency group, two master merges
+// close together publish at the same time and race package by package; the
+// loser fails with E403 on an already-published version (2026-08-13, #1244 vs
+// #1246). cancel-in-progress must stay false so a publish is never interrupted
+// half-way -- that is the path to a genuinely partial release.
+assert.match(
+	releaseWorkflow,
+	/^concurrency:\n {2}group: release-\$\{\{ github\.ref \}\}\n {2}cancel-in-progress: false$/m,
+	"release runs must serialize on a per-ref concurrency group and never cancel a publish in flight",
+);
 
 const ciWorkflow = await readRepositoryFile(".github/workflows/ci.yml");
 assert.match(


### PR DESCRIPTION
`release.yml` had no concurrency group, so two master merges close together publish to npm **at the same time**. That happened tonight and one run failed.

## What happened

#1244 (the version-bump commit) and #1246 merged two minutes apart. Both Release runs checked out a tree carrying the same pending version bumps, and both ran `changeset publish`. They raced package by package until one lost:

```
npm error code E403
npm error 403 Forbidden - PUT https://registry.npmjs.org/@peerbit%2fidentity-access-controller
  - You cannot publish over the previously published versions: 6.0.90.
Error: pnpm publish --no-git-checks --access public exited with code 1
```

#1246's run completed successfully; #1244's died on a package the other had published moments earlier.

## Damage assessment

**None to the registry.** I compared all 54 publishable packages against npm — every one matches its repo version, including the new `@peerbit/shared-log@16.0.4` and `@peerbit/document@15.0.4`. The winning run published the full set, so what we got was a false-red release run rather than a partial publish.

But a partial publish is precisely what this invites: had the runs interleaved differently, one could have published half the graph and then failed, leaving the registry with a set of packages whose workspace dependencies point at versions that do not exist yet.

## The fix

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

`cancel-in-progress: false` is load-bearing and must stay false — interrupting a run *mid-publish* is the one thing that would genuinely leave npm half-updated. A **queued** run being superseded is harmless here, because `changeset publish` publishes whatever versions are missing from the registry, so the newest run subsumes anything it evicts.

That is the opposite trade-off from #1248, which gives every CI push its own group. The two differ for a real reason: CI needs a verdict *per commit*, so runs must not share a group at all; releases converge on one registry, so they must share one and take turns. Both comments now say which property they are buying.

## Guard

Pinned in `test-release-security-contracts.mjs`, mutation-verified on both legs: deleting the concurrency block fails it, and flipping `cancel-in-progress` to `true` fails it too.