### PR TITLE
test(program): await the getReady rejection assertions

### DIFF
--- a/packages/programs/program/program/test/events.spec.ts
+++ b/packages/programs/program/program/test/events.spec.ts
@@ -292,7 +292,10 @@ describe("events", () => {
 
 		it("throws on no topics", async () => {
 			const test = new ProgramWithoutTopics();
-			expect(test.getReady()).rejectedWith(
+			// `rejectedWith` returns a promise; without awaiting it the assertion
+			// resolved after the test had already passed, so this test asserted
+			// nothing at all (it was its only assertion).
+			await expect(test.getReady()).rejectedWith(
 				"Program has no topics, cannot get ready",
 			);
 		});
@@ -302,7 +305,9 @@ describe("events", () => {
 			peer = await creatMockPeer();
 			await peer.open(test, { args: { dontOpenNested: true } });
 			expect(() => test.nested.getTopics()).to.throw(ClosedError);
-			expect(test.getReady()).rejectedWith(
+			// Same missing await as above: the ClosedError half of this test's
+			// claim was real, the getReady half was not being checked.
+			await expect(test.getReady()).rejectedWith(
 				"Program has no topics, cannot get ready", // will throw this error because now no topics will exist
 			);
 		});


### PR DESCRIPTION
Two `expect(promise).rejectedWith(...)` calls in `events.spec.ts` are never awaited, so the assertion settles after the test has already passed.

```ts
it("throws on no topics", async () => {
  const test = new ProgramWithoutTopics();
  expect(test.getReady()).rejectedWith(   // <- no await
    "Program has no topics, cannot get ready",
  );
});
```

`rejectedWith` returns a promise. Nothing awaits it, so mocha finishes the test before it resolves. `throws on no topics` has no other assertion, making it entirely vacuous; `will not ask for topics on closed subprogram` keeps its synchronous `ClosedError` check but the `getReady` half of its claim was unverified.

## Proof

Neuter the guard — make `if (allTopics.length === 0)` unreachable in `program.ts`, so `getReady()` resolves instead of rejecting:

| | result |
|---|---|
| tests as on master | **2 passing** |
| tests with `await` added | `AssertionError: expected promise to be rejected with an error including 'Program has no topics, cannot get rea…' but it was fulfilled with Map{}` |

Source restored: 2 passing.

The behaviour they describe is real and correct — it simply was not being checked. Adding `await` is the whole change.