### PR TITLE
ci: wait for released tarballs before the bootstrap rollout npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,13 @@ jobs:
         run: |
           node --test scripts/validate-retired-domain-references.test.mjs
           node scripts/validate-retired-domain-references.mjs
-      - name: Validate bootstrap rollout PR generation
+      # Globbed, not enumerated: a spec added under tools/ must not be able to
+      # sit unrun because nobody remembered to name it here. If the glob ever
+      # matches nothing, bash passes it through literally and node --test fails
+      # loudly rather than reporting a green run of zero files.
+      - name: Validate release automation tools
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
-        run: node --test tools/sync-bootstrap-rollout.spec.mjs
+        run: node --test tools/*.spec.mjs
       - name: Validate the supabase edge functions
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -138,8 +138,20 @@ jobs:
         run: |
           node tools/sync-bootstrap-rollout.mjs peerbit-bootstrap "${{ steps.server.outputs.version }}"
 
+      # `npm ci` below downloads tarballs the Release run published minutes ago.
+      # Run 31805881609 raced that and died on a 404 for peerbit-5.3.24.tgz, a
+      # version that served 200 shortly after. Kept as its own step so a
+      # propagation stall is visibly distinct from a real rollout failure.
+      - name: Wait for released tarballs to be fetchable
+        if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
+        timeout-minutes: 12
+        working-directory: peerbit-bootstrap
+        run: |
+          node "$GITHUB_WORKSPACE/tools/wait-for-registry-tarballs.mjs" . "${{ steps.server.outputs.version }}"
+
       - name: Validate generated rollout
         if: ${{ steps.server.outputs.changed == 'true' && steps.auth.outputs.enabled == 'true' }}
+        timeout-minutes: 20
         working-directory: peerbit-bootstrap
         run: |
           npm ci --ignore-scripts --no-audit --no-fund

--- a/tools/wait-for-registry-tarballs.mjs
+++ b/tools/wait-for-registry-tarballs.mjs
@@ -1,0 +1,314 @@
+// Waits until every registry tarball this rollout freshly pinned is actually
+// downloadable, before `npm ci` tries to download it.
+//
+// Why this exists: run 31805881609 failed in "Validate generated rollout" with
+//
+//   npm error 404 Not Found - GET https://registry.npmjs.org/peerbit/-/peerbit-5.3.24.tgz
+//
+// ~16 minutes after Release had published that version. The tarball URL served
+// 200 later, so nothing was missing -- the job raced registry propagation.
+//
+// Note what that says about the *shape* of the guard. The preceding step runs
+// tools/sync-bootstrap-rollout.mjs, whose installPackageLock() shells out to
+// `npm install --package-lock-only`; readServerLockState() then requires a
+// canonical `sha512-...` on every pinned entry (assertIntegrity). npm can only
+// write that integrity by reading `dist.integrity` out of the registry
+// packument. So the packument for peerbit@5.3.24 was already live and correct
+// at that moment -- only the tarball blob was not yet servable. A guard that
+// polls metadata (`npm view <pkg>@<version> version`, a packument GET, ...)
+// would have returned instantly and the 404 would have happened anyway. The
+// probe has to hit the same artifact `npm ci` fetches: the tarball URL.
+//
+// Which URLs: the ones this sync just introduced, computed as the registry
+// `resolved` URLs present in the generated package-lock.json but absent from
+// the committed one (`git show HEAD:package-lock.json`), unioned with every
+// registry entry pinned at the released version. Both halves are load-bearing.
+// The released version is @peerbit/server's (8.x); the tarball that 404'd was
+// `peerbit` (5.x), a transitive dependency published by the same release run --
+// version-equality alone would not have probed it, and the newly-added-URL set
+// alone depends on git being available.
+//
+// The probe deliberately sends no cache-busting headers and no query string: it
+// must observe exactly what `npm ci` will observe, edge cache included. A probe
+// that asks the CDN to revalidate could go green while npm ci still reads a
+// cached 404.
+//
+// Usage: node tools/wait-for-registry-tarballs.mjs <bootstrap-root> <version>
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REGISTRY_ORIGIN = "https://registry.npmjs.org";
+const USER_AGENT = "peerbit-post-release-tarball-probe";
+const MAX_ATTEMPTS = 20;
+const DELAY_STEP_MS = 5_000;
+const MAX_DELAY_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const PROBE_CONCURRENCY = 8;
+
+const ensure = (condition, message) => {
+	if (!condition) throw new Error(message);
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+const mapWithConcurrency = async (items, limit, worker) => {
+	const results = new Array(items.length);
+	let cursor = 0;
+	const runners = Array.from(
+		{ length: Math.min(limit, items.length) },
+		async () => {
+			while (cursor < items.length) {
+				const index = cursor++;
+				results[index] = await worker(items[index]);
+			}
+		},
+	);
+	await Promise.all(runners);
+	return results;
+};
+
+// "https://registry.npmjs.org/@peerbit/server/-/server-8.0.14.tgz" -> "@peerbit/server"
+const packageNameFromTarball = (url) => {
+	const marker = "/-/";
+	const index = url.pathname.indexOf(marker);
+	if (index <= 0) return undefined;
+	return decodeURIComponent(url.pathname.slice(1, index));
+};
+
+const registryTarballs = (lock) => {
+	const entries = new Map();
+	for (const [lockPath, entry] of Object.entries(lock.packages ?? {})) {
+		if (typeof entry?.resolved !== "string") continue;
+		let resolved;
+		try {
+			resolved = new URL(entry.resolved);
+		} catch {
+			continue;
+		}
+		if (resolved.origin !== REGISTRY_ORIGIN) continue;
+		entries.set(entry.resolved, {
+			url: entry.resolved,
+			name: packageNameFromTarball(resolved),
+			version: typeof entry.version === "string" ? entry.version : undefined,
+			lockPath: lockPath || "package-lock root",
+		});
+	}
+	return entries;
+};
+
+// Returns the committed lockfile's registry URLs, or undefined when the
+// previous revision cannot be read. spawnSync is used (not a shell pipeline) so
+// the exit status belongs to git itself and not to whatever ran last in a pipe.
+//
+// `git -C <root>` walks *up* to the nearest enclosing repository when <root>
+// has no .git of its own. Here <root> is the bootstrap checkout nested inside
+// the peerbit checkout, so a missing bootstrap .git would silently answer with
+// peerbit's own lockfile -- a completely unrelated set of URLs. Pin the answer
+// to <root> itself before trusting it.
+const committedRegistryUrls = (root) => {
+	const git = (args) =>
+		spawnSync("git", ["-C", root, ...args], {
+			encoding: "utf8",
+			maxBuffer: 64 * 1024 * 1024,
+		});
+	const toplevel = git(["rev-parse", "--show-toplevel"]);
+	if (toplevel.error || toplevel.status !== 0) return undefined;
+	if (fs.realpathSync(toplevel.stdout.trim()) !== root) return undefined;
+	const result = git(["show", "HEAD:package-lock.json"]);
+	if (result.error || result.status !== 0) return undefined;
+	try {
+		return new Set(registryTarballs(JSON.parse(result.stdout)).keys());
+	} catch {
+		return undefined;
+	}
+};
+
+export const selectProbeTargets = ({ lock, previousUrls, releasedVersion }) => {
+	// Required, not optional. A missing set must never quietly reduce this to
+	// version-equality matching -- see the ensure() in waitForRegistryTarballs.
+	ensure(
+		previousUrls instanceof Set,
+		"selectProbeTargets requires the committed lockfile's URL set",
+	);
+	const current = registryTarballs(lock);
+	const targets = new Map();
+	for (const [url, entry] of current) {
+		const freshlyPinned = !previousUrls.has(url);
+		if (freshlyPinned || entry.version === releasedVersion)
+			targets.set(url, entry);
+	}
+	return targets;
+};
+
+const probeTarball = async (url) => {
+	const request = async (method) => {
+		const response = await fetch(url, {
+			method,
+			redirect: "follow",
+			headers: { "user-agent": USER_AGENT },
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+		// Release the socket without downloading the payload.
+		await response.body?.cancel();
+		return response.status;
+	};
+	try {
+		let status = await request("HEAD");
+		// Some edges refuse HEAD on blobs; fall back to the exact GET npm issues.
+		if (status === 403 || status === 405 || status === 501)
+			status = await request("GET");
+		return { ok: status === 200, detail: `HTTP ${status}` };
+	} catch (error) {
+		return { ok: false, detail: `request failed: ${error.message}` };
+	}
+};
+
+// Distinguishes "the registry never heard of this version" from "the version is
+// published and the blob has not propagated". Only ever called on the failure
+// path, to explain a timeout -- never to decide that the wait succeeded.
+const classifyFailure = async (target) => {
+	if (!target.name) return "could not derive a package name from the URL";
+	const packument = `${REGISTRY_ORIGIN}/${target.name.replace(/\//g, "%2f")}`;
+	try {
+		const response = await fetch(packument, {
+			headers: {
+				accept: "application/vnd.npm.install-v1+json",
+				"user-agent": USER_AGENT,
+			},
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+		if (response.status === 404) {
+			await response.body?.cancel();
+			return `package ${target.name} does not exist in the registry`;
+		}
+		if (!response.ok) {
+			await response.body?.cancel();
+			return `packument lookup failed with HTTP ${response.status}`;
+		}
+		const body = await response.json();
+		return body?.versions?.[target.version]
+			? `${target.name}@${target.version} is published; the tarball has not propagated`
+			: `${target.name}@${target.version} is NOT published (packument does not list it)`;
+	} catch (error) {
+		return `packument lookup failed: ${error.message}`;
+	}
+};
+
+export const waitForRegistryTarballs = async ({
+	bootstrapRoot,
+	releasedVersion,
+	attempts = MAX_ATTEMPTS,
+	probe = probeTarball,
+}) => {
+	const root = fs.realpathSync(path.resolve(bootstrapRoot));
+	const lockFile = path.join(root, "package-lock.json");
+	ensure(fs.existsSync(lockFile), `Missing package-lock.json: ${lockFile}`);
+
+	// Not a warning. Without the committed lockfile there is no freshly-pinned
+	// set, so selectProbeTargets falls back to version-equality alone -- and the
+	// tarball this guard exists for (`peerbit` 5.x, a transitive published by the
+	// same run) is on a different version line from the released @peerbit/server
+	// 8.x, so it would not be probed at all. targets.size stays > 0 because the
+	// server entry always matches, so the run would go green having checked
+	// nothing that matters. Degrading to a guard that names a property it does
+	// not check is the failure this file exists to prevent; refuse instead.
+	const previousUrls = committedRegistryUrls(root);
+	ensure(
+		previousUrls,
+		`Could not read HEAD:package-lock.json from ${root}. Refusing to continue: without it only tarballs already at ${releasedVersion} would be probed, which silently skips freshly-pinned transitive dependencies on other version lines.`,
+	);
+
+	const targets = selectProbeTargets({
+		lock: readJson(lockFile),
+		previousUrls,
+		releasedVersion,
+	});
+	// sync-bootstrap-rollout.mjs always leaves node_modules/@peerbit/server
+	// pinned at the released version, so an empty set means the lockfile is not
+	// the one that step produced.
+	ensure(
+		targets.size > 0,
+		`No registry tarball in ${lockFile} is newly pinned or pinned at ${releasedVersion}; refusing to run a wait that checks nothing`,
+	);
+
+	let pending = [...targets.values()];
+	console.log(
+		`Waiting for ${pending.length} registry tarball(s) to become fetchable:`,
+	);
+	for (const target of pending) console.log(`  ${target.url}`);
+
+	const lastDetail = new Map();
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		const results = await mapWithConcurrency(
+			pending,
+			PROBE_CONCURRENCY,
+			async (target) => ({ target, result: await probe(target.url) }),
+		);
+		const stillPending = [];
+		for (const { target, result } of results) {
+			lastDetail.set(target.url, result.detail);
+			if (result.ok) console.log(`  ok ${target.url} (${result.detail})`);
+			else stillPending.push(target);
+		}
+		pending = stillPending;
+		if (pending.length === 0) {
+			console.log(
+				`All ${targets.size} tarball(s) are fetchable after attempt ${attempt}.`,
+			);
+			return { attempts: attempt, probed: targets.size };
+		}
+		if (attempt === attempts) break;
+		const delay = Math.min(DELAY_STEP_MS * attempt, MAX_DELAY_MS);
+		console.log(
+			`  attempt ${attempt}/${attempts}: ${pending.length} tarball(s) not fetchable yet; retrying in ${delay / 1000}s`,
+		);
+		for (const target of pending)
+			console.log(`    ${target.url} -> ${lastDetail.get(target.url)}`);
+		await sleep(delay);
+	}
+
+	const diagnoses = await mapWithConcurrency(
+		pending,
+		PROBE_CONCURRENCY,
+		async (target) => ({ target, reason: await classifyFailure(target) }),
+	);
+	const missing = diagnoses.filter(({ reason }) =>
+		reason.includes("NOT published"),
+	);
+	const lines = diagnoses.map(
+		({ target, reason }) =>
+			`  ${target.url}\n    last probe: ${lastDetail.get(target.url)}\n    registry says: ${reason}`,
+	);
+	throw new Error(
+		[
+			missing.length > 0
+				? `${missing.length} of ${pending.length} unfetchable tarball(s) are genuinely missing from the registry -- this is not a propagation delay, the release did not publish them.`
+				: `${pending.length} tarball(s) are published but still not downloadable after ${attempts} attempts -- registry propagation timed out. Re-run this job.`,
+			...lines,
+		].join("\n"),
+	);
+};
+
+const run = async () => {
+	const bootstrapRoot = process.argv[2];
+	const releasedVersion = process.argv[3];
+	ensure(
+		bootstrapRoot,
+		"Usage: node tools/wait-for-registry-tarballs.mjs <bootstrap-root> <released-version>",
+	);
+	ensure(releasedVersion, "Missing released version argument");
+	await waitForRegistryTarballs({ bootstrapRoot, releasedVersion });
+};
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+)
+	run().catch((error) => {
+		console.error(error.message);
+		process.exitCode = 1;
+	});

--- a/tools/wait-for-registry-tarballs.spec.mjs
+++ b/tools/wait-for-registry-tarballs.spec.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	selectProbeTargets,
+	waitForRegistryTarballs,
+} from "./wait-for-registry-tarballs.mjs";
+
+// The scenario every case here is built from is the one that actually failed
+// (run 31805881609): Release publishes @peerbit/server 8.0.14 *and* its
+// transitive dependency peerbit 5.3.99, the rollout pins both, and only the
+// transitive one is still unfetchable. The two live on different version lines,
+// which is exactly why version-equality matching alone is not sufficient.
+const RELEASED_VERSION = "8.0.14";
+const SERVER_TARBALL =
+	"https://registry.npmjs.org/@peerbit/server/-/server-8.0.14.tgz";
+const PEERBIT_TARBALL =
+	"https://registry.npmjs.org/peerbit/-/peerbit-5.3.99.tgz";
+const LODASH_TARBALL = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
+
+const lockWith = (entries) => ({
+	name: "peerbit-bootstrap",
+	lockfileVersion: 3,
+	packages: Object.fromEntries(
+		entries.map(({ lockPath, name, version, resolved }) => [
+			lockPath,
+			{ name, version, resolved, integrity: `sha512-${"a".repeat(86)}==` },
+		]),
+	),
+});
+
+const PREVIOUS = [
+	{
+		lockPath: "node_modules/@peerbit/server",
+		name: "@peerbit/server",
+		version: "8.0.13",
+		resolved: "https://registry.npmjs.org/@peerbit/server/-/server-8.0.13.tgz",
+	},
+	{
+		lockPath: "node_modules/peerbit",
+		name: "peerbit",
+		version: "5.3.98",
+		resolved: "https://registry.npmjs.org/peerbit/-/peerbit-5.3.98.tgz",
+	},
+	{
+		lockPath: "node_modules/lodash",
+		name: "lodash",
+		version: "4.17.21",
+		resolved: LODASH_TARBALL,
+	},
+];
+
+const CURRENT = [
+	{
+		lockPath: "node_modules/@peerbit/server",
+		name: "@peerbit/server",
+		version: RELEASED_VERSION,
+		resolved: SERVER_TARBALL,
+	},
+	{
+		lockPath: "node_modules/peerbit",
+		name: "peerbit",
+		version: "5.3.99",
+		resolved: PEERBIT_TARBALL,
+	},
+	{
+		lockPath: "node_modules/lodash",
+		name: "lodash",
+		version: "4.17.21",
+		resolved: LODASH_TARBALL,
+	},
+];
+
+const previousUrls = () => new Set(PREVIOUS.map((entry) => entry.resolved));
+
+test("probes a freshly pinned transitive on a different version line", () => {
+	const targets = selectProbeTargets({
+		lock: lockWith(CURRENT),
+		previousUrls: previousUrls(),
+		releasedVersion: RELEASED_VERSION,
+	});
+	// peerbit@5.3.99 does NOT equal the released 8.0.14, so it is selected only
+	// because it is newly pinned. This is the tarball that 404'd in production.
+	assert.ok(targets.has(PEERBIT_TARBALL));
+	assert.ok(targets.has(SERVER_TARBALL));
+	// Unchanged dependency: already on the registry long ago, nothing to wait for.
+	assert.ok(!targets.has(LODASH_TARBALL));
+});
+
+test("selectProbeTargets refuses to run without the committed URL set", () => {
+	// Regression guard. Defaulting previousUrls to "nothing was freshly pinned"
+	// silently degrades this to version-equality matching, which drops
+	// peerbit@5.3.99 while still selecting the server entry -- so targets stays
+	// non-empty and the wait passes having skipped the one URL that mattered.
+	for (const previous of [undefined, null, [...previousUrls()]]) {
+		assert.throws(
+			() =>
+				selectProbeTargets({
+					lock: lockWith(CURRENT),
+					previousUrls: previous,
+					releasedVersion: RELEASED_VERSION,
+				}),
+			/requires the committed lockfile's URL set/,
+		);
+	}
+});
+
+test("ignores non-registry resolved entries", () => {
+	const targets = selectProbeTargets({
+		lock: lockWith([
+			...CURRENT,
+			{
+				lockPath: "node_modules/private-thing",
+				name: "private-thing",
+				version: RELEASED_VERSION,
+				resolved: "https://npm.example.com/private-thing/-/x-8.0.14.tgz",
+			},
+		]),
+		previousUrls: previousUrls(),
+		releasedVersion: RELEASED_VERSION,
+	});
+	assert.ok(
+		[...targets.keys()].every((url) =>
+			url.startsWith("https://registry.npmjs.org/"),
+		),
+	);
+});
+
+const withBootstrapRepo = (entries, run) => {
+	const root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), "wait-tarballs-")),
+	);
+	const git = (...args) =>
+		spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+	try {
+		git("init", "--quiet");
+		git("config", "user.email", "test@example.com");
+		git("config", "user.name", "test");
+		fs.writeFileSync(
+			path.join(root, "package-lock.json"),
+			`${JSON.stringify(lockWith(PREVIOUS), null, 2)}\n`,
+		);
+		git("add", "-A");
+		git("commit", "--quiet", "-m", "base");
+		// Post-sync state: tracked file rewritten, not committed -- exactly what
+		// sync-bootstrap-rollout.mjs leaves behind for `npm ci` to consume.
+		fs.writeFileSync(
+			path.join(root, "package-lock.json"),
+			`${JSON.stringify(lockWith(entries), null, 2)}\n`,
+		);
+		return run(root);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+};
+
+test("returns once every probed tarball is fetchable", async () => {
+	await withBootstrapRepo(CURRENT, async (root) => {
+		const probed = [];
+		const result = await waitForRegistryTarballs({
+			bootstrapRoot: root,
+			releasedVersion: RELEASED_VERSION,
+			attempts: 3,
+			probe: async (url) => {
+				probed.push(url);
+				return { ok: true, detail: "HTTP 200" };
+			},
+		});
+		assert.equal(result.probed, 2);
+		assert.equal(result.attempts, 1);
+		assert.deepEqual(probed.sort(), [SERVER_TARBALL, PEERBIT_TARBALL].sort());
+	});
+});
+
+test("does not return success while a tarball still 404s", async () => {
+	await withBootstrapRepo(CURRENT, async (root) => {
+		let calls = 0;
+		await assert.rejects(
+			waitForRegistryTarballs({
+				bootstrapRoot: root,
+				releasedVersion: RELEASED_VERSION,
+				attempts: 2,
+				probe: async (url) => {
+					calls++;
+					return url === PEERBIT_TARBALL
+						? { ok: false, detail: "HTTP 404" }
+						: { ok: true, detail: "HTTP 200" };
+				},
+			}),
+			// It must name the still-missing tarball, not just fail vaguely.
+			(error) => error.message.includes(PEERBIT_TARBALL),
+		);
+		assert.ok(calls > 2, "the failing tarball should be retried");
+	});
+});
+
+test("refuses to run when the committed lockfile cannot be read", async () => {
+	const root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), "wait-tarballs-nogit-")),
+	);
+	try {
+		fs.writeFileSync(
+			path.join(root, "package-lock.json"),
+			`${JSON.stringify(lockWith(CURRENT), null, 2)}\n`,
+		);
+		let probeCalls = 0;
+		await assert.rejects(
+			waitForRegistryTarballs({
+				bootstrapRoot: root,
+				releasedVersion: RELEASED_VERSION,
+				attempts: 1,
+				probe: async () => {
+					probeCalls++;
+					return { ok: true, detail: "HTTP 200" };
+				},
+			}),
+			/Could not read HEAD:package-lock\.json/,
+		);
+		// The point is that it fails instead of probing a reduced target set.
+		assert.equal(probeCalls, 0);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("does not borrow an enclosing repository's lockfile", async () => {
+	// `git -C <dir>` walks up when <dir> has no .git. The bootstrap checkout is
+	// nested inside the peerbit checkout, so walking up would answer with
+	// peerbit's lockfile and produce a meaningless "freshly pinned" set.
+	const outer = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), "wait-tarballs-outer-")),
+	);
+	try {
+		const git = (...args) =>
+			spawnSync("git", ["-C", outer, ...args], { encoding: "utf8" });
+		git("init", "--quiet");
+		git("config", "user.email", "test@example.com");
+		git("config", "user.name", "test");
+		fs.writeFileSync(
+			path.join(outer, "package-lock.json"),
+			`${JSON.stringify(lockWith(PREVIOUS), null, 2)}\n`,
+		);
+		git("add", "-A");
+		git("commit", "--quiet", "-m", "outer");
+
+		const nested = path.join(outer, "peerbit-bootstrap");
+		fs.mkdirSync(nested);
+		fs.writeFileSync(
+			path.join(nested, "package-lock.json"),
+			`${JSON.stringify(lockWith(CURRENT), null, 2)}\n`,
+		);
+
+		await assert.rejects(
+			waitForRegistryTarballs({
+				bootstrapRoot: nested,
+				releasedVersion: RELEASED_VERSION,
+				attempts: 1,
+				probe: async () => ({ ok: true, detail: "HTTP 200" }),
+			}),
+			/Could not read HEAD:package-lock\.json/,
+		);
+	} finally {
+		fs.rmSync(outer, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What broke

Post Release Automation [run 31805881609](https://github.com/dao-xyz/peerbit/actions/runs/31805881609) failed in `Validate generated rollout`:

```
npm error 404 Not Found - GET https://registry.npmjs.org/peerbit/-/peerbit-5.3.24.tgz
```

Release had published that version ~16 minutes earlier. The same URL serves 200 now (`curl -o /dev/null -w '%{http_code}'` → `200`, 57508 bytes). Nothing was missing — the job raced registry propagation.

## Why it is worth fixing properly

That step is gated on `steps.server.outputs.changed == 'true'`, so it only runs when `@peerbit/server` gets a new version. Across the **last 60** post-release runs it executed **twice** and failed **once**:

```
EXECUTED: 31805881609 -> failure
EXECUTED: 31495723432 -> success
executed=2  skipped/absent=58
```

A rare step that fails half the time it does real work is worse than a common one that fails rarely: there is no repetition to make the flakiness obvious, so each occurrence reads as a genuine broken publish and burns an investigation. That is what it cost this morning.

## The guard has to probe the tarball, not the metadata

`tools/sync-bootstrap-rollout.mjs` runs `npm install --package-lock-only` and then requires a canonical `sha512-` on every pinned entry (`assertIntegrity`). npm can only write that integrity by reading `dist.integrity` out of the registry packument.

So the packument for `peerbit@5.3.24` was **already live and correct** when the blob 404'd. A metadata poll — `npm view <pkg>@<version> version`, a packument GET — would have returned instantly and the 404 would have happened anyway. That is a guard naming a property it does not check, which is the class this repo has been removing. The probe hits the same artifact `npm ci` fetches, sends no cache-busting headers, and follows redirects, so it observes what npm will observe, edge cache included.

## Which URLs get probed

The released version is `@peerbit/server` 8.x. The tarball that 404'd was `peerbit` 5.x — a transitive dependency published by the same release run, on a different version line. **Version-equality alone would not have probed it.**

The target set is the union of:
- entries present in the generated lockfile but absent from the committed one (freshly pinned), and
- entries pinned at the released version.

Both halves are load-bearing, and there is a test for exactly that asymmetry.

## Two failure modes closed rather than assumed

**Fail-open on a missing lockfile.** Without the committed lockfile there is no freshly-pinned set, so selection silently reduces to version-equality — dropping `peerbit@5.3.99` while still selecting the server entry, so `targets.size > 0` still passes and the wait goes green having skipped the one URL it exists for. It now refuses instead of warning. Not reachable through `actions/checkout` today, but a new fail-open guard is the exact defect this PR is about.

**Borrowing the wrong repository.** `git -C <root>` walks *up* when `<root>` has no `.git`. The bootstrap checkout is nested inside the peerbit checkout, so a missing `.git` would answer with peerbit's own lockfile and produce a meaningless "freshly pinned" set. The toplevel is now pinned to `<root>`.

## Shape

The wait is its own step with `timeout-minutes: 12` (worst case is 8m15s of backoff), so a propagation stall is visually distinct in the Actions UI from a real rollout failure. On timeout it asks the registry whether the version is published at all and says which of the two it is:

```
N tarball(s) are published but still not downloadable after 20 attempts -- registry propagation timed out. Re-run this job.
```
vs
```
N of M unfetchable tarball(s) are genuinely missing from the registry -- this is not a propagation delay, the release did not publish them.
```

## Verification

7 new tests, all mutation-verified — restoring the fail-open turns 3 red, dropping the toplevel pin turns exactly 1 red, and the restored file is 7/7:

```
M1: restore the fail-open (drop both ensures) -> pass 4  fail 3
M3: keep ensures, drop only the toplevel pin  -> pass 6  fail 1
restored                                      -> pass 7  fail 0
```

The CI step is globbed (`tools/*.spec.mjs`) rather than enumerated, so a spec added under `tools/` cannot sit unrun. If the glob ever matches nothing, bash passes it through literally and `node --test` fails loudly rather than reporting a green run of zero files.

Also green, with exit statuses captured directly rather than through a pipe: `prettier --check`, `eslint`, `node scripts/test-release-security-contracts.mjs`, `node --test tools/*.spec.mjs` (14 pass), and both workflow files parse under `yaml.safe_load`.

No changeset: `.github/**` and `tools/**` are tool-config paths under `scripts/ci/check-changeset-required.mjs`.
