### PR TITLE
perf(shared-log): drop the redundant encoder clone per rateless sync

### DIFF
--- a/.changeset/rateless-drop-redundant-clone.md
+++ b/.changeset/rateless-drop-redundant-clone.md
@@ -1,0 +1,14 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Drop a redundant full encoder copy per rateless-IBLT sync.
+
+`decoderFromCachedEncoder` cloned the cached encoder before calling
+`to_decoder()`, then freed the clone. `to_decoder` takes `&self` and clones the
+encoder state internally, so this produced two copies of the same buffer where
+one suffices. The encoder is roughly 48 bytes per entry in range, so a
+100k-entry range copied ~4.8 MB per StartSync purely to discard it.
+
+Behaviour is unchanged: the borrow already guarantees the cached encoder
+survives, which is what the clone was defending.

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -1278,30 +1278,23 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		encoder: EncoderWrapper,
 		beforeDecoderTransfer?: () => void,
 	): DecoderWrapper {
-		const clone = encoder.clone();
-		let cloneFreed = false;
+		// `to_decoder` takes &self and clones the encoder state internally
+		// (encoding.rs: `decoder.window = self.clone()`), so the caller's
+		// encoder is never consumed. Cloning here first was therefore a second
+		// full copy of the same buffer, immediately freed again: at N entries
+		// in range the encoder is ~48N bytes across three Vecs, so a 100k-entry
+		// range copied ~4.8 MB per StartSync for nothing. Callers pass the
+		// CACHED encoder, which the borrow already protects.
 		let decoder: DecoderWrapper | undefined;
 		let decoderTransferred = false;
-		const freeClone = () => {
-			if (cloneFreed) {
-				return;
-			}
-			cloneFreed = true;
-			clone.free();
-		};
 		try {
-			decoder = clone.to_decoder();
+			decoder = encoder.to_decoder();
 			beforeDecoderTransfer?.();
-			freeClone();
 			decoderTransferred = true;
 			return decoder;
 		} finally {
-			try {
-				freeClone();
-			} finally {
-				if (!decoderTransferred) {
-					decoder?.free();
-				}
+			if (!decoderTransferred) {
+				decoder?.free();
 			}
 		}
 	}

--- a/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
@@ -180,14 +180,14 @@ describe("rateless-iblt-syncronizer cache", () => {
 		}
 	});
 
-	it("frees a cached encoder clone once when decoder conversion throws", async () => {
+	it("does not free the cached encoder when decoder conversion throws", async () => {
 		const conversionError = new Error("decoder conversion failed");
-		const clone = {
-			to_decoder: sinon.stub().throws(conversionError),
-			free: sinon.spy(),
-		};
+		// `to_decoder` borrows (&self) and clones internally, so the cached
+		// encoder must survive a throw and must not be copied first. `clone`
+		// is spied purely so reintroducing the redundant copy fails here.
 		const encoder = {
-			clone: sinon.stub().returns(clone),
+			to_decoder: sinon.stub().throws(conversionError),
+			clone: sinon.spy(),
 			free: sinon.spy(),
 		};
 		const sync = new RatelessIBLTSynchronizer<"u64">({
@@ -214,12 +214,10 @@ describe("rateless-iblt-syncronizer cache", () => {
 				(sync as any).getLocalDecoderForRange(ranges),
 			).to.be.rejectedWith(conversionError.message);
 
-			expect(encoder.clone.calledOnce).to.equal(true);
-			expect(clone.to_decoder.calledOnce).to.equal(true);
-			expect(clone.free.calledOnce).to.equal(true);
+			expect(encoder.to_decoder.calledOnce).to.equal(true);
+			expect(encoder.clone.called).to.equal(false);
 			expect(encoder.free.called).to.equal(false);
 			await sync.close();
-			expect(clone.free.calledOnce).to.equal(true);
 			expect(encoder.free.calledOnce).to.equal(true);
 		} finally {
 			await sync.close();
@@ -229,12 +227,9 @@ describe("rateless-iblt-syncronizer cache", () => {
 	it("frees a produced cached decoder when local-decoder profiling throws", async () => {
 		const profileError = new Error("local decoder profile failed");
 		const decoder = { free: sinon.spy() };
-		const clone = {
-			to_decoder: sinon.stub().returns(decoder),
-			free: sinon.spy(),
-		};
 		const encoder = {
-			clone: sinon.stub().returns(clone),
+			to_decoder: sinon.stub().returns(decoder),
+			clone: sinon.spy(),
 			free: sinon.spy(),
 		};
 		const sync = new RatelessIBLTSynchronizer<"u64">({
@@ -268,13 +263,11 @@ describe("rateless-iblt-syncronizer cache", () => {
 				(sync as any).getLocalDecoderForRange(ranges),
 			).to.be.rejectedWith(profileError.message);
 
-			expect(encoder.clone.calledOnce).to.equal(true);
-			expect(clone.to_decoder.calledOnce).to.equal(true);
-			expect(clone.free.calledOnce).to.equal(true);
+			expect(encoder.to_decoder.calledOnce).to.equal(true);
+			expect(encoder.clone.called).to.equal(false);
 			expect(decoder.free.calledOnce).to.equal(true);
 			expect(encoder.free.called).to.equal(false);
 			await sync.close();
-			expect(clone.free.calledOnce).to.equal(true);
 			expect(decoder.free.calledOnce).to.equal(true);
 			expect(encoder.free.calledOnce).to.equal(true);
 		} finally {


### PR DESCRIPTION
Every rateless-IBLT sync copied the cached encoder twice and threw one copy away.

## The redundancy

`decoderFromCachedEncoder` did:

```ts
const clone = encoder.clone();   // full native copy
decoder = clone.to_decoder();    // ...which copies again, internally
freeClone();                     // then discards the first copy
```

The Rust says `to_decoder` borrows:

```rust
// packages/utils/rateless-iblt/src/encoding.rs:264
pub fn to_decoder(&self) -> Decoder<T> {
    let mut decoder = Decoder::<T>::new();
    decoder.window = self.clone();   // clones internally
    decoder
}
```

`&self`, and the wasm wrapper (`wasm.rs:206`) passes that through. So the encoder is never consumed, and the defensive clone the JS side added was pure waste.

The encoder is three `Vec`s at ~16 bytes per element, so ~48 bytes per entry in range: a 100k-entry range copied **~4.8 MB per StartSync** to immediately free it; at 1M entries, ~48 MB.

Behaviour is unchanged — the borrow already guarantees what the clone was defending, which is that callers pass the **cached** encoder and it must survive.

## Two tests changed, and they got stronger

They failed on the first run with `encoder.to_decoder is not a function` — test doubles built around the old `clone().to_decoder()` shape. That is the pins doing their job: the call contract genuinely changed.

One was named *"frees a cached encoder clone once when decoder conversion throws"*, and the object it names no longer exists. Rather than delete the coverage, both now pin the **stronger** invariant that replaced it:

- the cached encoder is **not** freed when `to_decoder` throws, and is freed exactly once on `close()`
- the produced decoder **is** freed when profiling throws
- and `clone` is spied purely so that **reintroducing the redundant copy fails the test**

That last assertion turns the performance property into a pinned contract rather than something a future edit can quietly undo.

## Verified

| | |
|---|---|
| `rateless-iblt-syncronizer` | 68 passing |
| broader sync suites (chunking, exchange heads, peer-state, priority) | 172 passing |
| mutation: reintroduce `encoder.clone()` | **fails**, as intended |
| restored | 8 passing |

Found by a re-census of the shared-log perf claims against current master; this was the one finding whose fix is pure waste removal with no behavioural change.