### PR TITLE
ci: make the shard-coverage guard see parameterized describes

### DIFF
--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -26,24 +26,110 @@ if (greps.length === 0) {
 }
 
 const testDir = path.join(root, "packages/programs/data/shared-log/test");
+
+// A spec file's OUTERMOST describes are the ones a shard --grep must match:
+// mocha builds a full title by joining the describe chain, and every shard grep
+// is anchored with ^, so only the first link decides whether a suite is
+// selected. Until 2026-08-14 "outermost" was approximated by "starts at column
+// 0", which silently excluded every file whose outermost describe sits inside a
+// `for`/`forEach` -- ranges, sharding, replication and durable-restart-
+// conformance, i.e. the four largest suites in the package and the entire
+// content of shards part-7a..7e. The guard reported "OK: 72" and never
+// mentioned that 4 of 59 files contributed nothing to that number.
+//
+// Indentation of the shallowest describe is the right proxy: a nested describe
+// is always more indented than the one containing it, so the minimum indent in
+// a file is its top level whether or not a loop wraps it.
+const outermostDescribes = (src) => {
+	const hits = [...src.matchAll(/^([\t ]*)describe\(\s*(.*)$/gm)];
+	if (hits.length === 0) return [];
+	const top = Math.min(...hits.map((m) => m[1].length));
+	return hits.filter((m) => m[1].length === top).map((m) => m[2]);
+};
+
+// Parameterized outermost describes cannot be read off the call site, so they
+// are expanded from the array that drives the loop. Deriving them (rather than
+// hardcoding the titles) means uncommenting a setup or adding a backend makes
+// the guard demand a shard grep for it, instead of quietly widening the blind
+// spot. Every entry is proven live below: a file listed here that no longer has
+// a non-literal outermost describe is a hard failure, not a silent no-op.
+const stripBlockComments = (src) => src.replace(/\/\*[\s\S]*?\*\//g, "");
+const arrayStrings = (src, identifier) => {
+	const m = stripBlockComments(src).match(
+		new RegExp(`\\b${identifier}\\b[^=]*=\\s*\\[([\\s\\S]*?)\\]`),
+	);
+	return m ? [...m[1].matchAll(/["'`]([^"'`]+)["'`]/g)].map((x) => x[1]) : [];
+};
+const setupNames = (src) => {
+	const m = stripBlockComments(src).match(
+		/\btestSetups\b[^=]*=\s*\[([\s\S]*?)\n\];/,
+	);
+	return m ? [...m[1].matchAll(/name:\s*["'`]([^"'`]+)["'`]/g)].map((x) => x[1]) : [];
+};
+const PARAMETERIZED = {
+	// describe("ranges: " + resolution, ...) over `resolutions`
+	"ranges.spec.ts": (src) =>
+		arrayStrings(src, "resolutions").map((r) => `ranges: ${r}`),
+	// describe(setup.name, ...) over the file's own `testSetups`
+	"sharding.spec.ts": setupNames,
+	"replication.spec.ts": setupNames,
+	// describe(`durable restart conformance (${backend})`, ...) over `BACKENDS`
+	"durable-restart-conformance.spec.ts": (src) =>
+		arrayStrings(src, "BACKENDS").map(
+			(b) => `durable restart conformance (${b})`,
+		),
+};
+
 const uncovered = [];
+const unresolved = [];
+const unusedParameterized = new Set(Object.keys(PARAMETERIZED));
 let checked = 0;
 for (const file of readdirSync(testDir).sort()) {
 	if (!file.endsWith(".spec.ts")) continue;
 	const src = readFileSync(path.join(testDir, file), "utf8");
-	for (const m of src.matchAll(/^describe\((["'`])((?:(?!\1).)*)\1/gm)) {
-		const title = m[2];
-		// Titles interpolating the setup name (`${setup.name} sharding` etc)
-		// are parameterized and covered by the ^u32-simple/^u64-iblt part-7
-		// greps; they cannot be resolved statically, so skip them here.
-		if (title.includes("${")) continue;
-		checked++;
-		if (!greps.some((g) => g.test(title))) {
-			uncovered.push(`${file}: "${title}"`);
+	for (const call of outermostDescribes(src)) {
+		const literal = call.match(/^(["'`])((?:(?!\1).)*)\1\s*,/);
+		let titles;
+		if (literal && !literal[2].includes("${")) {
+			titles = [literal[2]];
+		} else {
+			// Non-literal outermost describe: it MUST be expandable, otherwise
+			// this guard is blind to the file. Failing here is the whole point
+			// -- the previous version skipped these and reported success.
+			const expand = PARAMETERIZED[file];
+			titles = expand ? expand(src) : [];
+			unusedParameterized.delete(file);
+			if (titles.length === 0) {
+				unresolved.push(`${file}: describe(${call.slice(0, 60)}`);
+				continue;
+			}
+		}
+		for (const title of titles) {
+			checked++;
+			if (!greps.some((g) => g.test(title))) {
+				uncovered.push(`${file}: "${title}"`);
+			}
 		}
 	}
 }
 
+if (unresolved.length > 0) {
+	console.error(
+		"Outermost describes with a non-literal title that this guard cannot expand (it therefore cannot tell whether any shard runs them):",
+	);
+	for (const u of unresolved) console.error(`  ${u}`);
+	console.error(
+		"Add an expander for the file to PARAMETERIZED in this script, or give the describe a literal title.",
+	);
+	process.exit(1);
+}
+if (unusedParameterized.size > 0) {
+	console.error(
+		"PARAMETERIZED entries whose file no longer has a non-literal outermost describe (stale, remove them):",
+	);
+	for (const f of unusedParameterized) console.error(`  ${f}`);
+	process.exit(1);
+}
 if (uncovered.length > 0) {
 	console.error(
 		"Top-level describes not matched by any test:ci:part-* grep (these tests never run in CI):",
@@ -51,7 +137,9 @@ if (uncovered.length > 0) {
 	for (const u of uncovered) console.error(`  ${u}`);
 	process.exit(1);
 }
-console.log(`OK: ${checked} literal shared-log describes are all covered by CI shard greps.`);
+console.log(
+	`OK: ${checked} shared-log top-level describe titles (literal and expanded) are all covered by CI shard greps.`,
+);
 
 // --- Package-level reachability -------------------------------------------
 // Pre-existing debt baseline: these packages have a test:cov script but have


### PR DESCRIPTION
The guard that exists to stop shared-log suites from silently dropping out of CI could not see the four largest suites in the package.

## The blind spot

`check-shard-coverage.mjs` scanned for `/^describe\(/` — anchored at column 0, literal titles only. Four spec files declare their outermost `describe` **inside a loop**, so it is indented, and three of them build the title from a variable:

| file | outermost describe | tests |
|---|---|---|
| `ranges.spec.ts` | `describe("ranges: " + resolution` | 119 x 2 resolutions |
| `sharding.spec.ts` | `describe(setup.name` | 31 x 2 setups |
| `replication.spec.ts` | `describe(setup.name` | 80 x 2 setups |
| `durable-restart-conformance.spec.ts` | `describe(\`durable restart conformance (\${backend})\`` | x 2 backends |

Those four are the entire content of shards **part-7a..7e** plus part-6's `ranges:` leg. The guard printed `OK: 72 literal shared-log describes are all covered` — 72 of 76 — without ever hinting that the 4 it skipped were the big ones.

**And the comment explaining the exclusion described dead code.** It said parameterized titles "are covered by the ^u32-simple/^u64-iblt part-7 greps; they cannot be resolved statically, so skip them here", implemented as `if (title.includes("\${")) continue;`. That branch **never fires** — 0 of the 72 matched titles contain `\${`, because the regex never reaches a file whose describe is indented. A reader was told the four suites had been consciously handled when the handling could not run.

## What that allowed

Deleting the `ranges:` alternative from part-6's `--grep` — the only thing selecting those 238 test cases — left the guard at **exit 0, "OK: 72"**, unchanged. Renaming a setup name in `testSetups` empties four or five of the fourteen test legs with every job green. That is a re-run of the July 2026 incident this guard was written to prevent.

## The fix

**Outermost, not column-0.** A nested describe is always more indented than its parent, so the minimum indent in a file is its top level whether or not a loop wraps it. That finds 76 outermost describes instead of 72.

**Expanded, not skipped.** Parameterized titles are derived from the array driving the loop — `resolutions`, `BACKENDS`, and the file's own `testSetups` (block comments stripped first, so a commented-out setup does not count). 80 titles are now checked. Deriving rather than hardcoding means **uncommenting a setup makes the guard demand a shard grep for it** instead of quietly widening the blind spot.

**Silence is now a failure.** A non-literal outermost describe with no expander is a hard error naming the file, and a stale `PARAMETERIZED` entry whose file no longer has one is also a hard error. The previous version's response to "I cannot read this" was to skip and report success.

## Mutation-verified, three legs

| mutation | result |
|---|---|
| drop `ranges:` from the part-6 grep | fails: `ranges.spec.ts: "ranges: u32"`, `"ranges: u64"` |
| uncomment the `u64-simple` setup | fails: `sharding.spec.ts: "u64-simple"` |
| remove the `sharding.spec.ts` expander | fails: `describe(setup.name, () => {` |

All restore to green. The first is the exact case the old guard slept through.