### PR TITLE
chore: store the remaining changelogs in the canonical changesets form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 1.0.0 (2023-06-07)
 
-
 ### Bug Fixes
 
-* bootstrap sha ([5174b73](https://github.com/dao-xyz/peerbit/commit/5174b73a34ec0f054f2c9a877fb445b96c120524))
-* rev skip labeling ([44b11a8](https://github.com/dao-xyz/peerbit/commit/44b11a875b60d6ace60b4345ee9440ee14d3ae79))
-* test-release ([a22252e](https://github.com/dao-xyz/peerbit/commit/a22252e5fb843d2186f6009722ab92cb977ef695))
+- bootstrap sha ([5174b73](https://github.com/dao-xyz/peerbit/commit/5174b73a34ec0f054f2c9a877fb445b96c120524))
+- rev skip labeling ([44b11a8](https://github.com/dao-xyz/peerbit/commit/44b11a875b60d6ace60b4345ee9440ee14d3ae79))
+- test-release ([a22252e](https://github.com/dao-xyz/peerbit/commit/a22252e5fb843d2186f6009722ab92cb977ef695))

--- a/packages/clients/canonical/transport/CHANGELOG.md
+++ b/packages/clients/canonical/transport/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.0.0 (2026-01-17)
 
-
 ### Features
 
-* **canonical:** add proxy packages and e2e suites ([ad5b802](https://github.com/dao-xyz/peerbit/commit/ad5b802fd57546cc1757852d449e7616e32ff097))
+- **canonical:** add proxy packages and e2e suites ([ad5b802](https://github.com/dao-xyz/peerbit/commit/ad5b802fd57546cc1757852d449e7616e32ff097))

--- a/packages/utils/build-assets/CHANGELOG.md
+++ b/packages/utils/build-assets/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## [1.1.0](https://github.com/dao-xyz/peerbit/compare/build-assets-v1.0.0...build-assets-v1.1.0) (2025-11-25)
 
-
 ### Features
 
-* migrate to borsh 6 and Typescript Stage 3 decorators ([86caba4](https://github.com/dao-xyz/peerbit/commit/86caba4f2128d3b1e2d274bea1b537722b5ec1c7))
-* unify asset bundling into dist/assets for asset generating packages ([5d6612c](https://github.com/dao-xyz/peerbit/commit/5d6612c726f5eebbf5e05cc082a1fca16831e9e2))
+- migrate to borsh 6 and Typescript Stage 3 decorators ([86caba4](https://github.com/dao-xyz/peerbit/commit/86caba4f2128d3b1e2d274bea1b537722b5ec1c7))
+- unify asset bundling into dist/assets for asset generating packages ([5d6612c](https://github.com/dao-xyz/peerbit/commit/5d6612c726f5eebbf5e05cc082a1fca16831e9e2))
 
 ## 1.0.0 (2025-10-03)
 
-
 ### Bug Fixes
 
-* add build-assets package ([2d246b7](https://github.com/dao-xyz/peerbit/commit/2d246b7eae57192f7675b96a20ed382dd7171c80))
+- add build-assets package ([2d246b7](https://github.com/dao-xyz/peerbit/commit/2d246b7eae57192f7675b96a20ed382dd7171c80))

--- a/packages/utils/rateless-iblt/CHANGELOG.md
+++ b/packages/utils/rateless-iblt/CHANGELOG.md
@@ -2,84 +2,72 @@
 
 ## [1.2.0](https://github.com/dao-xyz/peerbit/compare/riblt-v1.1.0...riblt-v1.2.0) (2026-01-17)
 
-
 ### Features
 
-* **canonical:** add proxy packages and e2e suites ([ad5b802](https://github.com/dao-xyz/peerbit/commit/ad5b802fd57546cc1757852d449e7616e32ff097))
+- **canonical:** add proxy packages and e2e suites ([ad5b802](https://github.com/dao-xyz/peerbit/commit/ad5b802fd57546cc1757852d449e7616e32ff097))
 
 ## [1.1.0](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.8...riblt-v1.1.0) (2025-11-25)
 
-
 ### Features
 
-* unify asset bundling into dist/assets for asset generating packages ([5d6612c](https://github.com/dao-xyz/peerbit/commit/5d6612c726f5eebbf5e05cc082a1fca16831e9e2))
+- unify asset bundling into dist/assets for asset generating packages ([5d6612c](https://github.com/dao-xyz/peerbit/commit/5d6612c726f5eebbf5e05cc082a1fca16831e9e2))
 
 ## [1.0.8](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.7...riblt-v1.0.8) (2025-10-03)
 
-
 ### Bug Fixes
 
-* pnpm package manager ([a6e95de](https://github.com/dao-xyz/peerbit/commit/a6e95de9a4fb418acd73f68639bec66fe6747856))
+- pnpm package manager ([a6e95de](https://github.com/dao-xyz/peerbit/commit/a6e95de9a4fb418acd73f68639bec66fe6747856))
 
 ## [1.0.7](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.6...riblt-v1.0.7) (2025-09-24)
 
-
 ### Bug Fixes
 
-* update deps ([6d9be00](https://github.com/dao-xyz/peerbit/commit/6d9be00c82fdb2bc0d4477cbfa49b40213c86e17))
+- update deps ([6d9be00](https://github.com/dao-xyz/peerbit/commit/6d9be00c82fdb2bc0d4477cbfa49b40213c86e17))
 
 ## [1.0.6](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.5...riblt-v1.0.6) (2025-02-20)
 
-
 ### Bug Fixes
 
-* add sideEffects declaration for wasm init ([e5392af](https://github.com/dao-xyz/peerbit/commit/e5392af070375f001eb82d9bc13b7bfa5c885c07))
+- add sideEffects declaration for wasm init ([e5392af](https://github.com/dao-xyz/peerbit/commit/e5392af070375f001eb82d9bc13b7bfa5c885c07))
 
 ## [1.0.5](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.4...riblt-v1.0.5) (2025-02-20)
 
-
 ### Bug Fixes
 
-* await init in browser ([182ba4d](https://github.com/dao-xyz/peerbit/commit/182ba4dedabd4a32d4af6a46763892581adfd6d0))
+- await init in browser ([182ba4d](https://github.com/dao-xyz/peerbit/commit/182ba4dedabd4a32d4af6a46763892581adfd6d0))
 
 ## [1.0.4](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.3...riblt-v1.0.4) (2024-12-30)
 
-
 ### Bug Fixes
 
-* copy js after rust build ([f5c8aec](https://github.com/dao-xyz/peerbit/commit/f5c8aece92d30a74b57f604a4526066e47b8feb0))
-* init non-browser wasm module by default ([8abb258](https://github.com/dao-xyz/peerbit/commit/8abb2588613c378f7f78112f7ddab4bf8d3a8815))
-* init wasm correctly for module bundling ([90e5ecc](https://github.com/dao-xyz/peerbit/commit/90e5ecc7fdf974cf6990a8b09539501b69a7215b))
+- copy js after rust build ([f5c8aec](https://github.com/dao-xyz/peerbit/commit/f5c8aece92d30a74b57f604a4526066e47b8feb0))
+- init non-browser wasm module by default ([8abb258](https://github.com/dao-xyz/peerbit/commit/8abb2588613c378f7f78112f7ddab4bf8d3a8815))
+- init wasm correctly for module bundling ([90e5ecc](https://github.com/dao-xyz/peerbit/commit/90e5ecc7fdf974cf6990a8b09539501b69a7215b))
 
 ## [1.0.3](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.2...riblt-v1.0.3) (2024-12-28)
 
-
 ### Bug Fixes
 
-* rm .gitignore from dist folder ([91f517a](https://github.com/dao-xyz/peerbit/commit/91f517a5c64a52af3c6dd6188f34fd8971d1b623))
+- rm .gitignore from dist folder ([91f517a](https://github.com/dao-xyz/peerbit/commit/91f517a5c64a52af3c6dd6188f34fd8971d1b623))
 
 ## [1.0.2](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.1...riblt-v1.0.2) (2024-12-28)
 
-
 ### Bug Fixes
 
-* build into dist instead of pkg ([10f303c](https://github.com/dao-xyz/peerbit/commit/10f303c46fd4a7dea48820b931c16e9cae74a143))
+- build into dist instead of pkg ([10f303c](https://github.com/dao-xyz/peerbit/commit/10f303c46fd4a7dea48820b931c16e9cae74a143))
 
 ## [1.0.1](https://github.com/dao-xyz/peerbit/compare/riblt-v1.0.0...riblt-v1.0.1) (2024-12-28)
 
-
 ### Bug Fixes
 
-* include dist ([c36cb9c](https://github.com/dao-xyz/peerbit/commit/c36cb9cc21fb23b32088fa54bc2dc7b947e0242b))
+- include dist ([c36cb9c](https://github.com/dao-xyz/peerbit/commit/c36cb9cc21fb23b32088fa54bc2dc7b947e0242b))
 
 ## 1.0.0 (2024-12-28)
 
-
 ### Features
 
-* add rateless-iblt ([5aca96b](https://github.com/dao-xyz/peerbit/commit/5aca96b43e0109b62608b69acbe2daf44f43dbb7))
-
+- add rateless-iblt ([5aca96b](https://github.com/dao-xyz/peerbit/commit/5aca96b43e0109b62608b69acbe2daf44f43dbb7))
 
 ### Bug Fixes
 
-* don't override global fetch ([0c15e34](https://github.com/dao-xyz/peerbit/commit/0c15e34a1bafabf2fe6a94ae8ec43c9f12367b8c))
+- don't override global fetch ([0c15e34](https://github.com/dao-xyz/peerbit/commit/0c15e34a1bafabf2fe6a94ae8ec43c9f12367b8c))


### PR DESCRIPTION
## Why

On a package's first changesets release, changesets rewrites that package's `CHANGELOG.md` into its own format. When the stored file is still in the release-please format this repo migrated away from, that rewrite lands as a large unrelated reformatting diff — which is what blocked `@peerbit/logger` until `0ae92f9e9` normalized it ahead of time.

Four files were still in the old format (`* ` bullets, double blank line after each version heading) against 48 already canonical. Three are publishable and would each hit this on their next release:

- `@peerbit/canonical-transport`
- `@peerbit/build-assets`
- `@peerbit/riblt`

Doing it now costs a mechanical diff. Doing it later costs a blocked release, one package at a time.

## The fourth file

`CHANGELOG.md` at the repository root is included, and it is genuinely inert — the root package is `{"name":"org","private":true}` and `.` is not listed in `workspaces`, so changesets never regenerates it.

It is here because it was the last file keeping the tree from being uniformly canonical. With it converted:

```
prettier --check '**/CHANGELOG.md'
All matched files use Prettier code style!
```

across all 52. That gives a one-command completeness check in place of a hand sweep — which matters, because the sweep that produced the original "three files" list used `git ls-files '*/CHANGELOG.md'`, and that glob requires a directory prefix, so it silently skipped the root file. Prettier is the right authority here anyway: `@changesets/apply-release-plan` prettier-formats the changelog it writes, so a prettier-clean file is a fixed point of the release process.

## This is a pure reformat

Only bullet markers and blank-line runs change. Every heading, version, date, URL, commit hash and bullet text is preserved byte for byte.

Verified per file by diffing against the committed revision with bullet markers stripped and blank runs collapsed — all four identical:

```
✓ CHANGELOG.md
✓ packages/clients/canonical/transport/CHANGELOG.md
✓ packages/utils/build-assets/CHANGELOG.md
✓ packages/utils/rateless-iblt/CHANGELOG.md
```

None of the four contains a code fence or a non-bullet leading `*` (no `***` rules, no emphasis at line start), so nothing outside a list marker was touched — checked by filtering the diff for changed lines that are not bullet conversions, which returns empty.

No changeset: `.md` files are not runtime files under `scripts/ci/check-changeset-required.mjs`, and the reference commit `0ae92f9e9` shipped the same way.
