### PR TITLE
ci: typecheck every supabase edge function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,13 +144,26 @@ jobs:
       - name: Validate bootstrap rollout PR generation
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: node --test tools/sync-bootstrap-rollout.spec.mjs
-      - name: Validate managed DNS lease edge function
+      - name: Validate the supabase edge functions
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |
           pnpm dlx deno@2.9.2 check \
             --frozen \
             --config apps/peerbit-org/supabase/functions/dns-lease/deno.json \
             apps/peerbit-org/supabase/functions/dns-lease/index.ts
+          # The updates-* entrypoints were typechecked by nothing until
+          # 2026-08-14. `deno check` is transitive, so the dns-lease line above
+          # covers _shared/{cloudflare-dns,crypto,dns-lease,dns-lease-renewal}
+          # but reaches neither these four nor _shared/{cors,resend}.ts, which
+          # only they import. They have no deno.json of their own -- they import
+          # supabase-js by URL rather than the pinned npm: specifier dns-lease
+          # uses -- so they are checked as they are written, which does mean this
+          # line fetches type declarations from esm.sh.
+          pnpm dlx deno@2.9.2 check \
+            apps/peerbit-org/supabase/functions/updates-confirm/index.ts \
+            apps/peerbit-org/supabase/functions/updates-subscribe/index.ts \
+            apps/peerbit-org/supabase/functions/updates-sync/index.ts \
+            apps/peerbit-org/supabase/functions/updates-unsubscribe/index.ts
           node --test \
             apps/peerbit-org/supabase/functions/_shared/dns-lease.test.ts \
             apps/peerbit-org/supabase/functions/_shared/cloudflare-dns.test.ts \

--- a/scripts/ci/check-shard-coverage.mjs
+++ b/scripts/ci/check-shard-coverage.mjs
@@ -39,6 +39,39 @@ if (uninvokedRootTests.length > 0) {
 	process.exit(1);
 }
 
+// Supabase edge functions are Deno, so no tsconfig and no shard reaches them;
+// their only typecheck is an explicit `deno check` line in ci.yml. Four of the
+// five entrypoints were named nowhere until 2026-08-14 and were compiled by
+// nothing on the way to deployment. Each entrypoint must appear in a deno check
+// invocation by name -- transitive coverage of _shared/* comes free from that.
+const edgeFunctionsDir = path.join(
+	root,
+	"apps/peerbit-org/supabase/functions",
+);
+if (existsSync(edgeFunctionsDir)) {
+	const ciWorkflowText = readFileSync(
+		path.join(root, ".github/workflows/ci.yml"),
+		"utf8",
+	);
+	const uncheckedFunctions = [];
+	for (const entry of readdirSync(edgeFunctionsDir, { withFileTypes: true })) {
+		if (!entry.isDirectory() || entry.name.startsWith("_")) continue;
+		const relative = `apps/peerbit-org/supabase/functions/${entry.name}/index.ts`;
+		if (!existsSync(path.join(root, relative))) continue;
+		if (!ciWorkflowText.includes(relative)) uncheckedFunctions.push(relative);
+	}
+	if (uncheckedFunctions.length > 0) {
+		console.error(
+			"Supabase edge function entrypoints that no `deno check` in ci.yml names (nothing typechecks them before deploy):",
+		);
+		for (const f of uncheckedFunctions) console.error(`  ${f}`);
+		console.error(
+			"Add the entrypoint to the `Validate the supabase edge functions` step in .github/workflows/ci.yml.",
+		);
+		process.exit(1);
+	}
+}
+
 const greps = [];
 for (const [name, cmd] of Object.entries(pkg.scripts)) {
 	if (!name.startsWith("test:ci:part-")) continue;


### PR DESCRIPTION
Four of the five Supabase edge function entrypoints were compiled by **nothing** on the way to deployment.

## What was and was not covered

`deno check` is transitive, so the existing line —

```
deno check --frozen --config .../dns-lease/deno.json .../dns-lease/index.ts
```

— covered `dns-lease/index.ts` plus the four `_shared` modules it imports (`cloudflare-dns`, `crypto`, `dns-lease`, `dns-lease-renewal`). It reached **none** of:

| file | |
|---|---|
| `updates-confirm/index.ts` | |
| `updates-subscribe/index.ts` | |
| `updates-sync/index.ts` | |
| `updates-unsubscribe/index.ts` | |
| `_shared/cors.ts` | imported only by the four above |
| `_shared/resend.ts` | imported only by `updates-subscribe` and `updates-sync` |

These are Deno, so no tsconfig covers them and no test shard reaches them. An explicit `deno check` line in `ci.yml` is their only possible typecheck, and they were named in none.

They pass today (`deno check` on all four: exit 0), so this is a gap in *checking*, not a latent type error. Adding the four entrypoints picks up `cors.ts` and `resend.ts` transitively, which covers all 14 `.ts` files under `supabase/functions` — the three `_shared/*.test.ts` are already run by the adjacent `node --test`.

## One thing deliberately left alone

`dns-lease` imports `@supabase/supabase-js` as a bare specifier pinned to `npm:@supabase/supabase-js@2.110.2` through its own `deno.json`. The four `updates-*` functions instead import `https://esm.sh/@supabase/supabase-js@2` — a floating major fetched at check time, which is why this line pulls type declarations from esm.sh.

Converting them to the pinned form would be the better end state, but it changes how **deployed** edge functions resolve their dependencies, so it is a deployment-affecting decision rather than a CI one. Checking them as they are written is the honest, non-invasive step; the pinning question is left for a deliberate call.

## Guard

`check-shard-coverage.mjs` now requires every `supabase/functions/*/index.ts` to be named in a `deno check` invocation, so a new edge function cannot be added unchecked. Mutation-verified:

| mutation | result |
|---|---|
| drop `updates-sync` from the check | fails naming `updates-sync/index.ts` — the original defect |
| add a new `probe-fn/index.ts` | fails naming `probe-fn/index.ts` |

The step is renamed from `Validate managed DNS lease edge function` to `Validate the supabase edge functions`, since its old name described its old (partial) scope accurately.