### PR TITLE
ci: require native-job steps to invoke every test script they excuse

### DIFF
--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -324,13 +324,56 @@ const ciWorkflow = readFileSync(
 	path.join(root, ".github/workflows/ci.yml"),
 	"utf8",
 );
+// A step NAME only proves a step exists, not what it runs. @peerbit/any-store-rust
+// satisfied the name check via `pnpm --filter @peerbit/any-store-rust run test`
+// while its `test:e2e` script -- 3 browser OPFS persistence tests under e2e/ --
+// was invoked by nothing. So every EXTRA test script (anything matching test:*
+// other than test:cov, which the shard-reachability leg above covers) must be
+// invoked inside that package's own step, or be declared unrun below.
+//
+// The step body has to be isolated first: a repo-wide substring search for
+// "run test:e2e" matches the @peerbit/shared-log-rust step and would credit it
+// to any-store, which is the same unscoped-match bug this guard exists to catch.
+const nativeStepBody = (pkgName) => {
+	const marker = `- name: Test ${pkgName}\n`;
+	const start = ciWorkflow.indexOf(marker);
+	if (start < 0) return null;
+	const rest = ciWorkflow.slice(start + marker.length);
+	const next = rest.search(/^ {6}- (?:name|uses):/m);
+	return next < 0 ? rest : rest.slice(0, next);
+};
+
+// Extra test scripts that genuinely have no runner. Same honest-debt category as
+// BROWSER_E2E_UNRUN: playwright against a browser, with no browser leg wired up.
+const NATIVE_JOB_UNRUN_SCRIPTS = new Map([
+	["packages/utils/any-store/rust", ["test:e2e"]],
+]);
+
 const unproven = [];
+const uninvoked = [];
 for (const dir of NATIVE_JOB_TESTED) {
-	const name = JSON.parse(
+	const manifest = JSON.parse(
 		readFileSync(path.join(root, dir, "package.json"), "utf8"),
-	).name;
-	if (!ciWorkflow.includes(`name: Test ${name}`)) {
-		unproven.push(`${dir} (${name})`);
+	);
+	const body = nativeStepBody(manifest.name);
+	if (body === null) {
+		unproven.push(`${dir} (${manifest.name})`);
+		continue;
+	}
+	const declaredUnrun = new Set(NATIVE_JOB_UNRUN_SCRIPTS.get(dir) ?? []);
+	for (const script of Object.keys(manifest.scripts ?? {})) {
+		if (!script.startsWith("test:") || script === "test:cov") continue;
+		if (declaredUnrun.has(script)) continue;
+		if (!body.includes(`run ${script}`)) {
+			uninvoked.push(`${dir} (${manifest.name}): ${script}`);
+		}
+	}
+	for (const script of declaredUnrun) {
+		if (!manifest.scripts?.[script]) {
+			uninvoked.push(
+				`${dir}: NATIVE_JOB_UNRUN_SCRIPTS lists "${script}", which no longer exists — remove it`,
+			);
+		}
 	}
 }
 if (unproven.length > 0) {
@@ -340,6 +383,16 @@ if (unproven.length > 0) {
 	for (const u of unproven) console.error(`  ${u}`);
 	console.error(
 		"Add the Native job step, or move the package to BROWSER_E2E_UNRUN / wire it into a shard.",
+	);
+	process.exit(1);
+}
+if (uninvoked.length > 0) {
+	console.error(
+		"Native-job packages with a test:* script their own step never invokes (those suites run nowhere):",
+	);
+	for (const u of uninvoked) console.error(`  ${u}`);
+	console.error(
+		"Invoke it from that package's Native job step, or list it in NATIVE_JOB_UNRUN_SCRIPTS as declared debt.",
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
Tightens the guard I added in #1250. It checked that a step **named** `Test <pkg>` exists — which proves a step exists, not what it runs.

## The gap in my own fix

`@peerbit/any-store-rust` satisfied it via `- name: Test @peerbit/any-store-rust` / `run: pnpm --filter @peerbit/any-store-rust run test`. But that package has two suites:

```json
"test":     "cargo test && npm run build && aegir test -t node",
"test:e2e": "npm run build && playwright test --config e2e/playwright.config.ts"
```

Only the first is invoked. `e2e/tests/opfs.spec.ts` — 3 browser OPFS persistence tests covering WAL/sublevel survival across worker and page reloads, and incomplete-checkpoint fallback, added in 7ed57e918 / 3319decf0 specifically to cover that hardening — runs nowhere, while the guard printed OK and its comment asserted the package's tests were covered.

## What the check does now

Every `test:*` script (other than `test:cov`, which the shard-reachability leg above already covers) must be invoked **inside that package's own Native step**, or be listed in `NATIVE_JOB_UNRUN_SCRIPTS` as declared debt. `any-store-rust`'s `test:e2e` goes there — same honest-debt category as `BROWSER_E2E_UNRUN`: playwright against a browser, no browser leg wired up. Declared, not disguised.

## The step body has to be isolated first

My first attempt at this census searched the whole workflow for `run test:e2e` and reported **no problem** — because that string does appear in `ci.yml`, in the `@peerbit/shared-log-rust` step. An unscoped substring match credited one package's invocation to another and produced a false negative.

That is precisely the bug class this guard exists to catch, so the check now extracts the step body between `- name: Test <pkg>` and the next `- name:`/`- uses:` and searches only within it.

## Mutation-verified, three legs

| mutation | result |
|---|---|
| remove the declared-unrun entry | fails: `any-store/rust (@peerbit/any-store-rust): test:e2e` — the real defect |
| add a `test:browser` to indexer-rust its step does not invoke | fails naming `test:browser` |
| delete `test:e2e` while it is still declared | fails: `lists "test:e2e", which no longer exists — remove it` |

All restore to green. Found by round 2 of the silent-no-op audit, which was pointed at what round 1 never opened.