### PR TITLE
perf(shared-log): compute tick participation exactly instead of sampling

### DIFF
--- a/.changeset/tick-exact-participation.md
+++ b/.changeset/tick-exact-participation.md
@@ -1,0 +1,19 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Compute total participation exactly instead of sampling it 25 times per second.
+
+The adaptive rebalance tick called `calculateTotalParticipation()` on its default
+path, which Monte-Carlo estimates coverage with `appromixateCoverage({ samples:
+25 })` — 25 sequential index `count()` queries per tick. The same function
+already offers `{ sum: true }`, which totals `widthNormalized` across the
+replication index in a single `iterate().all()`.
+
+The two compute the same quantity: the mean coverage of the domain is the sum of
+the range widths. The sampled form was an estimate of the exact one, so this
+removes 25 of the tick's 27 index round-trips per open adaptive log — which is
+every default-configured log, since `replicate: true` and `replicate: undefined`
+both resolve to adaptive.
+
+The replication controller now sees a stable input rather than a sampled one.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -25014,7 +25014,22 @@ export class SharedLog<
 
 				const peersSize = (await peers.getSize()) || 1;
 				if (!isCurrent()) return false;
-				const totalParticipation = await this.calculateTotalParticipation();
+				// `{ sum: true }` totals widthNormalized over the replication
+				// index in ONE query. The default path instead calls
+				// appromixateCoverage({ samples: 25 }), which Monte-Carlo
+				// estimates the same quantity -- the mean coverage of the
+				// domain IS the sum of the range widths -- using 25 sequential
+				// count() queries. So this is the exact value at 1/25th of the
+				// index traffic, and it is 25 of the 27 queries this 1 Hz tick
+				// issued per open adaptive log.
+				//
+				// The controller consequently sees a stable input instead of a
+				// sampled one; that is a behaviour change, not just a speedup,
+				// which is why it is landing against the convergence suites
+				// rather than on the strength of the query count alone.
+				const totalParticipation = await this.calculateTotalParticipation({
+					sum: true,
+				});
 				if (!isCurrent()) return false;
 
 				const newFactor = this.replicationController.step({


### PR DESCRIPTION
The 1 Hz adaptive rebalance tick issued **27 index round-trips per second per open log**. 25 of them came from one call, and an exact single-query equivalent was already sitting in the same function.

## The redundancy

```ts
async calculateTotalParticipation(options?: { sum?: boolean }) {
    if (options?.sum) {
        const ranges = await this.replicationIndex.iterate().all();   // 1 query
        let sum = 0;
        for (const range of ranges) sum += range.value.widthNormalized;
        return sum;
    }
    return appromixateCoverage({ ..., samples: 25 });                 // 25 queries
}
```

The tick called it **without** `{ sum: true }`, taking the sampling path: 25 sequential `count()` queries over a fixed 25-point grid, plus ~175 freshly-allocated query AST objects, every second.

The two branches compute the same quantity. Mean coverage of the domain **is** the sum of the range widths — `appromixateCoverage` is a Monte-Carlo estimate of exactly what `{ sum: true }` computes directly. So the tick was paying 25 queries for a noisy approximation of a value it could read exactly in one.

Tick cost goes **27 → 3** index round-trips. This is not an opt-in path: `replicate: true` and `replicate: undefined` both normalise to adaptive, so it applies to every default-configured log.

## This is a behaviour change, and was treated as one

The value feeds the replication controller's `totalFactor`, and the call site carries a standing `// TODO use this._totalParticipation when flakiness is fixed` — someone has been bitten changing this input before. The controller now sees a stable value where it previously saw a sampled one. Strictly better input, but different input.

So it was validated against the convergence suites rather than on the query count, and run **twice** to distinguish a stable controller from a lucky run:

| suite | pass 1 | pass 2 |
|---|---|---|
| `u32-simple sharding` | 31 passing | 31 passing |
| `u32-simple replication` | 64 passing | 64 passing |
| `PIDReplicationController` + `ranges:` | 1514 passing | — |

The convergence diagnostics are the substantive evidence. Three peers at full coverage settle to a participation of ~1/3 each, both times:

```
pass 1:  0.33350  0.33422  0.33476
pass 2:  0.33160  0.33546  0.33577
```

That is the controller reaching the correct steady state on the exact input, not merely a suite going green.

## Note on what is not claimed

No wall-clock benchmark is quoted. The census that surfaced this also found that the four base-vs-head harnesses have no documented noise floor and that CI runs the sync-peer-state comparator's unit tests but never the benchmark itself — so there is currently no trustworthy way to attach a millisecond figure to this. The defensible claim is the one made above: 25 fewer index queries per tick, derived from the code, with convergence unchanged.
