### PR TITLE
chore(logger): store the changelog in the canonical changesets form

### DIFF
--- a/packages/utils/logger/CHANGELOG.md
+++ b/packages/utils/logger/CHANGELOG.md
@@ -2,79 +2,69 @@
 
 ## [2.0.1](https://github.com/dao-xyz/peerbit/compare/logger-v2.0.0...logger-v2.0.1) (2026-03-30)
 
-
 ### Bug Fixes
 
-* **packages:** normalize npm metadata for released modules ([#702](https://github.com/dao-xyz/peerbit/issues/702)) ([bc77b1d](https://github.com/dao-xyz/peerbit/commit/bc77b1d196f86d3783050903e85bef720d703cf2))
+- **packages:** normalize npm metadata for released modules ([#702](https://github.com/dao-xyz/peerbit/issues/702)) ([bc77b1d](https://github.com/dao-xyz/peerbit/commit/bc77b1d196f86d3783050903e85bef720d703cf2))
 
 ## [2.0.0](https://github.com/dao-xyz/peerbit/compare/logger-v1.0.4...logger-v2.0.0) (2025-11-25)
 
-
 ### ⚠ BREAKING CHANGES
 
-* re-export libp2p logger instead of pino
+- re-export libp2p logger instead of pino
 
 ### Features
 
-* add react tests ([42b3923](https://github.com/dao-xyz/peerbit/commit/42b3923c4ff551a691ab2e2c1e605a84ec55d059))
-* migrate to borsh 6 and Typescript Stage 3 decorators ([86caba4](https://github.com/dao-xyz/peerbit/commit/86caba4f2128d3b1e2d274bea1b537722b5ec1c7))
-* re-export libp2p logger instead of pino ([bf00a08](https://github.com/dao-xyz/peerbit/commit/bf00a08df73ea7fd1c381d9a4771dc61a86f9d30))
+- add react tests ([42b3923](https://github.com/dao-xyz/peerbit/commit/42b3923c4ff551a691ab2e2c1e605a84ec55d059))
+- migrate to borsh 6 and Typescript Stage 3 decorators ([86caba4](https://github.com/dao-xyz/peerbit/commit/86caba4f2128d3b1e2d274bea1b537722b5ec1c7))
+- re-export libp2p logger instead of pino ([bf00a08](https://github.com/dao-xyz/peerbit/commit/bf00a08df73ea7fd1c381d9a4771dc61a86f9d30))
 
 ## [1.0.4](https://github.com/dao-xyz/peerbit/compare/logger-v1.0.3...logger-v1.0.4) (2025-09-04)
 
-
 ### Bug Fixes
 
-* SharedWorker compatibility ([0769fe6](https://github.com/dao-xyz/peerbit/commit/0769fe67e3c13ea504287aa1c26e41da3b5753eb))
+- SharedWorker compatibility ([0769fe6](https://github.com/dao-xyz/peerbit/commit/0769fe67e3c13ea504287aa1c26e41da3b5753eb))
 
 ## [1.0.3](https://github.com/dao-xyz/peerbit/compare/logger-v1.0.2...logger-v1.0.3) (2024-07-20)
 
-
 ### Bug Fixes
 
-* fmt ([bdee4f4](https://github.com/dao-xyz/peerbit/commit/bdee4f4943fcabd21c53a4f37dba17d04cea2577))
-* peerbit eslint rules ([5056694](https://github.com/dao-xyz/peerbit/commit/5056694f90ad03c0c5ba1e47c6ac57387d85aba9))
+- fmt ([bdee4f4](https://github.com/dao-xyz/peerbit/commit/bdee4f4943fcabd21c53a4f37dba17d04cea2577))
+- peerbit eslint rules ([5056694](https://github.com/dao-xyz/peerbit/commit/5056694f90ad03c0c5ba1e47c6ac57387d85aba9))
 
 ## [1.0.2](https://github.com/dao-xyz/peerbit/compare/logger-v1.0.1...logger-v1.0.2) (2023-12-31)
 
-
 ### Bug Fixes
 
-* update linter ([b0e2e14](https://github.com/dao-xyz/peerbit/commit/b0e2e140cfbd0fb278e00bc1127219be6242c735))
+- update linter ([b0e2e14](https://github.com/dao-xyz/peerbit/commit/b0e2e140cfbd0fb278e00bc1127219be6242c735))
 
 ## [1.0.1](https://github.com/dao-xyz/peerbit/compare/logger-v1.0.0...logger-v1.0.1) (2023-07-04)
 
-
 ### Bug Fixes
 
-* rm postbuild script ([b627bf0](https://github.com/dao-xyz/peerbit/commit/b627bf0dcdb99d24ac8c9055586e72ea2d174fcc))
+- rm postbuild script ([b627bf0](https://github.com/dao-xyz/peerbit/commit/b627bf0dcdb99d24ac8c9055586e72ea2d174fcc))
 
 ## 1.0.0 (2023-06-28)
 
-
 ### ⚠ BREAKING CHANGES
 
-* client abstraction
+- client abstraction
 
 ### Features
 
-* client abstraction ([6a1226d](https://github.com/dao-xyz/peerbit/commit/6a1226d4f8fc6deb167bff86cf7bdd6227c01a6b))
-
+- client abstraction ([6a1226d](https://github.com/dao-xyz/peerbit/commit/6a1226d4f8fc6deb167bff86cf7bdd6227c01a6b))
 
 ### Bug Fixes
 
-* bump dependencies ([8a8fd44](https://github.com/dao-xyz/peerbit/commit/8a8fd440149a966337382db77afe1071141e5c74))
+- bump dependencies ([8a8fd44](https://github.com/dao-xyz/peerbit/commit/8a8fd440149a966337382db77afe1071141e5c74))
 
 ## 1.0.0 (2023-06-15)
 
-
 ### Bug Fixes
 
-* bump dependencies ([8a8fd44](https://github.com/dao-xyz/peerbit/commit/8a8fd440149a966337382db77afe1071141e5c74))
+- bump dependencies ([8a8fd44](https://github.com/dao-xyz/peerbit/commit/8a8fd440149a966337382db77afe1071141e5c74))
 
 ## @peerbit/logger [0.0.7](https://github.com/dao-xyz/peerbit/compare/@peerbit/logger@0.0.6...@peerbit/logger@0.0.7) (2023-06-07)
 
-
 ### Bug Fixes
 
-* add release cfg ([de76654](https://github.com/dao-xyz/peerbit/commit/de766548f8106804d319e8b51e9607f2a3f60726))
+- add release cfg ([de76654](https://github.com/dao-xyz/peerbit/commit/de766548f8106804d319e8b51e9607f2a3f60726))


### PR DESCRIPTION
The version PR (#1267) is **blocked** and cannot publish:

```
Changeset coverage guard failed: packages/utils/logger/CHANGELOG.md rewrites or
drops existing release history instead of preserving it as the exact terminal
structural tail
```

## No history is being dropped

I diffed the bot's output against master byte by byte. The entire divergence is two cosmetic normalisations of the **pre-existing** entries:

```
master:  \n\n\n### Bug Fixes   …   * **packages:** normalize npm metadata
bot:     \n\n### Bug Fixes     …   - **packages:** normalize npm metadata
```

A collapsed blank line, and `*` bullets rewritten to `-`. Verified across the whole file: **identical heading set, identical bullet set** — only whitespace and markers differ.

## Why now, and why this package

`@peerbit/logger`'s changelog is still entirely in the old release-please format (`## [2.0.1](compare-link) (date)`). #1263 is the first changeset ever to include this package, so changesets is regenerating that file for the first time and emitting its own markdown serialisation for the historical entries as it goes.

Not prettier, incidentally — the repo's `fmt` script covers `.js/.ts/.json/.vue` and not markdown, and running prettier over the file does **not** reproduce the bot's output. This is changesets' own serialiser.

The guard is right to demand byte-exact preservation; the file simply was not yet in the form the tool emits.

## The fix

Store the history in exactly the form changesets produces, taken from the bot's own output rather than guessed. Verified programmatically that the guard's rule now holds — the bot's output ends with the new file minus its header — so the next regeneration is a pure prepend.

## Two more will hit this

```
packages/clients/canonical/transport/CHANGELOG.md
packages/utils/rateless-iblt/CHANGELOG.md
```

Both still carry `* **` bullets and neither has been through a changesets release yet, so each will block its first version PR the same way. I have deliberately **not** pre-converted them: the canonical form has to come from the tool's actual output, and inventing it by hand is how a formatting nit turns into genuine history loss. When one of them next appears in a release, take the bot's output the same way this PR did.
