### PR TITLE
test(docs): actually run the 15 documentation example suites

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,9 +16,9 @@
 	"scripts": {
 		"clean": "#not used",
 		"build": "tsc -p tsconfig.json",
-		"test": "true",
+		"test": "aegir test -t node",
 		"lint": "aegir lint",
-		"test:cov": "true"
+		"test:cov": "aegir test -t node --cov"
 	},
 	"dependencies": {
 		"@dao-xyz/borsh": "^6.0.0",

--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -240,7 +240,44 @@ const findPackages = (dir, acc) => {
 	return acc;
 };
 
+// Being reachable from a shard is worthless if the script does nothing. `docs`
+// was wired into part-5a's --roots and counted toward "N packages reachable"
+// while its test:cov was the shell builtin `true` -- 15 documentation example
+// suites, added 2024-04-08, executed nowhere from 2026-03-08 until 2026-08-14.
+// The commit that neutered it called the package an "empty test workspace";
+// the specs had been there for nearly two years. Reachability and execution are
+// different claims, and only one of them was being checked.
+const NO_OP_SCRIPT = /^(?:\s*(?:true|:|exit\s+0|echo\b[^&|;]*|#.*)\s*)$/;
+const isNoOpScript = (script) =>
+	script.trim() === "" ||
+	NO_OP_SCRIPT.test(script) ||
+	/^node\s+(?:-e|--eval)\s+["']?process\.exit\(0\)["']?$/.test(script.trim());
+
+// Packages that legitimately have a placeholder test:cov because they contain
+// no tests at all. Unlike a bare comment, this is checked: the package must
+// genuinely contain no spec/test file, so adding one turns the placeholder into
+// a hard failure instead of silently swallowing the new suite.
+const NO_TESTS_BY_DESIGN = new Set(["packages/utils/build-assets"]);
+const containsTestFiles = (dir) => {
+	const stack = [dir];
+	while (stack.length > 0) {
+		const current = stack.pop();
+		for (const entry of readdirSync(path.join(root, current), {
+			withFileTypes: true,
+		})) {
+			if (entry.name === "node_modules" || entry.name === "dist") continue;
+			if (entry.isDirectory()) {
+				stack.push(`${current}/${entry.name}`);
+			} else if (/\.(spec|test)\.[cm]?[jt]sx?$/.test(entry.name)) {
+				return `${current}/${entry.name}`;
+			}
+		}
+	}
+	return null;
+};
+
 const unreachable = [];
+const noOpScripts = [];
 let reachableCount = 0;
 for (const dir of ["docs", ...findPackages("packages", [])]) {
 	let manifest;
@@ -254,6 +291,17 @@ for (const dir of ["docs", ...findPackages("packages", [])]) {
 	if (!manifest.scripts?.["test:cov"]) continue;
 	if (reachableDirs.has(dir) || filterNames.has(manifest.name)) {
 		reachableCount++;
+		if (isNoOpScript(manifest.scripts["test:cov"])) {
+			const stray = NO_TESTS_BY_DESIGN.has(dir) ? containsTestFiles(dir) : true;
+			if (stray) {
+				noOpScripts.push(
+					`${dir} (${manifest.name}): test:cov = ${JSON.stringify(manifest.scripts["test:cov"])}` +
+						(typeof stray === "string"
+							? ` — but it now contains ${stray}`
+							: ""),
+				);
+			}
+		}
 	} else if (!KNOWN_UNREACHABLE.has(dir)) {
 		unreachable.push(`${dir} (${manifest.name})`);
 	}
@@ -296,6 +344,16 @@ if (unproven.length > 0) {
 	process.exit(1);
 }
 
+if (noOpScripts.length > 0) {
+	console.error(
+		"Packages wired into a CI shard whose test:cov does nothing (they inflate the reachable count while running no tests):",
+	);
+	for (const s of noOpScripts) console.error(`  ${s}`);
+	console.error(
+		"Give the package a real test:cov, or remove it from the shard roots so it is counted as unreachable honestly.",
+	);
+	process.exit(1);
+}
 if (unreachable.length > 0) {
 	console.error(
 		"Packages with a test:cov script not reachable from any test:ci:* script (their tests never run in CI):",


### PR DESCRIPTION
`docs` has 15 example spec files. Its test script is the shell builtin `true`, so none of them have executed since March.

## Timeline

| date | event |
|---|---|
| **2024-04-08** | all 15 spec files added |
| 2026-03-08 | `fix(docs): avoid hanging empty test workspace` — `aegir test -t node` → `node -e "process.exit(0)"` |
| 2026-03-08 | `fix(docs): make empty test workspace arg-safe` → `true` |

The package was called an "empty test workspace". The specs had been sitting in it for **twenty-three months**. Whatever hang was being fixed, the remedy silenced a real suite, and `test:cov` was changed to `true` alongside it.

Five months later that matters more than it did then: `@peerbit/shared-log` went to 16.x and `@peerbit/document` to 15.x today. The documentation examples are the code users copy, and nothing had compiled or run them against those majors.

## They pass, unmodified

```
tsc -p tsconfig.json      -> rc=0, emits 15 spec files to dist/test/**
aegir test -t node        -> 15 passing (30s), 1 pending
```

No example needed fixing. The 1 pending is `bootstrap.spec.ts`, self-gated on `PEERBIT_RUN_REMOTE_BOOTSTRAP_TEST` because it dials the live network — correctly skipped in CI.

`docs` is already in part-5a's `--roots`, the root `build` covers it (`aegir run build`), and the pack step archives every `dist` directory, so the restored artifact carries `docs/dist/test` into the shard. Re-enabling the script is the whole change; +30s on part-5a, which is not on the critical path.

## Why no guard caught this

**Reachable and executed are different claims, and only the first was checked.** `docs` was in the shard roots and counted toward "N packages with test:cov are reachable" the entire time its script was `true`.

The guard now checks the second claim too, and it immediately found one I was not looking for: `@peerbit/build-assets`, whose `test:cov` is `echo 'No tests configured'`.

That one is honest — the package really has no tests. But deleting the script would make it **invisible** to the guard rather than merely misleading, which is not an improvement. So it goes in a `NO_TESTS_BY_DESIGN` baseline that is *enforced*: the package must genuinely contain no spec file, and adding one fails with `— but it now contains packages/utils/build-assets/test/probe.spec.ts`.

## Mutation-verified

| mutation | result |
|---|---|
| `docs` test:cov back to `true` | fails: `docs (docs): test:cov = "true"` |
| back to `node -e "process.exit(0)"` (the other historical form) | fails, quoted form and all |
| drop a spec file into `build-assets` | fails naming the stray file |

All restore to green.