### PR TITLE
fix(stream): stop the foreign-crypto import from killing the test run

### DIFF
--- a/packages/transport/stream/test/messages-signing.spec.ts
+++ b/packages/transport/stream/test/messages-signing.spec.ts
@@ -14,8 +14,13 @@ import {
 	Signatures,
 	TracedDelivery,
 } from "@peerbit/stream-interface";
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import {
+	cpSync,
+	existsSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "fs";
 import path from "path";
 import { Uint8ArrayList } from "uint8arraylist";
 import { pathToFileURL } from "url";
@@ -34,17 +39,42 @@ const serializeUnsignedMessage = (message: DataMessage) => {
 const toByteArray = (bytes: Uint8Array | Uint8ArrayList) =>
 	bytes instanceof Uint8Array ? bytes : bytes.subarray();
 
+// Loads a SECOND, independent copy of @peerbit/crypto so the test can prove a
+// signature produced by a foreign module identity still normalizes.
+//
+// Two details are load-bearing, and getting either wrong kills the whole run
+// rather than failing this test. Until 2026-08-14 this copied `src` into
+// os.tmpdir() and imported `index.ts`:
+//
+//   1. os.tmpdir() is outside every node_modules, so the copy's ten bare
+//      specifiers (@dao-xyz/borsh, @libp2p/crypto, @noble/curves, ...) cannot
+//      resolve — Node walks up from /tmp and finds nothing.
+//   2. importing raw `.ts` puts the file through aegir's TypeScript loader with
+//      no tsconfig context.
+//
+// The failure was not a failing test: the process exited 0 mid-run, mocha
+// printed no summary, and every spec after this one silently never executed —
+// 46 of ~187 tests ran and CI stayed green.
+//
+// So: copy the COMPILED output, and stage it INSIDE the crypto package where
+// its own dependencies resolve.
 const importForeignCrypto = async () => {
-	const tempRoot = mkdtempSync(path.join(tmpdir(), "peerbit-crypto-duplicate-"));
-	const cryptoSrc = path.resolve(process.cwd(), "../../utils/crypto/src");
-	cpSync(cryptoSrc, path.join(tempRoot, "src"), { recursive: true });
-	writeFileSync(
-		path.join(tempRoot, "package.json"),
-		JSON.stringify({ type: "module" }),
-	);
+	const cryptoRoot = path.resolve(process.cwd(), "../../utils/crypto");
+	const cryptoDist = path.join(cryptoRoot, "dist/src");
+	if (!existsSync(path.join(cryptoDist, "index.js"))) {
+		throw new Error(
+			`@peerbit/crypto must be built before this test: ${cryptoDist}/index.js is missing`,
+		);
+	}
+	const tempRoot = mkdtempSync(path.join(cryptoRoot, ".foreign-crypto-"));
 	try {
+		cpSync(cryptoDist, path.join(tempRoot, "src"), { recursive: true });
+		writeFileSync(
+			path.join(tempRoot, "package.json"),
+			JSON.stringify({ type: "module" }),
+		);
 		const moduleUrl =
-			pathToFileURL(path.join(tempRoot, "src/index.ts")).href +
+			pathToFileURL(path.join(tempRoot, "src/index.js")).href +
 			`?t=${Date.now()}`;
 		const foreign = await import(moduleUrl);
 		return {


### PR DESCRIPTION
`@peerbit/stream` runs **46 of its ~187 tests**. The other ~139 never execute, and CI is green.

## What happens

`messages-signing.spec.ts` loads a second, independent copy of `@peerbit/crypto` to prove a signature made by a foreign module identity still normalizes. It did that by copying `crypto/src` into `os.tmpdir()` and dynamically importing **`index.ts`**:

```js
const tempRoot = mkdtempSync(path.join(tmpdir(), "peerbit-crypto-duplicate-"));
cpSync(path.resolve(process.cwd(), "../../utils/crypto/src"), path.join(tempRoot, "src"), { recursive: true });
const moduleUrl = pathToFileURL(path.join(tempRoot, "src/index.ts")).href + `?t=${Date.now()}`;
const foreign = await import(moduleUrl);
```

Two things are wrong with that location and that extension:

1. **`os.tmpdir()` is outside every `node_modules`.** The copied module has ten bare specifiers — `@dao-xyz/borsh`, `@libp2p/crypto`, `@libp2p/interface`, `@noble/curves/secp256k1`, `@stablelib/sha256`, … — and Node resolves those by walking up from the importing file. From `/tmp` there is nothing to find.
2. **It imports raw `.ts`**, so the file goes through aegir's TypeScript loader with no tsconfig context.

## Why it was invisible

The result is **not a failing test**. The process exits **0** partway through, mocha never prints a summary, and every spec loaded after this one silently does not run. The job passes.

Isolated: `--grep 'message signing'` runs 2 of that file's 10 tests and stops. The third is this one. All 102 tests in `stream.spec.ts` are among those never reached.

This is pre-existing — master CI's part-3 log shows the same 46 ✔ ending on the same test. I found it while validating an unrelated dependency change, which is the only reason it surfaced at all.

## The fix

Copy the **compiled** `dist/src` rather than `src`, and stage it **inside the crypto package** rather than in `/tmp`:

- inside `packages/utils/crypto/`, Node's upward resolution reaches that package's own `node_modules`, so every bare specifier resolves;
- `index.js` needs no loader.

The test's guarantee is unchanged: a distinct file URL still gets its own module-registry entry, so `foreign.Ed25519Keypair` remains a different class identity from the imported one — which is the whole point of the test. It also now fails with a clear message if `@peerbit/crypto` has not been built, instead of taking the suite down.

## Result

```
before:  46 passing, no summary line, rc=0
after:  185 passing (2m),              rc=0
```

Verified on **master's own dependency set** (clean `pnpm install --frozen-lockfile`, full build, then the suite), so the fix does not depend on anything else in flight.

## Follow-up worth doing separately

`scripts/ci/assert-tests-ran.mjs` (#1255) already fails a shard that produces no test summary, but it is wired only to part-7 and it aggregates across packages — so one package silently producing no summary is masked by its neighbours that do. Making it assert *per package* would have caught this, and would catch the next one.