### PR TITLE
test(shared-log): make the delivery ack gate fail diagnosably instead of hanging

### DIFF
--- a/packages/programs/data/shared-log/test/delivery.spec.ts
+++ b/packages/programs/data/shared-log/test/delivery.spec.ts
@@ -18,6 +18,48 @@ import {
 import { NoPeersError } from "../src/index.js";
 import { EventStore } from "./utils/stores/index.js";
 
+// The ack gates below resolve only if the LOCAL publish interceptor recorded the
+// foreground message id before the REMOTE interceptor sees its ACK. When the
+// native (rust-core) data plane plans and sends the delivery without passing
+// through the patched JS `publishMessage`, nothing is recorded, the gate never
+// matches, and a bare `await ackAttempted.promise` hangs until mocha's 60s
+// timeout with no clue why -- which is exactly how this suite failed
+// intermittently in the Native CI job (~13% of runs) while reporting nothing
+// but "Timeout of 60000ms exceeded".
+//
+// Bounding the wait does not remove the race; it turns a silent hang into a
+// failure that names the state needed to diagnose it. `gate` is released on the
+// failure path so the in-flight append cannot wedge teardown.
+const awaitAckGate = async (
+	ackAttempted: { promise: Promise<void> },
+	gate: { resolve: () => void },
+	describeState: () => string,
+	timeoutMs = 20e3,
+) => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			ackAttempted.promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(
+							new Error(
+								`ack gate never fired within ${timeoutMs}ms — ${describeState()}`,
+							),
+						),
+					timeoutMs,
+				);
+			}),
+		]);
+	} catch (error) {
+		gate.resolve();
+		throw error;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+};
+
 type DeliveryPeerServices = TestSession["peers"][number]["services"] & {
 	fanout: FanoutTree;
 };
@@ -260,7 +302,13 @@ describe("append delivery options", () => {
 				return result;
 			});
 
-		await ackAttempted.promise;
+		await awaitAckGate(
+			ackAttempted,
+			gate,
+			() =>
+				`foregroundMessageId=${foregroundMessageId ?? "(never published via the JS path)"}, ` +
+				`recorded=${JSON.stringify([...deliveryPriorityByMessageId])}`,
+		);
 		expect(resolved).to.equal(false);
 		expect(foregroundAckedMessageId).to.equal(foregroundMessageId);
 		expect(deliveryPriorityByMessageId.get(foregroundAckedMessageId!)).to.equal(
@@ -440,7 +488,11 @@ describe("append delivery options", () => {
 				return result;
 			});
 
-		await ackAttempted.promise;
+		await awaitAckGate(
+			ackAttempted,
+			gate,
+			() => "no acknowledged delivery reached the remote publish interceptor",
+		);
 		expect(resolved).to.equal(false);
 
 		gate.resolve();


### PR DESCRIPTION
The `append delivery options` suite fails ~13% of Native CI runs with nothing but:

```
Error: Timeout of 60000ms exceeded. ... (dist/test/delivery.spec.js)
```

Sixty seconds of silence and no indication of what did not happen. This makes the failure self-explaining.

## Why it hangs

Two tests end with a bare `await ackAttempted.promise`, and that deferred resolves only if a two-step chain completes:

1. the **local** publish interceptor sees a `DataMessage` with `AcknowledgeDelivery` addressed to the remote, and records its priority in `deliveryPriorityByMessageId`
2. the **remote** interceptor sees an `ACK` whose `messageIdToAcknowledge` is already in that map with `FOREGROUND_READ_MESSAGE_PRIORITY`

If step 1 never records, step 2's lookup returns `undefined`, the gate never fires, and the await never settles. Nothing bounds it.

The likely trigger is specific to the leg that flakes: under the native (rust-core) data plane the foreground delivery can be planned and sent **without passing through the patched JS `publishMessage`**, so the map stays empty. The test's own comment already acknowledges native traffic differs here (*"Native convergence can emit unrelated acknowledged traffic during this append"*). That is a hypothesis, not a proven cause — which is the point of this change.

## What this does, and does not, do

It does **not** remove the race. It bounds both gates at 20s and fails with the state needed to identify the cause on the next occurrence:

```
Error: ack gate never fired within 20000ms — foregroundMessageId=xLCU9Bz5UcLbhQu4qg0NVzBHyvKoopEXCfwYJO1Wuy4=,
recorded=[["xLCU9Bz5…",2],["WUUPgs89…",3],["lG/s8qht…",3]]
```

That output discriminates all three candidate causes immediately:

| output | meaning |
|---|---|
| `foregroundMessageId=(never published via the JS path)` | native bypass — hypothesis confirmed |
| id set, but absent from `recorded` | ordering race between the two interceptors |
| id present with the wrong priority | priority mismatch |

`gate` is released on the failure path so the in-flight append cannot wedge teardown.

## Verified

| | |
|---|---|
| default mode | 13 passing |
| `PEERBIT_SHARED_LOG_RUST_CORE=1` | 13 passing |
| gate condition forced false | fails in **40s** (was a 60s hang) with the diagnostic above |
| restored | 13 passing |

Applied to both occurrences in the file (lines 263 and 443), which share the pattern.