### PR TITLE
ci: run the four browser e2e suites nothing was running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,7 +780,13 @@ jobs:
           pnpm run build
           pnpm exec aegir test -t node
       - name: Test @peerbit/any-store-rust
-        run: pnpm --filter @peerbit/any-store-rust run test
+        # test:e2e is the OPFS persistence suite (WAL/sublevel survival across
+        # worker and page reloads, incomplete-checkpoint fallback). It is a
+        # separate script, so `run test` alone left it unexecuted -- chromium is
+        # already installed above for the browser legs.
+        run: |
+          pnpm --filter @peerbit/any-store-rust run test
+          pnpm --filter @peerbit/any-store-rust run test:e2e
       - name: Test @peerbit/native-backbone
         run: pnpm --filter @peerbit/native-backbone run test
       - name: Test @peerbit/log-rust

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"test:part-2": "aegir run test --roots ./packages/programs/data/document/** -- -t node",
 		"test:ci:part-2a": "aegir run test:cov --roots ./packages/programs/data/document/document ./packages/programs/data/document/interface ./packages/programs/data/document/proxy -- --no-build",
 		"test:ci:part-2b": "aegir run test:cov --roots ./packages/programs/data/document/react",
-		"test:ci:part-2c": "aegir run test:cov --roots ./packages/programs/data/document/react/e2e/canonical ./packages/programs/data/document/react/e2e/party ./packages/programs/data/document/proxy/e2e",
+		"test:ci:part-2c": "aegir run test:cov --roots ./packages/programs/data/document/react/e2e/canonical ./packages/programs/data/document/react/e2e/party ./packages/programs/data/document/proxy/e2e ./packages/programs/data/shared-log/proxy/e2e ./packages/utils/any-store/proxy/e2e ./packages/transport/stream/e2e/browser",
 		"test:part-3": "aegir run test --roots ./packages/transport/** -- -t node",
 		"test:ci:part-3": "aegir run test:cov --roots ./packages/transport/** -- --no-build",
 		"test:part-4": "aegir run test --roots ./packages/programs/data/shared-log ./packages/programs/data/shared-log/proxy -- -t node",

--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -195,13 +195,17 @@ const NATIVE_JOB_TESTED = new Set([
 	"packages/utils/indexer/rust",
 ]);
 
-// BROWSER_E2E_UNRUN: playwright suites with no runner wired up. These really
-// are not executed anywhere -- an honest debt entry, not a redirection.
-const BROWSER_E2E_UNRUN = new Set([
-	"packages/programs/data/shared-log/proxy/e2e",
-	"packages/transport/stream/e2e/browser",
-	"packages/utils/any-store/proxy/e2e",
-]);
+// BROWSER_E2E_UNRUN is now EMPTY, and that is the point: nothing in this repo
+// has a test:cov that no CI job runs.
+//
+// It used to hold the three playwright suites, excused as "needing a browser
+// runner". They did not. CI already installs chromium for part-1 and part-2c,
+// and part-2c already ran @peerbit/document-canonical-e2e -- whose two siblings
+// are byte-for-byte the same shape (same scripts, same index.html /
+// playwright.config.ts / service-worker.ts layout, only the dev-server port
+// differs: 5260/5261/5262). The excuse was inherited prose, not a measurement;
+// all three pass unchanged and are wired into part-2c below.
+const BROWSER_E2E_UNRUN = new Set([]);
 
 const KNOWN_UNREACHABLE = new Set([
 	...NATIVE_JOB_TESTED,
@@ -378,10 +382,10 @@ const nativeStepBody = (pkgName) => {
 };
 
 // Extra test scripts that genuinely have no runner. Same honest-debt category as
-// BROWSER_E2E_UNRUN: playwright against a browser, with no browser leg wired up.
-const NATIVE_JOB_UNRUN_SCRIPTS = new Map([
-	["packages/utils/any-store/rust", ["test:e2e"]],
-]);
+// Also empty now. any-store-rust's test:e2e (the OPFS persistence suite) was
+// the last declared-unrun script; the Native job already installs chromium, so
+// its own step runs it rather than declaring it as debt.
+const NATIVE_JOB_UNRUN_SCRIPTS = new Map([]);
 
 const unproven = [];
 const uninvoked = [];


### PR DESCRIPTION
The reachability baseline said three playwright suites "need a browser runner". They did not. CI has installed chromium for part-2c all along, and part-2c already ran their sibling.

## The excuse was inherited prose

`@peerbit/document-canonical-e2e` runs in part-2c. Its two siblings are the same shape — same scripts, same `index.html` / `playwright.config.ts` / `service-worker.ts` / `vite.config.ts` layout, each with its own `webServer` on a distinct port (5260 / 5261 / 5262, so no collision). Nothing about them needed infrastructure that did not exist.

This is the same mistake as #1250's `indexer-rust`: a category written once, never re-measured, and inherited forward.

## What was not running

| suite | tests | |
|---|---|---|
| `@peerbit/shared-log-canonical-e2e` | **8** | service worker + shared worker sharing, open-by-address, host-emitted event propagation, ref release on tab close (incl. abrupt), RPC failure after host disconnect and after abrupt close |
| `@peerbit/any-store-canonical-e2e` | **2** | AnyStore shared across tabs via service worker and shared worker |
| `stream-browser-test` | **2** | webrtc payload transmit; two rust-core browser peers exchanging via a TS relay |
| `@peerbit/any-store-rust` `test:e2e` | **3** | OPFS: WAL/sublevel survival across worker and page reloads, batched mutations across worker reloads, fallback when the newest manifest points at an incomplete checkpoint |

All four pass unchanged.

### The stream one hid behind a similar-looking step

`ci.yml` runs `pnpm --filter @peerbit/network-rust run test:stream-rust-core`, which reads like it covers the browser suite. It is `@peerbit/network-rust`'s **node** script (`aegir test -t node` under `PEERBIT_STREAM_RUST_CORE=1`) — a different package. `stream-browser-test`'s own `test:rust-core` and `test` were invoked by nothing, so both of its browser tests ran nowhere.

## Result

`BROWSER_E2E_UNRUN` and `NATIVE_JOB_UNRUN_SCRIPTS` are now **both empty**, and that is the point: no package in this repo has a `test:cov` that no CI job runs. The baseline drops **6 → 3**, and the three that remain are the rust crates in `NATIVE_JOB_TESTED`, each already enforced (since #1250/#1258) to have a step that invokes every test script it declares.

Reachable count 46 → 49.

## Verified by execution

```
$ pnpm run test:ci:part-2c            # rc=0
@peerbit/any-store-canonical-e2e:   2 passed (5.2s)
stream-browser-test:                2 passed (10.1s)
@peerbit/document-react-canonical-e2e: 3 passed (13.0s)
@peerbit/shared-log-canonical-e2e:  8 passed (24.2s)
@peerbit/document-canonical-e2e:    9 passed (38.8s)
```

~39s wall clock for the whole shard; part-2c is not on the critical path. Checked that none of the three new roots is also matched by part-1's, part-3's, part-4's or part-6's patterns, so nothing double-executes.

Mutation-verified: un-wiring the shared-log e2e root fails naming the package; reverting the any-store-rust step to `run test` alone fails naming `test:e2e`.