### PR TITLE
ci: install wasm-pack from the pinned script everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,7 +746,7 @@ jobs:
             packages/utils/rateless-iblt
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
       - name: Install Playwright browser

--- a/.github/workflows/nightly-sims.yml
+++ b/.github/workflows/nightly-sims.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile=false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ on:
 permissions:
   contents: read
 
+# Must match ci.yml. Until 2026-08-14 both publish jobs installed wasm-pack with
+# `curl .../init.sh | sh`, which resolves LATEST, so the version CI validated
+# against was not the version that built the published wasm artifacts.
+env:
+  WASM_PACK_VERSION: 0.13.1
+
 # Releases must never run concurrently. Two master merges close together each
 # start a Release run; both check out a tree carrying the same pending version
 # bumps, both call `changeset publish`, and they race package by package. The
@@ -95,7 +101,7 @@ jobs:
       # the changesets action runs (several packages ship wasm-pack artifacts).
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile
 
@@ -218,7 +224,7 @@ jobs:
 
       - name: Install deps
         run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          ./scripts/ci/install-wasm-pack.sh
           rustup target add wasm32-unknown-unknown
           pnpm install --frozen-lockfile
 

--- a/scripts/test-release-security-contracts.mjs
+++ b/scripts/test-release-security-contracts.mjs
@@ -197,6 +197,29 @@ assert.doesNotMatch(
 	/run: pnpm run --if-present release(?::rc)?/,
 	"release workflows must not silently skip a missing guarded script",
 );
+// Several published packages ship wasm-pack output, so the toolchain that
+// builds them is part of the supply chain. Until 2026-08-14 both publish jobs
+// installed it with `curl .../wasm-pack/installer/init.sh -sSf | sh`, which
+// (a) resolves LATEST, so the repo-wide WASM_PACK_VERSION pin governed the jobs
+// that VALIDATE wasm but not the jobs that PUBLISH it, and (b) swallows curl's
+// exit status, because GitHub's default `bash -e` does not set pipefail and the
+// pipeline reports `sh`'s status instead. install-wasm-pack.sh pins the version,
+// runs under `set -euo pipefail`, and verifies the binary after install.
+assert.doesNotMatch(
+	releaseWorkflow,
+	/wasm-pack\/installer\/init\.sh/,
+	"release jobs must not install wasm-pack from the unpinned upstream installer",
+);
+assert.match(
+	releaseWorkflow,
+	/\.\/scripts\/ci\/install-wasm-pack\.sh/,
+	"release jobs must install wasm-pack through the pinned, fail-closed script",
+);
+assert.match(
+	releaseWorkflow,
+	/^env:\n {2}WASM_PACK_VERSION: /m,
+	"the release workflow must pin WASM_PACK_VERSION explicitly rather than inherit the script default",
+);
 // Release runs must serialize. Without a concurrency group, two master merges
 // close together publish at the same time and race package by package; the
 // loser fails with E403 on an already-published version (2026-08-13, #1244 vs


### PR DESCRIPTION
Several published packages ship wasm-pack output, so the toolchain that builds them is part of the supply chain. **Both npm publish jobs installed it unpinned.**

## The split

`ci.yml` declares `WASM_PACK_VERSION: 0.13.1`, and `scripts/ci/install-wasm-pack.sh` honours it under `set -euo pipefail`, fetches with `--fail --retry 5 --retry-all-errors`, and verifies the binary afterwards. Six steps used it. Four did not:

| workflow | line | what it does |
|---|---|---|
| `release.yml` | 98 | **publishes to npm** |
| `release.yml` | 221 | **publishes RCs to npm** |
| `ci.yml` | 749 | `test_native` — the job that cargo-tests and wasm-builds every crate |
| `nightly-sims.yml` | 194 | nightly simulations |

All four ran `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`.

## Two defects

**The pin did not reach the artifacts.** That installer resolves *latest*, not `0.13.1`. So the version CI validated against governed the jobs that **check** wasm and not the jobs that **ship** it — including `test_native`, whose entire purpose is validating the wasm output. A regression or compromise in a newer wasm-pack would reach published packages without any job having exercised that version.

**The install could fail silently.** GitHub's default shell for `run:` is `bash -e`, which does **not** set `pipefail`, so a pipeline reports the status of its *last* command. `curl … | sh` therefore reports `sh`'s exit code, and `sh` reading empty input exits 0:

```
$ bash -e  step.sh; echo "STEP EXIT = $?"
curl: (6) Could not resolve host: …
reached the end of the step body
STEP EXIT = 0

$ bash -eo pipefail step.sh; echo "STEP EXIT = $?"
curl: (6) Could not resolve host: …
STEP EXIT = 6
```

The pinned script has no such hole: it is `set -euo pipefail` and ends by running `wasm-pack --version`.

## Change

All four now call `./scripts/ci/install-wasm-pack.sh` — 10 of 10 sites pinned. `release.yml` also gets an explicit workflow-level `WASM_PACK_VERSION: 0.13.1` rather than silently inheriting the script's default, so the publish path states its own pin.

## Guard

Three assertions in `test-release-security-contracts.mjs` (the right home — this governs what builds published artifacts), mutation-verified:

| mutation | result |
|---|---|
| one publish job back to `curl … \| sh` | fails: *release jobs must not install wasm-pack from the unpinned upstream installer* |
| drop the explicit `WASM_PACK_VERSION` | fails: *must pin WASM_PACK_VERSION explicitly rather than inherit the script default* |

Found by round 2 of the silent-no-op audit.