### PR TITLE
ci: run @peerbit/indexer-rust tests and enforce the native-job excuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,21 @@ jobs:
       - name: Cargo test indexer core crate
         # Pure Rust crate without a package.json, so it is invoked directly.
         run: cargo test --manifest-path packages/utils/indexer/core/Cargo.toml
+      - name: Test @peerbit/indexer-rust
+        # Added 2026-08-14: this crate had NO test step at all, so its 296 tests
+        # -- the RustIndex half of the indexer parity contract -- had never run
+        # in CI, while check-shard-coverage's baseline excused it as "tested in
+        # the Native job". That baseline entry is now enforced against this
+        # step's name. Spelled out rather than `pnpm --filter ... run test`
+        # because the package script runs aegir without "-t node" (same reason
+        # as @peerbit/log-rust below), and because the shared conformance suite
+        # it consumes must be built first.
+        run: |
+          cd packages/utils/indexer/rust
+          cargo test
+          pnpm --filter @peerbit/indexer-tests build
+          pnpm run build
+          pnpm exec aegir test -t node
       - name: Test @peerbit/any-store-rust
         run: pnpm --filter @peerbit/any-store-rust run test
       - name: Test @peerbit/native-backbone

--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -63,16 +63,35 @@ console.log(`OK: ${checked} literal shared-log describes are all covered by CI s
 // Every Node-runnable package has now been wired in by explicit roots (the
 // glob still cannot reach them): eleven into part-1, and the peerbit-server
 // pair into part-5a because its 132 tests take ~33s and part-5a is light.
-// What remains genuinely needs different infrastructure rather than a shard
-// entry: the rust crates build in the Native job, and the three playwright
-// suites need a browser runner.
-const KNOWN_UNREACHABLE = new Set([
+//
+// What is left falls in two categories, and they are kept apart on purpose:
+// "some other job runs it" is a claim that can rot, while "nothing runs it" is
+// a claim that cannot. Writing both as one prose sentence is how the rot hid.
+//
+// NATIVE_JOB_TESTED: run by a hand-rolled `cd`-and-run step in the Native job,
+// which this script's --roots/--filter parser cannot see. That excuse is now
+// ENFORCED below by requiring a matching `name: Test <pkg>` step in ci.yml --
+// until 2026-08-14 the comment claimed all three rust crates were covered this
+// way, and @peerbit/indexer-rust had NO such step: 296 tests (108 local plus
+// two runs of the shared @peerbit/indexer-tests conformance suite) covering the
+// RustIndex backend had never executed in CI.
+const NATIVE_JOB_TESTED = new Set([
 	"packages/log/rust",
+	"packages/utils/any-store/rust",
+	"packages/utils/indexer/rust",
+]);
+
+// BROWSER_E2E_UNRUN: playwright suites with no runner wired up. These really
+// are not executed anywhere -- an honest debt entry, not a redirection.
+const BROWSER_E2E_UNRUN = new Set([
 	"packages/programs/data/shared-log/proxy/e2e",
 	"packages/transport/stream/e2e/browser",
 	"packages/utils/any-store/proxy/e2e",
-	"packages/utils/any-store/rust",
-	"packages/utils/indexer/rust",
+]);
+
+const KNOWN_UNREACHABLE = new Set([
+	...NATIVE_JOB_TESTED,
+	...BROWSER_E2E_UNRUN,
 ]);
 
 const rootTokens = new Set();
@@ -159,6 +178,34 @@ for (const dir of KNOWN_UNREACHABLE) {
 		);
 		process.exit(1);
 	}
+}
+
+// A package excused as "the Native job runs it" must actually have a step in
+// the Native job that runs it. Without this, the excuse is unfalsifiable prose
+// and a package can sit in the baseline for months with nothing executing its
+// tests -- which is exactly what happened to @peerbit/indexer-rust.
+const ciWorkflow = readFileSync(
+	path.join(root, ".github/workflows/ci.yml"),
+	"utf8",
+);
+const unproven = [];
+for (const dir of NATIVE_JOB_TESTED) {
+	const name = JSON.parse(
+		readFileSync(path.join(root, dir, "package.json"), "utf8"),
+	).name;
+	if (!ciWorkflow.includes(`name: Test ${name}`)) {
+		unproven.push(`${dir} (${name})`);
+	}
+}
+if (unproven.length > 0) {
+	console.error(
+		"Packages excused as NATIVE_JOB_TESTED with no `name: Test <pkg>` step in ci.yml (nothing runs their tests):",
+	);
+	for (const u of unproven) console.error(`  ${u}`);
+	console.error(
+		"Add the Native job step, or move the package to BROWSER_E2E_UNRUN / wire it into a shard.",
+	);
+	process.exit(1);
 }
 
 if (unreachable.length > 0) {


### PR DESCRIPTION
`@peerbit/indexer-rust` has **296 tests that have never run in CI**, and the coverage guard's baseline said they were covered.

## The claim vs the workflow

`check-shard-coverage.mjs`'s `KNOWN_UNREACHABLE` comment — which I wrote in #1246 — said the remaining entries were fine because "the rust crates build in the Native job". The Native job has explicit steps for `@peerbit/any-store-rust`, `@peerbit/log-rust`, `@peerbit/shared-log-rust`, `@peerbit/document-rust` and `@peerbit/network-rust`. It has **none** for `@peerbit/indexer-rust`. The three `ci.yml` matches for `indexer/rust` are `rust-cache` `workspaces:` paths and one comment — build caching, not test invocation.

So the excuse was true for two of the three rust crates and false for the third, and nothing could tell the difference because it was prose.

## What was not running

`packages/utils/indexer/rust/test/index.spec.ts` — 108 local `it()`s plus two full runs of the shared `@peerbit/indexer-tests` conformance suite (persist and transient). Verified locally on this branch:

```
cargo test                      -> ok, 1 passed
pnpm --filter @peerbit/indexer-tests build   -> rc=0
pnpm run build (wasm-pack)      -> rc=0
pnpm exec aegir test -t node    -> 296 passing (591ms)
```

This is the RustIndex half of the indexer parity contract — the native backend the `mode:"auto"` generic index builds on. It passes today; nothing was stopping it from regressing.

## Making the excuse enforceable

The real defect is not the missing step, it is that "some other job runs it" was unfalsifiable. The baseline is now split:

- **`NATIVE_JOB_TESTED`** — excused because a hand-rolled `cd`-and-run step in the Native job covers it (invisible to this script's `--roots`/`--filter` parser). Each entry is now **checked**: the guard requires a matching `name: Test <pkg>` step in `ci.yml` and fails naming the package if it is absent.
- **`BROWSER_E2E_UNRUN`** — playwright suites with no runner. Genuinely not executed anywhere; an honest debt entry rather than a redirection.

"Nothing runs it" is a claim that cannot rot. "Another job runs it" is a claim that can, so it now has to prove itself.

## Pin-first

The new leg was run **before** adding the workflow step and failed on the real defect:

```
Packages excused as NATIVE_JOB_TESTED with no `name: Test <pkg>` step in ci.yml:
  packages/utils/indexer/rust (@peerbit/indexer-rust)
```

Then mutation-verified after: deleting the new step reproduces exactly that failure; restoring it passes.

Found by an audit hunting guards that look like they enforce something and do not — the same class as #1245 (one-level glob) and #1248 (concurrency).