### PR TITLE
ci: measure the benchmark noise floor with an A/A job

### DIFF
--- a/.github/workflows/benchmark-noise-floor.yml
+++ b/.github/workflows/benchmark-noise-floor.yml
@@ -1,0 +1,536 @@
+name: Benchmark noise floor
+# Runs ONE commit's benchmark suites N times so the per-task "delta mean %"
+# that .github/workflows/benchmarks.yml prints for base vs head can be judged
+# against a measured floor. A delta smaller than the floor is not evidence.
+#
+# Deliberate scope limit: install and build happen ONCE and every repeat reuses
+# that single build, so this measures RUN-TO-RUN noise on a fixed build. It
+# therefore EXCLUDES build-to-build variance (dependency resolution, codegen and
+# layout differences, wasm artifacts), which the A/B job DOES include because it
+# installs and builds base and head separately. The floor produced here is a
+# LOWER bound on the noise in a benchmarks.yml comparison, never an upper bound.
+#
+# Every action pin, toolchain step, env block, working directory and benchmark
+# invocation below is copied from benchmarks.yml. That fidelity is the point: a
+# floor measured with a different toolchain, or with different suite parameters,
+# does not apply to that job's numbers.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref (branch, tag or SHA) to measure repeatedly
+        required: false
+        default: master
+        type: string
+      repeats:
+        description: How many times to run the suites on the one build (2-10)
+        required: false
+        default: "4"
+        type: string
+      suites:
+        description: >-
+          Comma-separated subset of shared-log, transport, document - the same
+          three suite groups benchmarks.yml selects from a PR's changed files.
+        required: false
+        default: shared-log,transport,document
+        type: string
+
+permissions: {}
+
+jobs:
+  noise-floor:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    # BUDGET. An earlier version of this comment claimed "<= 12 min" for
+    # sync-batch-sweep on the strength of SWEEP_TIMEOUT. That was wrong, and the
+    # whole 25 min/repeat figure derived from it was wrong with it. What that
+    # timeout actually covers, from benchmark/sync-batch-sweep.ts:
+    #
+    #   BOUNDED by SWEEP_TIMEOUT (120000 ms): the catch-up wait only -- the
+    #     waitForResolved that watches db2's log length. Nothing else reads it.
+    #   NOT BOUNDED by anything: the ts-node child startup and type-load, the
+    #     two-peer session open, the SWEEP_ENTRY_COUNT (20000) sequential
+    #     db1.add() preload that runs BEFORE the timed section, the dial, and
+    #     the drop/stop teardown. One such child is spawned per batch size, so
+    #     all of that happens 6 times.
+    #
+    # So SWEEP_TIMEOUT funds 6 x 2 = 12 min of *bounded* wait and says nothing
+    # about the rest. Per-repeat allowance, stated as an allowance and not as an
+    # upper bound, because only the first line of each pair is actually enforced:
+    #
+    #   sync-batch-sweep  6 x (2 min bounded wait
+    #                          + 5 min unbounded: ~1 min child start,
+    #                            ~3 min for 20000 offline appends,
+    #                            ~1 min open/dial/teardown)        =  42 min
+    #   file-ingest       (FILE_INGEST_WARMUP 1 + ITERATIONS 3) x
+    #                     FILE_INGEST_READY_TIMEOUT_MS 30000 ms = 2 min bounded,
+    #                     + 2 min unbounded setup/teardown        =   4 min
+    #   chunk-transfer    (CHUNK_TRANSFER_WARMUP 1 + ITERATIONS 3) x
+    #                     CHUNK_TRANSFER_TIMEOUT_MS 30000 ms = 2 min bounded,
+    #                     + 2 min unbounded setup/teardown        =   4 min
+    #   rateless-iblt-startsync-cache, rateless-iblt-sender-startsync,
+    #                     pid-convergence and document-put carry NO timeout at
+    #                     all. benchmarks.yml fits two passes of them, plus two
+    #                     installs and two builds, inside its own 120 min, so
+    #                     9 min per pass is a generous allowance   =   9 min
+    #                                                               -------
+    #                                                                 59 min
+    #
+    # Round to 60 min per repeat. Install + wasm-pack + build run ONCE: 45 min,
+    # on the same reasoning as before (benchmarks.yml funds two of them inside
+    # 120 min alongside its sweeps).
+    #
+    #   default repeats 5  -> 45 + 5 x 60  = 345 min   fits
+    #   maximum repeats 10 -> 45 + 10 x 60 = 645 min   does NOT fit, and cannot:
+    #                                                  GitHub-hosted jobs are
+    #                                                  killed at 6 h regardless
+    #                                                  of this setting.
+    #
+    # 350 is therefore the honest number: it is under the platform ceiling, so
+    # WE cut the job off rather than the platform, and the "Report noise floor"
+    # step below runs on failure and publishes a partial floor from the repeats
+    # that did finish. A partial floor is passed --min-runs = repeats, so it
+    # comes out NOT TRUSTWORTHY and non-zero; it can inform the next dispatch
+    # but it can never be quoted as a floor. High repeat counts are expected to
+    # land there, and that is a better outcome than silence after 6 h.
+    timeout-minutes: 350
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    concurrency:
+      # Serialize per measured ref, but never cancel: a floor run is hours of
+      # measurement, and a second dispatch should queue behind it rather than
+      # destroy it. (benchmarks.yml cancels because a superseded PR benchmark is
+      # worthless; a completed floor is not.)
+      group: bench-noise-floor-${{ inputs.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Resolve run plan
+        id: plan
+        env:
+          RAW_REPEATS: ${{ inputs.repeats }}
+          RAW_SUITES: ${{ inputs.suites }}
+        run: |
+          set -euo pipefail
+          # Both values are dispatcher-controlled text. They are read from the
+          # environment rather than interpolated into this script, and they only
+          # reach $GITHUB_OUTPUT after matching a strict pattern. REPEATS in
+          # particular is later used in an arithmetic for-loop, where unvalidated
+          # text would be evaluated, not just compared.
+          repeats="${RAW_REPEATS//[[:space:]]/}"
+          if [[ ! "$repeats" =~ ^([2-9]|10)$ ]]; then
+            echo "::error::repeats must be an integer between 2 and 10; got '${RAW_REPEATS}'. One run measures nothing, and the timeout budget is sized for at most 10."
+            exit 1
+          fi
+
+          # Fail closed on an empty selection. benchmarks.yml tolerates "no
+          # suites" because a PR may legitimately touch none of them; here the
+          # operator asked for a measurement, so producing no runs at all would
+          # be a green job with an empty report. This has to be checked BEFORE
+          # the split: `read -a` returns non-zero on an empty here-string, so
+          # under `set -e` an empty value would otherwise abort this step with no
+          # diagnostic at all.
+          normalized="${RAW_SUITES//[[:space:]]/}"
+          if [ -z "$normalized" ]; then
+            echo "::error::suites must name at least one of shared-log, transport, document."
+            exit 1
+          fi
+
+          run_shared_log=false
+          run_transport=false
+          run_document=false
+
+          IFS=',' read -r -a requested <<< "$normalized"
+          for suite in "${requested[@]}"; do
+            case "$suite" in
+              shared-log) run_shared_log=true ;;
+              transport) run_transport=true ;;
+              document) run_document=true ;;
+              "")
+                echo "::error::suites has an empty entry; it must be a comma-separated subset of shared-log, transport, document."
+                exit 1
+                ;;
+              *)
+                echo "::error::unknown suite '${suite}'; suites must be a comma-separated subset of shared-log, transport, document."
+                exit 1
+                ;;
+            esac
+          done
+
+          # Rebuilt from the flags, so a repeated suite name cannot duplicate an
+          # entry here. Same order and spelling as benchmarks.yml's "selected".
+          selected=""
+          if [ "$run_shared_log" = true ]; then
+            selected="shared-log"
+          fi
+          if [ "$run_transport" = true ]; then
+            selected="${selected:+${selected},}transport"
+          fi
+          if [ "$run_document" = true ]; then
+            selected="${selected:+${selected},}document"
+          fi
+
+          {
+            echo "repeats=${repeats}"
+            echo "run_shared_log=${run_shared_log}"
+            echo "run_transport=${run_transport}"
+            echo "run_document=${run_document}"
+            echo "selected=${selected}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Measuring ${selected} ${repeats} times."
+
+      # This job executes whatever code lives at "ref". It holds no secrets and
+      # only read access to contents, and it publishes nothing back to GitHub:
+      # the artifact and the step summary are its entire output.
+      - name: Checkout ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      # Runs on the pinned Node, and early enough that a failure anywhere below
+      # still leaves an attributable artifact. The artifact upload is gated on
+      # this step, so a rejected dispatch input fails once rather than twice.
+      - name: Record run metadata
+        id: metadata
+        env:
+          NOISE_FLOOR_REF: ${{ inputs.ref }}
+          NOISE_FLOOR_REPEATS: ${{ steps.plan.outputs.repeats }}
+          NOISE_FLOOR_SELECTED: ${{ steps.plan.outputs.selected }}
+        run: |
+          set -euo pipefail
+          mkdir -p bench-results
+          # bench-results/ is the results-dir handed to scripts/bench/noise-floor.mjs.
+          # Non-run entries are expected there: the script's own default report
+          # path is <results-dir>/noise-floor.json.
+          NOISE_FLOOR_SHA="$(git rev-parse HEAD)" node --input-type=module -e '
+            import { writeFileSync } from "node:fs";
+
+            const metadata = {
+              kind: "benchmark-noise-floor",
+              note: "One commit, one build, repeated runs. Measures run-to-run noise only; build-to-build variance is excluded here but present in the A/B benchmarks job.",
+              ref: process.env.NOISE_FLOOR_REF,
+              sha: process.env.NOISE_FLOOR_SHA,
+              repeats: Number(process.env.NOISE_FLOOR_REPEATS),
+              selected_suites: process.env.NOISE_FLOOR_SELECTED.split(","),
+              run_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            };
+
+            writeFileSync(
+              "bench-results/metadata.json",
+              JSON.stringify(metadata, null, 2) + "\n",
+            );
+          '
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 10.24.0
+          run_install: false
+
+      # Copied verbatim from benchmarks.yml, including the version pin and the
+      # target pre-install. No caching anywhere in this job: benchmarks.yml
+      # caches nothing either, and a restore-keys-style cache could serve one
+      # ref's compiled output to another ref's measurement, which would corrupt
+      # the very quantity this job exists to measure.
+      - name: Install wasm-pack
+        run: |
+          cargo install wasm-pack --version '=0.13.1' --locked
+          # Pre-install the wasm target once: concurrent wasm-pack builds
+          # otherwise race their own `rustup target add` and fail on a
+          # component conflict (observed in run 30832179916).
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile=false
+
+      # Built once, on purpose. Every repeat below measures this exact build, so
+      # the resulting floor contains no build-to-build variance.
+      - name: Build
+        env:
+          RUN_SHARED_LOG: ${{ steps.plan.outputs.run_shared_log }}
+          RUN_TRANSPORT: ${{ steps.plan.outputs.run_transport }}
+          RUN_DOCUMENT: ${{ steps.plan.outputs.run_document }}
+        run: |
+          set -euo pipefail
+          if [ "$RUN_SHARED_LOG" = "true" ]; then
+            pnpm --filter @peerbit/shared-log... run build
+          fi
+          if [ "$RUN_TRANSPORT" = "true" ]; then
+            pnpm --filter @peerbit/stream... run build
+          fi
+          if [ "$RUN_DOCUMENT" = "true" ]; then
+            pnpm --filter @peerbit/document... run build
+          fi
+
+      # benchmarks.yml skips a benchmark that is absent from one side, because a
+      # base/head asymmetry is a normal thing for it to tolerate. Here the ref is
+      # fixed, so an absent entrypoint would silently drop that task from every
+      # run and shrink the floor's coverage without saying so. Fail closed, up
+      # front, before spending an hour of runner time.
+      - name: Verify benchmark entrypoints and reporter exist
+        env:
+          RUN_SHARED_LOG: ${{ steps.plan.outputs.run_shared_log }}
+          RUN_TRANSPORT: ${{ steps.plan.outputs.run_transport }}
+          RUN_DOCUMENT: ${{ steps.plan.outputs.run_document }}
+        run: |
+          set -euo pipefail
+          missing=0
+          require_file() {
+            if [ ! -f "$1" ]; then
+              echo "::error::${1} does not exist at this ref."
+              missing=1
+            fi
+          }
+
+          # The report step runs the reporter from the SAME ref that is being
+          # measured. Finding out it is absent after hours of measurement would
+          # waste the entire run.
+          require_file scripts/bench/noise-floor.mjs
+
+          if [ "$RUN_SHARED_LOG" = "true" ]; then
+            require_file packages/programs/data/shared-log/benchmark/rateless-iblt-startsync-cache.ts
+            require_file packages/programs/data/shared-log/benchmark/rateless-iblt-sender-startsync.ts
+            require_file packages/programs/data/shared-log/benchmark/sync-batch-sweep.ts
+            require_file packages/programs/data/shared-log/benchmark/pid-convergence.ts
+          fi
+          if [ "$RUN_DOCUMENT" = "true" ]; then
+            require_file packages/programs/data/document/document/benchmark/document-put.ts
+            require_file packages/programs/data/document/document/benchmark/file-ingest.ts
+          fi
+          if [ "$RUN_TRANSPORT" = "true" ]; then
+            # benchmarks.yml runs the compiled artifact for this one, so this is
+            # also a check that the build above produced it.
+            require_file packages/transport/stream/dist/benchmark/chunk-transfer.js
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::This ref cannot produce a floor (see the errors above). Deselect the affected suite with the 'suites' input, or measure a ref that carries every file this run needs."
+            exit 1
+          fi
+
+      - name: Run benchmark repeats
+        env:
+          REPEATS: ${{ steps.plan.outputs.repeats }}
+          RUN_SHARED_LOG: ${{ steps.plan.outputs.run_shared_log }}
+          RUN_TRANSPORT: ${{ steps.plan.outputs.run_transport }}
+          RUN_DOCUMENT: ${{ steps.plan.outputs.run_document }}
+          # Every value below is copied verbatim from benchmarks.yml's three
+          # per-suite env blocks. The variable names are disjoint across the
+          # suites (RIBLT_*/SWEEP_*, DOC_*/FILE_INGEST_*, CHUNK_TRANSFER_*) and
+          # NODE_OPTIONS/BENCH_JSON are identical in all three, so this single
+          # merged block hands each benchmark exactly the environment the A/B job
+          # hands it.
+          NODE_OPTIONS: --no-warnings
+          BENCH_JSON: "1"
+          RIBLT_SIZES: "1000,10000,50000"
+          RIBLT_WARMUP: "2"
+          RIBLT_ITERATIONS: "10"
+          SWEEP_BATCH_SIZES: "256,512,1024,4096,16384,65536"
+          SWEEP_ENTRY_COUNT: "20000"
+          SWEEP_WARMUP_RUNS: "0"
+          SWEEP_RUNS: "1"
+          SWEEP_TIMEOUT: "120000"
+          DOC_WARMUP: "2"
+          DOC_ITERATIONS: "10"
+          FILE_INGEST_WARMUP: "1"
+          FILE_INGEST_ITERATIONS: "3"
+          FILE_INGEST_CHUNKS: "24"
+          FILE_INGEST_CHUNK_BYTES: "262144"
+          FILE_INGEST_READY_TIMEOUT_MS: "30000"
+          CHUNK_TRANSFER_WARMUP: "1"
+          CHUNK_TRANSFER_ITERATIONS: "3"
+          CHUNK_TRANSFER_CHUNKS: "24"
+          CHUNK_TRANSFER_CHUNK_BYTES: "262144"
+          CHUNK_TRANSFER_TIMEOUT_MS: "30000"
+        run: |
+          # -e alone is the GitHub default; -o pipefail and -u are added on
+          # purpose. Everything in the loop below is a simple command, so -e
+          # aborts the whole job on the first failing benchmark instead of
+          # marching on to the next repeat with a hole in the results.
+          set -euo pipefail
+
+          shared_log_directory="$GITHUB_WORKSPACE/packages/programs/data/shared-log"
+          document_directory="$GITHUB_WORKSPACE/packages/programs/data/document/document"
+          stream_directory="$GITHUB_WORKSPACE/packages/transport/stream"
+
+          # A benchmark that dies after the shell opened its redirect leaves a
+          # zero-byte or half-written file behind. Counting that as a run would
+          # make the floor look tighter than it is - exactly the failure mode
+          # this job exists to rule out - so every suite file is proved before
+          # the next benchmark starts.
+          # TWO SHAPES, both real, and this assert used to know only one of
+          # them. Six suites emit tinybench's { tasks: [{ name, mean_ms, hz }] };
+          # document-put.ts emits { name, rows: [{ name, opsPerSecond,
+          # totalPutMs, ... }], meta } and has no `tasks` key at all, so the old
+          # "carries no benchmark tasks" check rejected every valid document-put
+          # run and this job could never have completed with `document` selected.
+          # The field mapping below is the same one
+          # scripts/bench/noise-floor.mjs applies (totalPutMs -> mean_ms,
+          # opsPerSecond -> hz); the two must agree or a file this step accepts
+          # could still be dropped by the reporter.
+          #
+          # NOTE, deliberately not fixed from here: .github/workflows/
+          # benchmarks.yml makes the same `tasks`-only assumption in its A/B
+          # comparison, which is why its "document: put" table renders empty.
+          # That is a separate change to a workflow this one only copies from.
+          assert_suite_json() {
+            SUITE_JSON_FILE="$1" node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+
+              const file = process.env.SUITE_JSON_FILE;
+              const raw = readFileSync(file, "utf8");
+              if (raw.trim() === "") {
+                throw new Error(`${file} is empty`);
+              }
+
+              const parsed = JSON.parse(raw);
+              const isTasksShape = Array.isArray(parsed.tasks);
+              const rows = isTasksShape
+                ? parsed.tasks
+                : Array.isArray(parsed.rows)
+                  ? parsed.rows
+                  : null;
+              if (rows === null || rows.length === 0) {
+                throw new Error(
+                  `${file} carries neither a non-empty "tasks" array nor a non-empty "rows" array`,
+                );
+              }
+
+              // Only the fields the noise-floor reporter actually consumes are
+              // required. A half-written file loses them, which is the exact
+              // truncation this assert exists to catch.
+              const durationField = isTasksShape ? "mean_ms" : "totalPutMs";
+              const rateField = isTasksShape ? "hz" : "opsPerSecond";
+              for (const row of rows) {
+                if (typeof row?.name !== "string") {
+                  throw new Error(`${file} carries an entry without a name`);
+                }
+                if (!Number.isFinite(row?.[durationField])) {
+                  throw new Error(
+                    `${file} entry "${row.name}" has no finite ${durationField}`,
+                  );
+                }
+                if (!isTasksShape && !Number.isFinite(row?.[rateField])) {
+                  throw new Error(
+                    `${file} entry "${row.name}" has no finite ${rateField}`,
+                  );
+                }
+              }
+            '
+          }
+
+          # No pipes in either runner. A pipeline reports its LAST command's
+          # status, so `node ... | tee` would hide a failing benchmark even with
+          # -e set, and `$?` after a pipe would be tee's status, not node's.
+          run_ts_benchmark() {
+            local directory="$1"
+            local entrypoint="$2"
+            local destination="$3"
+            ( cd "$directory" && node --loader ts-node/esm "$entrypoint" ) > "$destination"
+            assert_suite_json "$destination"
+          }
+
+          run_js_benchmark() {
+            local directory="$1"
+            local entrypoint="$2"
+            local destination="$3"
+            ( cd "$directory" && node "$entrypoint" ) > "$destination"
+            assert_suite_json "$destination"
+          }
+
+          # REPEATS matched ^([2-9]|10)$ in the plan step, so this arithmetic
+          # context evaluates a number and nothing else.
+          for (( repeat = 1; repeat <= REPEATS; repeat++ )); do
+            destination="$GITHUB_WORKSPACE/bench-results/run-${repeat}"
+            mkdir -p "$destination"
+            echo "::group::Repeat ${repeat} of ${REPEATS}"
+
+            # Suite order inside a repeat matches one side of benchmarks.yml.
+            if [ "$RUN_SHARED_LOG" = "true" ]; then
+              run_ts_benchmark "$shared_log_directory" ./benchmark/rateless-iblt-startsync-cache.ts "$destination/rateless-iblt-startsync-cache.json"
+              run_ts_benchmark "$shared_log_directory" ./benchmark/rateless-iblt-sender-startsync.ts "$destination/rateless-iblt-sender-startsync.json"
+              run_ts_benchmark "$shared_log_directory" ./benchmark/sync-batch-sweep.ts "$destination/sync-batch-sweep.json"
+              run_ts_benchmark "$shared_log_directory" ./benchmark/pid-convergence.ts "$destination/pid-convergence.json"
+            fi
+            if [ "$RUN_DOCUMENT" = "true" ]; then
+              run_ts_benchmark "$document_directory" ./benchmark/document-put.ts "$destination/document-put.json"
+              run_ts_benchmark "$document_directory" ./benchmark/file-ingest.ts "$destination/file-ingest.json"
+            fi
+            if [ "$RUN_TRANSPORT" = "true" ]; then
+              run_js_benchmark "$stream_directory" ./dist/benchmark/chunk-transfer.js "$destination/chunk-transfer.json"
+            fi
+
+            echo "::endgroup::"
+          done
+
+      - name: Report noise floor
+        # always(), not the default success(). The measurement step above can
+        # burn hours and then die -- a hung suite, or this job's own
+        # timeout-minutes -- and under success() that published NOTHING: no
+        # summary, no per-task numbers, no way to tell which repeat it got to. A
+        # partial floor is strictly more useful than silence, and it cannot be
+        # mistaken for a real one: --min-runs is the requested repeat count, so
+        # fewer completed repeats is a blocking `insufficient-runs` and the
+        # report says NOT TRUSTWORTHY and exits non-zero. Gated on metadata for
+        # the same reason the upload is: a rejected dispatch input should fail
+        # once, on the validation step, not again here.
+        if: always() && steps.metadata.conclusion == 'success'
+        env:
+          REPEATS: ${{ steps.plan.outputs.repeats }}
+        run: |
+          set -euo pipefail
+
+          # How far the measurement actually got. Counted from the directories on
+          # disk rather than from the previous step's status, so a partial result
+          # is labelled with a number instead of an adjective.
+          completed=0
+          for candidate in bench-results/run-*/; do
+            if [ -d "$candidate" ]; then
+              completed=$(( completed + 1 ))
+            fi
+          done
+
+          banner=""
+          if [ "$completed" -lt "$REPEATS" ]; then
+            banner="> [!CAUTION]\n> **PARTIAL RUN.** ${completed} of ${REPEATS} requested repeat(s) produced a run directory; the measurement step did not finish. Everything below is computed from those ${completed} repeat(s) only. It is reported as NOT TRUSTWORTHY on purpose and must not be quoted as a noise floor -- a floor from a truncated, non-random subset of runs reads LOW, and a low floor makes every perf claim look significant. Re-dispatch, or lower 'repeats', to get a quotable number.\n"
+            echo "::warning::Partial noise-floor run: ${completed}/${REPEATS} repeats completed. Publishing a partial, explicitly untrustworthy report."
+          fi
+
+          # Deliberately not `node ... | tee "$GITHUB_STEP_SUMMARY"`: a
+          # pipeline's status is the LAST command's, so tee would report success
+          # for a script that judged the floor untrustworthy and exited non-zero.
+          # Capture the status directly, publish the report either way, then
+          # re-raise it.
+          status=0
+          node scripts/bench/noise-floor.mjs bench-results --min-runs "$REPEATS" > noise-floor-body.md || status=$?
+          {
+            if [ -n "$banner" ]; then
+              printf '%b\n' "$banner"
+            fi
+            cat noise-floor-body.md
+          } > noise-floor-report.md
+          rm -f noise-floor-body.md
+
+          cat noise-floor-report.md
+          cat noise-floor-report.md >> "$GITHUB_STEP_SUMMARY"
+          cp noise-floor-report.md bench-results/noise-floor-report.md
+          exit "$status"
+
+      - name: Upload noise-floor results
+        # Gated on the metadata step so a rejected dispatch input fails once, on
+        # the validation step, instead of failing again on a missing directory.
+        if: always() && steps.metadata.conclusion == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-noise-floor-${{ github.run_id }}-${{ github.run_attempt }}
+          path: bench-results
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: Validate release automation tools
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: node --test tools/*.spec.mjs
+      # Same rule for scripts/bench/. The noise-floor reporter's whole job is to
+      # refuse to publish an understated number, so an unrun spec would defeat it
+      # silently -- exactly the failure it exists to catch.
+      - name: Validate benchmark analysis scripts
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
+        run: node --test scripts/bench/*.spec.mjs
       - name: Validate the supabase edge functions
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |

--- a/scripts/bench/noise-floor.mjs
+++ b/scripts/bench/noise-floor.mjs
@@ -1,0 +1,1204 @@
+// Turns "how big does a benchmark delta have to be before it means anything?"
+// into a measured number.
+//
+// .github/workflows/benchmarks.yml checks out a PR's base and head onto one
+// runner, runs the same suites twice, and prints a per-task "Δ mean %". Nothing
+// in that report says how large a Δ has to be to be a signal. Folklore from
+// earlier sessions: base-vs-base of *identical* code moved by ±10%, and
+// requestMaybeSyncTotal swung 30-70% between identical runs. This script
+// consumes N repeats of the SAME commit (an A/A experiment) and reports, per
+// (suite, task, metric), the distribution of |Δ| that identical code produces.
+//
+// Usage:
+//   node scripts/bench/noise-floor.mjs <results-dir> [--min-runs <n>] [--json-out <path>]
+//
+// <results-dir> holds run-1/ ... run-N/, each containing the suite JSON files
+// benchmarks.yml already writes (same names).
+//
+// TWO SUITE SHAPES, BOTH REAL. Six of the seven suites emit tinybench's
+// { tasks: [{ name, mean_ms, hz, ... }] }. document-put.json does NOT: it emits
+// { name, rows: [{ name, iterations, payloadBytes, opsPerSecond, cleanupMs,
+// ...profile fields..., totalPutMs }], meta } -- see
+// packages/programs/data/document/document/benchmark/document-put.ts, which
+// builds a BenchRow per scenario and writes `rows`, never `tasks`. Assuming the
+// tasks shape made this script drop the whole document suite; see
+// readSuiteFile for the normalisation and for why the mapping is what it is.
+//
+// (NOTE for a later change, deliberately NOT fixed here: .github/workflows/
+// benchmarks.yml makes the same wrong assumption in its A/B report, which is
+// why its "document: put" table has been rendering empty. Out of scope for this
+// file.)
+//
+// THE HEADLINE STATISTIC. For each (suite, task, metric) we take all C(N,2)
+// unordered pairs of runs and report median / p95 / max of
+//
+//   |Δ%| = |a - b| / min(a, b) * 100
+//
+// and the HEADLINE -- the number a reader is meant to quote, and the one the
+// decision rule points at -- is the observed MAXIMUM, not the p95. Three
+// reasons, all the same reason:
+//
+//   * Understating the floor is the catastrophic direction. It makes every
+//     perf claim look significant. The max is the only one of the three that
+//     can never understate the spread that was actually observed.
+//   * The max is monotone in the number of runs. Pairs from N+1 runs are a
+//     superset of the pairs from N, so adding runs can only reveal more tail.
+//     p95 is NOT monotone here: nearest-rank p95 over C(N,2) pairs equals the
+//     maximum for N <= 6 and then steps down to the second-largest at N = 7
+//     (21 pairs), so raising `repeats` from 5 to 7 could HALVE the published
+//     number on unchanged data and delete the caveat with it.
+//   * "More measurement made the floor smaller" is precisely the incentive a
+//     tool like this must not create.
+//
+// p95 is still reported, as a clearly secondary column, always labelled with
+// the actual pair count. It is never presented as authoritative.
+//
+// Two deliberate choices there:
+//
+//   * Unordered pairs, not "run-1 as the base". benchmarks.yml happens to
+//     divide by the base run, but in an A/A experiment either run could have
+//     been the base, so the pair has two possible readings. Dividing by
+//     min(a, b) reports the larger of the two. A noise floor that reads low is
+//     the dangerous direction -- it makes every perf claim look significant --
+//     so every rounding decision in this file leans high.
+//
+//   * min(a, b) also makes the floor invariant under the reciprocal, so a task
+//     yields the identical |Δ%| whether you look at mean_ms or at
+//     hz = 1000/mean_ms. (Dividing by the base does not: that is why Δ mean and
+//     Δ ops/s in benchmarks.yml never quite mirror each other.) Both metrics
+//     are still reported, because the *dispersion* statistics -- stddev and
+//     coefficient of variation -- are not reciprocal-invariant, and a task can
+//     look stable in one metric and not the other.
+//
+// p95 uses nearest-rank, no interpolation: interpolation would pull the value
+// below an observed sample. Whether nearest-rank p95 is even distinguishable
+// from the maximum is derived, not guessed: it equals the maximum exactly when
+// ceil(0.95 * pairs) === pairs, which the report states alongside the pair
+// count instead of hard-coding a threshold. stddev is the sample (n-1) form for
+// the same reason -- it is the larger of the two conventions.
+//
+// WHY THIS FILE IS SO SUSPICIOUS OF ITS OWN INPUT. A floor computed from too
+// few samples, or from the runs that happened to survive, is a *small* number,
+// and a small floor silently blesses every subsequent perf claim. Degrading
+// quietly is worse than not running at all. So the script never averages over
+// whatever it found:
+//
+//   * fewer than --min-runs usable runs   -> blocking, and --min-runs < 2 is
+//                                            refused outright (no spread from
+//                                            one sample)
+//   * a suite present in some runs but    -> blocking. The suites that vanish
+//     missing/corrupt/task-less in others    are the runs where something went
+//                                            wrong, so the survivors are biased
+//                                            toward stability.
+//   * a task present in some runs only    -> blocking, and its n is printed
+//                                            next to its floor either way
+//   * null / NaN / Infinity / <= 0        -> the metric is marked invalid, not
+//                                            averaged over the valid subset. A
+//                                            relative delta against a zero
+//                                            baseline is undefined; emitting
+//                                            Infinity or a 0% "floor" would be
+//                                            a lie in the dangerous direction.
+//   * a floor of exactly 0                -> labelled `no variation resolved`,
+//                                            never `deterministic`. Identical
+//                                            values across runs mean no
+//                                            variation was RESOLVED, which is
+//                                            either a genuinely reproducible
+//                                            benchmark OR real variation below
+//                                            the source's rounding step --
+//                                            document-put emits
+//                                            round(opsPerSecond), 0.05% at 2000
+//                                            ops/s but 4% at 24. The two are
+//                                            indistinguishable from the data, so
+//                                            this file names the observation and
+//                                            refuses to name the cause. A 0%
+//                                            floor must never be used to bless a
+//                                            small A/B delta.
+//
+// A suite that is ABSENT (ENOENT) from every run is only a warning: the
+// noise-floor job deliberately selects a subset of suites, and a file that was
+// never written cannot be a collection failure. It is still printed in the
+// header ("Suites collected: k/7").
+//
+// A suite that is PRESENT in every run but unreadable in every run is a
+// different animal and is BLOCKING. This is the fail-open this script exists to
+// prevent: the summary aggregates only the tasks it managed to measure, so a
+// systematically broken suite quietly leaves the denominator and takes its
+// noisiest task with it. Measured on a real fixture, one suite broken in every
+// run moved the headline from 55.56% to 2.02% -- a 27x understatement, printed
+// with trustworthy:true. `readSuiteFile` already distinguishes the two cases
+// ("missing" is ENOENT and nothing else); the verdict now uses that instead of
+// discarding it, and the reason travels into the JSON report so a downstream
+// consumer can tell "we did not ask for this suite" from "this suite broke".
+//
+// The report is always written and always printed, including when it is
+// untrustworthy -- the diagnosis is the useful part. The exit code carries the
+// verdict: 0 trustworthy, 1 report produced but not trustworthy, 2 usage error.
+//
+// Output is a pure function of the input files: no timestamps, no randomness,
+// every list explicitly sorted.
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const USAGE =
+	"Usage: node scripts/bench/noise-floor.mjs <results-dir> [--min-runs <n>] [--json-out <path>]";
+
+const DEFAULT_MIN_RUNS = 3;
+const ABSOLUTE_MIN_RUNS = 2;
+const DEFAULT_REPORT_NAME = "noise-floor.json";
+const P95_FRACTION = 0.95;
+const MAX_LISTED_PROBLEMS = 50;
+const SCHEMA = "peerbit-bench-noise-floor/2";
+const HEADLINE_STATISTIC =
+	"max |Δ%| observed across all unordered run pairs (never the p95: see the header comment)";
+const DECISION_RULE =
+	"An A/B delta on task T is evidence only if it exceeds T's A/A max |Δ%|. Compare against the max column, not the p95 column.";
+
+// Nearest-rank p95 over `pairs` samples picks index ceil(0.95 * pairs); that is
+// the last index exactly when ceil(0.95 * pairs) === pairs, i.e. the "p95" is
+// literally the maximum and carries no extra information. Derived rather than
+// hard-coded so the report never asserts a resolution the sample size cannot
+// support (with 0.95 this is true up to 19 pairs, so up to 6 runs).
+export const p95IsJustTheMaximum = (pairs) =>
+	pairs > 0 && Math.ceil(P95_FRACTION * pairs) === pairs;
+
+// Same files, same order, as the suites in .github/workflows/benchmarks.yml.
+const SUITES = [
+	{
+		file: "rateless-iblt-startsync-cache.json",
+		title: "shared-log: StartSync local decoder cache",
+	},
+	{
+		file: "rateless-iblt-sender-startsync.json",
+		title: "shared-log: sender StartSync setup (onMaybeMissingEntries)",
+	},
+	{
+		file: "sync-batch-sweep.json",
+		title: "shared-log: sync catch-up batch sweep",
+	},
+	{
+		file: "pid-convergence.json",
+		title: "shared-log: PID convergence (model)",
+	},
+	{ file: "document-put.json", title: "document: put" },
+	{ file: "chunk-transfer.json", title: "transport: multi-hop chunk transfer" },
+	{ file: "file-ingest.json", title: "document: chunked file-ingest" },
+];
+const SUITE_FILES = new Set(SUITES.map((suite) => suite.file));
+
+const METRICS = [
+	{ key: "mean_ms", label: "mean_ms", digits: 6 },
+	{ key: "hz", label: "hz (ops/s)", digits: 3 },
+];
+
+export class UsageError extends Error {}
+
+const ensure = (condition, message) => {
+	if (!condition) throw new Error(message);
+};
+
+const byName = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+
+const round = (value, digits) =>
+	value === null || value === undefined ? null : Number(value.toFixed(digits));
+
+export const parseArgs = (argv) => {
+	let resultsDir;
+	let minRuns = DEFAULT_MIN_RUNS;
+	let jsonOut;
+	const pending = [...argv];
+
+	const takeValue = (flag, inline) => {
+		const value = inline ?? pending.shift();
+		if (value === undefined) throw new UsageError(`${flag} requires a value`);
+		return value;
+	};
+
+	while (pending.length > 0) {
+		const argument = pending.shift();
+		const separator = argument.startsWith("--") ? argument.indexOf("=") : -1;
+		const flag = separator > 0 ? argument.slice(0, separator) : argument;
+		const inline = separator > 0 ? argument.slice(separator + 1) : undefined;
+
+		if (flag === "--min-runs") {
+			const raw = takeValue(flag, inline);
+			if (!/^\d+$/.test(raw))
+				throw new UsageError(`--min-runs must be a whole number, got "${raw}"`);
+			const parsed = Number(raw);
+			// Not clamped, refused. Silently raising a caller's 1 to 2 would let a
+			// workflow believe it asked for something this script never honoured.
+			if (parsed < ABSOLUTE_MIN_RUNS)
+				throw new UsageError(
+					`--min-runs must be at least ${ABSOLUTE_MIN_RUNS}: a noise floor is a spread between runs, and ${parsed} run(s) have no spread to measure`,
+				);
+			minRuns = parsed;
+		} else if (flag === "--json-out") {
+			jsonOut = takeValue(flag, inline);
+		} else if (argument.startsWith("-")) {
+			throw new UsageError(`Unknown option: ${argument}`);
+		} else if (resultsDir === undefined) {
+			resultsDir = argument;
+		} else {
+			throw new UsageError(`Unexpected extra argument: ${argument}`);
+		}
+	}
+
+	if (resultsDir === undefined) throw new UsageError("Missing <results-dir>");
+	return {
+		resultsDir,
+		minRuns,
+		jsonOut: jsonOut ?? path.join(resultsDir, DEFAULT_REPORT_NAME),
+	};
+};
+
+// A benchmark number is usable only if a relative delta against it is defined.
+// null/NaN/Infinity/0 all arrive here from real failure modes: tinybench writes
+// `mean_ms: task.result?.mean ?? null` when a task never ran, and
+// sync-batch-sweep writes `hz: mean_ms > 0 ? 1000 / mean_ms : 0`.
+export const classifyValue = (value) => {
+	if (value === null) return { ok: false, reason: "missing (null)" };
+	// Distinguished from null on purpose: `undefined` is what a suite row that
+	// simply does not carry the field looks like after normalisation, and
+	// "missing (absent field)" points at a shape problem rather than at a
+	// benchmark that ran and recorded nothing.
+	if (value === undefined)
+		return { ok: false, reason: "missing (absent field)" };
+	if (typeof value !== "number")
+		return { ok: false, reason: `non-numeric (${typeof value})` };
+	if (Number.isNaN(value)) return { ok: false, reason: "NaN" };
+	if (!Number.isFinite(value))
+		return { ok: false, reason: value > 0 ? "Infinity" : "-Infinity" };
+	if (value <= 0) return { ok: false, reason: `not positive (${value})` };
+	return { ok: true, value };
+};
+
+export const describeSamples = (values) => {
+	const n = values.length;
+	if (n === 0)
+		return { n, mean: null, stddev: null, cv_pct: null, min: null, max: null };
+	const mean = values.reduce((total, value) => total + value, 0) / n;
+	// Sample (n-1) stddev, and null rather than 0 for a single sample: a lone
+	// observation has unknown spread, and printing 0.00% would read as "rock
+	// solid" -- exactly the fail-open this script exists to prevent.
+	const stddev =
+		n > 1
+			? Math.sqrt(
+					values.reduce((total, value) => total + (value - mean) ** 2, 0) /
+						(n - 1),
+				)
+			: null;
+	return {
+		n,
+		mean,
+		stddev,
+		cv_pct: stddev === null || mean <= 0 ? null : (stddev / mean) * 100,
+		min: Math.min(...values),
+		max: Math.max(...values),
+	};
+};
+
+// All C(n,2) unordered pairs, as |a - b| / min(a, b) * 100, ascending.
+export const pairwiseAbsDeltasPct = (values) => {
+	for (const value of values)
+		ensure(
+			typeof value === "number" && Number.isFinite(value) && value > 0,
+			`pairwiseAbsDeltasPct requires positive finite samples, got ${value}`,
+		);
+	const deltas = [];
+	for (let i = 0; i < values.length; i++)
+		for (let j = i + 1; j < values.length; j++) {
+			const a = values[i];
+			const b = values[j];
+			deltas.push((Math.abs(a - b) / Math.min(a, b)) * 100);
+		}
+	deltas.sort((x, y) => x - y);
+	return deltas;
+};
+
+export const percentileNearestRank = (sorted, fraction) => {
+	if (sorted.length === 0) return null;
+	const rank = Math.ceil(fraction * sorted.length);
+	return sorted[Math.min(Math.max(rank, 1), sorted.length) - 1];
+};
+
+export const median = (sorted) => {
+	if (sorted.length === 0) return null;
+	const middle = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 1
+		? sorted[middle]
+		: (sorted[middle - 1] + sorted[middle]) / 2;
+};
+
+// Which field of a suite row carries each METRICS key, per shape. The tinybench
+// shape names them identically; document-put's `rows` shape does not, and the
+// mapping below is the whole reason this script can see that suite at all.
+//
+//   mean_ms <- totalPutMs    the row's own put duration. document-put.ts times
+//                            `iterations` puts into profile.totalPutMs, so this
+//                            is a total rather than a per-op mean. That is fine
+//                            and deliberate: |Δ%| divides by min(a, b), so it is
+//                            invariant under multiplication by a constant, and
+//                            `iterations` is fixed by DOC_ITERATIONS across the
+//                            repeats of one A/A experiment. Dividing by
+//                            `iterations` here would be the only mapping that
+//                            could *hide* a run whose iteration count drifted,
+//                            and hiding is the direction this file refuses.
+//   hz      <- opsPerSecond  document-put.ts computes it as
+//                            round(iterations / totalPutMs * 1000), i.e. the
+//                            same reciprocal relationship tinybench's hz has to
+//                            mean_ms, up to that same constant factor. So the
+//                            reciprocal-invariance of |Δ%| holds for this shape
+//                            too, and the two metrics still differ in CV, which
+//                            is why both are kept.
+//
+// Neither field is defaulted. A row that lacks one arrives at classifyValue as
+// `undefined` and becomes a blocking `invalid-metric-value` naming the field --
+// a loud problem, never a silent skip.
+const TASKS_SHAPE = { shape: "tasks", mean_ms: "mean_ms", hz: "hz" };
+const ROWS_SHAPE = { shape: "rows", mean_ms: "totalPutMs", hz: "opsPerSecond" };
+
+const normalizeRow = (row, fields) => ({
+	name: row.name,
+	mean_ms: row[fields.mean_ms],
+	hz: row[fields.hz],
+});
+
+const unreadable = (status, detail, digest = null) => ({
+	status,
+	detail,
+	digest,
+	shape: null,
+	metricFields: TASKS_SHAPE,
+	tasks: new Map(),
+	duplicates: [],
+	unnamed: 0,
+});
+
+const readSuiteFile = (file) => {
+	let raw;
+	try {
+		raw = fs.readFileSync(file, "utf8");
+	} catch (error) {
+		// ENOENT is the ONLY status that means "this suite was never collected".
+		// Everything else means the file exists and we failed to read it, which
+		// analyze() treats as a collection failure rather than a deselection.
+		return error.code === "ENOENT"
+			? unreadable("missing", "file not found")
+			: unreadable("unreadable", error.message);
+	}
+	// Byte digest of the exact input, used only to spot run directories that are
+	// copies of each other rather than independent measurements.
+	const digest = crypto.createHash("sha256").update(raw).digest("hex");
+	if (raw.trim() === "") return unreadable("empty", "file is empty", digest);
+	let parsed;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		return unreadable(
+			"unparseable",
+			`JSON parse error: ${error.message}`,
+			digest,
+		);
+	}
+	// `tasks` wins when both are present: it is the canonical tinybench shape,
+	// and a file carrying both would be a new emitter worth noticing rather than
+	// guessing at.
+	const fields = Array.isArray(parsed?.tasks)
+		? TASKS_SHAPE
+		: Array.isArray(parsed?.rows)
+			? ROWS_SHAPE
+			: null;
+	if (fields === null)
+		return unreadable(
+			"unparseable",
+			"no `tasks` array and no `rows` array (a suite must emit one of the two shapes this script knows)",
+			digest,
+		);
+	const rows = fields === TASKS_SHAPE ? parsed.tasks : parsed.rows;
+
+	const tasks = new Map();
+	const duplicates = [];
+	let unnamed = 0;
+	for (const row of rows) {
+		if (typeof row?.name !== "string") {
+			unnamed += 1;
+			continue;
+		}
+		// Two rows with one name make the per-run sample ambiguous; the last one
+		// would silently win. Keep the first and say so.
+		if (tasks.has(row.name)) {
+			duplicates.push(row.name);
+			continue;
+		}
+		tasks.set(row.name, normalizeRow(row, fields));
+	}
+	if (tasks.size === 0)
+		return {
+			...unreadable(
+				"no-tasks",
+				unnamed > 0
+					? `zero named ${fields.shape} (${unnamed} entr(y/ies) had no name)`
+					: `zero ${fields.shape}`,
+				digest,
+			),
+			shape: fields.shape,
+			metricFields: fields,
+			duplicates,
+			unnamed,
+		};
+	return {
+		status: "ok",
+		detail: null,
+		digest,
+		shape: fields.shape,
+		metricFields: fields,
+		tasks,
+		duplicates,
+		unnamed,
+	};
+};
+
+const discoverRuns = (root) => {
+	const runs = [];
+	for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const match = /^run-(\d+)$/.exec(entry.name);
+		if (!match) continue;
+		runs.push({
+			name: entry.name,
+			index: Number(match[1]),
+			dir: path.join(root, entry.name),
+		});
+	}
+	// Numeric, so run-10 sorts after run-9; name breaks ties like run-1/run-01.
+	runs.sort((a, b) => a.index - b.index || byName(a.name, b.name));
+	return runs;
+};
+
+const unrecognizedJsonFiles = (dir) => {
+	let entries;
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	return entries
+		.filter(
+			(entry) =>
+				entry.isFile() &&
+				entry.name.endsWith(".json") &&
+				!SUITE_FILES.has(entry.name),
+		)
+		.map((entry) => entry.name)
+		.sort(byName);
+};
+
+export const analyze = ({ resultsDir, minRuns = DEFAULT_MIN_RUNS }) => {
+	ensure(
+		Number.isInteger(minRuns) && minRuns >= ABSOLUTE_MIN_RUNS,
+		`analyze requires an integer minRuns >= ${ABSOLUTE_MIN_RUNS}`,
+	);
+	const root = path.resolve(resultsDir);
+	const problems = [];
+	const add = (severity, code, message, extra = {}) =>
+		problems.push({ severity, code, message, ...extra });
+
+	const discovered = discoverRuns(root);
+	const reads = discovered.map((run) => ({
+		run,
+		suites: new Map(
+			SUITES.map((suite) => [
+				suite.file,
+				readSuiteFile(path.join(run.dir, suite.file)),
+			]),
+		),
+		extras: unrecognizedJsonFiles(run.dir),
+	}));
+
+	// A run directory with no readable suite at all (the job died before it ran,
+	// or the copy step missed it) is dropped from the sample rather than counted
+	// as "every suite is missing here" -- but dropping it is itself blocking, so
+	// the smaller denominator can never pass unnoticed.
+	const usable = reads.filter((read) =>
+		[...read.suites.values()].some((suite) => suite.status === "ok"),
+	);
+	const excluded = reads.filter((read) => !usable.includes(read));
+	for (const read of excluded)
+		add(
+			"blocking",
+			"unusable-run",
+			`${read.run.name} contains no readable suite JSON with at least one task; it is excluded from the sample`,
+			{ run: read.run.name },
+		);
+	for (const read of reads)
+		for (const extra of read.extras)
+			add(
+				"warning",
+				"unrecognized-file",
+				`${read.run.name}/${extra} is not a known suite file; it was ignored (a renamed benchmark would land here)`,
+				{ run: read.run.name, file: extra },
+			);
+
+	// Cheap insurance against a hand-assembled results directory: N byte-identical
+	// run directories would otherwise produce a 0.00% floor and exit 0. The
+	// workflow's own loop cannot generate this (real timings never repeat to the
+	// byte), so it means the inputs were copied. A warning rather than a refusal,
+	// because a *single* deliberately deterministic model suite really can emit
+	// identical bytes twice -- see the `deterministic` handling below.
+	const signatures = new Map();
+	for (const read of usable) {
+		const parts = [...read.suites.entries()]
+			.filter(([, suite]) => suite.digest !== null)
+			.map(([file, suite]) => `${file}\u0000${suite.digest}`)
+			.sort(byName);
+		if (parts.length === 0) continue;
+		const signature = crypto
+			.createHash("sha256")
+			.update(parts.join("\u0001"))
+			.digest("hex");
+		if (!signatures.has(signature)) signatures.set(signature, []);
+		signatures.get(signature).push(read.run.name);
+	}
+	for (const group of [...signatures.values()]
+		.filter((names) => names.length > 1)
+		.sort((a, b) => byName(a[0], b[0])))
+		add(
+			"warning",
+			"duplicate-run-input",
+			`${group.join(", ")} contain byte-identical suite JSON; independent runs do not repeat to the byte, so these are almost certainly copies of one measurement and every |Δ%| they contribute is a fabricated 0%`,
+			{ runs: group },
+		);
+
+	const runCount = usable.length;
+	if (discovered.length === 0)
+		add(
+			"blocking",
+			"no-runs",
+			`No run-<n> directories found under ${root}; there is nothing to compare`,
+		);
+	if (runCount < minRuns)
+		add(
+			"blocking",
+			"insufficient-runs",
+			`Only ${runCount} usable run(s), need at least ${minRuns}. A noise floor from too few runs reads low, which makes every perf claim look significant; refusing to publish one`,
+			{ usableRuns: runCount, minRuns },
+		);
+
+	const suiteReports = [];
+	for (const suite of SUITES) {
+		const present = usable.filter(
+			(read) => read.suites.get(suite.file).status === "ok",
+		);
+		const absent = usable.filter(
+			(read) => read.suites.get(suite.file).status !== "ok",
+		);
+
+		// Every absent run carries WHY, and the reason travels into the JSON
+		// report. "not-collected" with no reason tells a downstream consumer
+		// nothing, and the difference between the two reasons is the difference
+		// between a deselected suite and a silent 27x understatement.
+		const missingReasons = absent.map((read) => ({
+			run: read.run.name,
+			reason: read.suites.get(suite.file).status,
+			detail: read.suites.get(suite.file).detail,
+		}));
+
+		if (present.length === 0) {
+			// The discriminator that used to be thrown away. `missing` is ENOENT and
+			// only ENOENT (see readSuiteFile), so anything else means the file was
+			// there and we could not read it.
+			const broken = absent.filter(
+				(read) => read.suites.get(suite.file).status !== "missing",
+			);
+			suiteReports.push({
+				file: suite.file,
+				title: suite.title,
+				status: broken.length > 0 ? "unreadable-everywhere" : "not-collected",
+				reason:
+					broken.length > 0
+						? `present but unreadable in ${broken.length}/${runCount} run(s); no task from this suite reached the summary`
+						: // Says what was observed, not why. This script never reads
+							// the job's metadata, so it cannot tell "deselected" from
+							// "selected but the step never wrote the file". Naming the
+							// benign cause would hide the other one.
+							"absent (file not found) in every usable run; either it was not selected, or its step never wrote a file -- this report cannot tell which, so confirm the suite was deselected before treating its absence as expected",
+				presentIn: [],
+				missingIn: absent.map((read) => read.run.name),
+				missingReasons,
+				tasks: [],
+			});
+			if (broken.length > 0)
+				for (const read of broken)
+					add(
+						"blocking",
+						"suite-unreadable-everywhere",
+						`${suite.file} exists in ${read.run.name} but is ${read.suites.get(suite.file).status} (${read.suites.get(suite.file).detail}), and it produced no usable output in ANY of the ${runCount} run(s). Its tasks are therefore absent from the summary entirely, which understates the headline floor by exactly the amount they would have contributed. A suite that is present but broken is a collection failure, not a deselection`,
+						{
+							suite: suite.file,
+							run: read.run.name,
+							reason: read.suites.get(suite.file).status,
+							detail: read.suites.get(suite.file).detail,
+						},
+					);
+			else if (runCount > 0)
+				add(
+					"warning",
+					"suite-not-collected",
+					`${suite.file} is absent (file not found) from all ${runCount} run(s); it was not collected, so no floor is reported for it`,
+					{ suite: suite.file, reason: "missing" },
+				);
+			continue;
+		}
+
+		for (const read of absent)
+			add(
+				"blocking",
+				"suite-missing-in-run",
+				`${suite.file} is usable in ${present.length}/${runCount} run(s) but ${read.run.name} has it ${read.suites.get(suite.file).status} (${read.suites.get(suite.file).detail}); the surviving runs are not a fair sample`,
+				{
+					suite: suite.file,
+					run: read.run.name,
+					reason: read.suites.get(suite.file).status,
+				},
+			);
+		for (const read of present) {
+			const parsed = read.suites.get(suite.file);
+			for (const name of [...parsed.duplicates].sort(byName))
+				add(
+					"blocking",
+					"duplicate-task",
+					`${read.run.name}/${suite.file} lists task "${name}" more than once; which row is the sample is ambiguous`,
+					{ suite: suite.file, run: read.run.name, task: name },
+				);
+			if (parsed.unnamed > 0)
+				add(
+					"blocking",
+					"unnamed-task",
+					`${read.run.name}/${suite.file} has ${parsed.unnamed} task(s) without a name; they cannot be matched across runs`,
+					{ suite: suite.file, run: read.run.name },
+				);
+		}
+
+		const taskNames = [
+			...new Set(
+				present.flatMap((read) => [
+					...read.suites.get(suite.file).tasks.keys(),
+				]),
+			),
+		].sort(byName);
+
+		const taskReports = [];
+		for (const name of taskNames) {
+			const seenIn = [];
+			const absentIn = [];
+			for (const read of usable) {
+				const parsed = read.suites.get(suite.file);
+				if (parsed.status === "ok" && parsed.tasks.has(name)) seenIn.push(read);
+				else absentIn.push(read.run.name);
+			}
+			// Only raise a task-level problem when the suite itself was fine in that
+			// run; otherwise the suite-level entry above already explains it and we
+			// would emit one duplicate per task.
+			for (const read of present)
+				if (!read.suites.get(suite.file).tasks.has(name))
+					add(
+						"blocking",
+						"task-missing-in-run",
+						`${suite.file} task "${name}" is absent from ${read.run.name} although that run's suite parsed; a task that only appears in some runs of identical code is a red flag, and its floor would rest on ${seenIn.length} of ${runCount} runs`,
+						{ suite: suite.file, run: read.run.name, task: name },
+					);
+
+			const metrics = {};
+			for (const metric of METRICS) {
+				const values = [];
+				const invalid = [];
+				const sourceFields = new Map();
+				for (const read of seenIn) {
+					const parsedSuite = read.suites.get(suite.file);
+					const task = parsedSuite.tasks.get(name);
+					const classified = classifyValue(task[metric.key]);
+					if (classified.ok) values.push(classified.value);
+					else {
+						invalid.push({ run: read.run.name, reason: classified.reason });
+						sourceFields.set(
+							read.run.name,
+							parsedSuite.metricFields[metric.key],
+						);
+					}
+				}
+
+				if (invalid.length > 0) {
+					for (const entry of invalid) {
+						// Naming the underlying field matters for the `rows` shape: a
+						// document-put row that lost `totalPutMs` must not read as "the
+						// mean_ms was null", which points at the wrong thing.
+						const field = sourceFields.get(entry.run) ?? metric.key;
+						add(
+							"blocking",
+							"invalid-metric-value",
+							`${suite.file} task "${name}" has ${metric.key} = ${entry.reason} in ${entry.run}${
+								field === metric.key
+									? ""
+									: ` (read from the row field "${field}")`
+							}; a relative delta against it is undefined, so no floor is computed for this metric`,
+							{
+								suite: suite.file,
+								run: entry.run,
+								task: name,
+								metric: metric.key,
+								sourceField: field,
+							},
+						);
+					}
+					metrics[metric.key] = {
+						status: "invalid",
+						n: values.length,
+						invalidSamples: invalid,
+						mean: null,
+						stddev: null,
+						cv_pct: null,
+						min: null,
+						max: null,
+						pairs: 0,
+						median_abs_delta_pct: null,
+						p95_abs_delta_pct: null,
+						max_abs_delta_pct: null,
+						noVariationResolved: false,
+					};
+					continue;
+				}
+
+				const stats = describeSamples(values);
+				if (values.length < 2) {
+					metrics[metric.key] = {
+						status: "insufficient-samples",
+						n: values.length,
+						invalidSamples: [],
+						mean: round(stats.mean, 9),
+						stddev: null,
+						cv_pct: null,
+						min: round(stats.min, 9),
+						max: round(stats.max, 9),
+						pairs: 0,
+						median_abs_delta_pct: null,
+						p95_abs_delta_pct: null,
+						max_abs_delta_pct: null,
+						noVariationResolved: false,
+					};
+					continue;
+				}
+
+				const deltas = pairwiseAbsDeltasPct(values);
+				const worst = deltas[deltas.length - 1];
+				// A zero floor means no variation was RESOLVED. It does not mean
+				// the benchmark is deterministic, and this file must not claim a
+				// cause it cannot observe. Two different things produce it:
+				//
+				//   1. a genuinely reproducible benchmark (some model suites are), or
+				//   2. real variation smaller than the source's own rounding step.
+				//
+				// (2) is not hypothetical. document-put.ts emits
+				// `opsPerSecond: Math.round(...)`, so its resolution is one whole
+				// op/s -- 0.05% at 2000 ops/s, but 4% at 24 -- and totalPutMs is
+				// rounded to 2 decimals. A "0% floor" taken as determinism would
+				// let every later A/B delta on that task clear the bar, which is
+				// the understating direction this file exists to refuse.
+				const noVariationResolved = worst === 0;
+				if (noVariationResolved)
+					add(
+						"note",
+						"no-variation-resolved",
+						`${suite.file} task "${name}" reported an identical ${metric.key} in all ${values.length} runs. Treat this as "below the resolution of this measurement", NOT as a measured 0% floor: it is indistinguishable from variation smaller than the source's rounding step. Do not use it to justify accepting a small A/B delta on this task.`,
+						{ suite: suite.file, task: name, metric: metric.key },
+					);
+				metrics[metric.key] = {
+					status: "ok",
+					n: values.length,
+					invalidSamples: [],
+					mean: round(stats.mean, 9),
+					stddev: round(stats.stddev, 9),
+					cv_pct: round(stats.cv_pct, 6),
+					min: round(stats.min, 9),
+					max: round(stats.max, 9),
+					pairs: deltas.length,
+					median_abs_delta_pct: round(median(deltas), 6),
+					p95_abs_delta_pct: round(
+						percentileNearestRank(deltas, P95_FRACTION),
+						6,
+					),
+					max_abs_delta_pct: round(worst, 6),
+					noVariationResolved,
+				};
+			}
+
+			taskReports.push({
+				name,
+				n: seenIn.length,
+				complete: seenIn.length === runCount,
+				seenIn: seenIn.map((read) => read.run.name),
+				absentIn,
+				metrics,
+			});
+		}
+
+		suiteReports.push({
+			file: suite.file,
+			title: suite.title,
+			status: absent.length === 0 ? "ok" : "partial",
+			reason: null,
+			presentIn: present.map((read) => read.run.name),
+			missingIn: absent.map((read) => read.run.name),
+			missingReasons,
+			tasks: taskReports,
+		});
+	}
+
+	const pairsPerTask = runCount >= 2 ? (runCount * (runCount - 1)) / 2 : 0;
+	const p95Degenerate = p95IsJustTheMaximum(pairsPerTask);
+	if (p95Degenerate)
+		add(
+			"note",
+			"coarse-p95",
+			`${runCount} runs give only ${pairsPerTask} pairs per task, and ceil(${P95_FRACTION} * ${pairsPerTask}) = ${pairsPerTask}, so the nearest-rank p95 IS the maximum. It carries no information the headline max does not already carry; the headline is the max either way`,
+			{ pairs: pairsPerTask },
+		);
+
+	const summary = {};
+	for (const metric of METRICS) {
+		const measured = [];
+		for (const suite of suiteReports)
+			for (const task of suite.tasks) {
+				const stats = task.metrics[metric.key];
+				if (stats?.status === "ok")
+					measured.push({
+						suite: suite.file,
+						task: task.name,
+						max: stats.max_abs_delta_pct,
+						p95: stats.p95_abs_delta_pct,
+					});
+			}
+		// The headline aggregates the per-task MAXIMA. Sorting a copy leaves
+		// `measured` in its deterministic (suite, task) order for the worst-task
+		// tie-break below.
+		const maxes = measured.map((entry) => entry.max).sort((a, b) => a - b);
+		const p95s = measured.map((entry) => entry.p95).sort((a, b) => a - b);
+		// Ties resolve by (suite, task) so the named worst task is stable.
+		const worst = measured
+			.slice()
+			.sort(
+				(a, b) =>
+					b.max - a.max || byName(a.suite, b.suite) || byName(a.task, b.task),
+			)[0];
+		summary[metric.key] = {
+			tasksMeasured: measured.length,
+			// Headline. Monotone in the run count: more runs can only add pairs.
+			medianOfMax: round(median(maxes), 6),
+			worstMax: worst ? worst.max : null,
+			worstTask: worst ? { suite: worst.suite, task: worst.task } : null,
+			tasksAbove5Pct: maxes.filter((value) => value > 5).length,
+			tasksAbove10Pct: maxes.filter((value) => value > 10).length,
+			// Secondary, and never quoted without its pair count: at these sample
+			// sizes p95 is either the maximum outright or one rank below it, and it
+			// can DROP when runs are added. See the header comment.
+			pairsPerTask,
+			p95IsJustTheMaximum: p95Degenerate,
+			medianOfP95: round(median(p95s), 6),
+			worstP95: measured.length > 0 ? p95s[p95s.length - 1] : null,
+			noVariationTasks: suiteReports.reduce(
+				(total, suite) =>
+					total +
+					suite.tasks.filter(
+						(task) => task.metrics[metric.key]?.noVariationResolved,
+					).length,
+				0,
+			),
+		};
+	}
+
+	const blocking = problems.filter((entry) => entry.severity === "blocking");
+	return {
+		schema: SCHEMA,
+		resultsDir: root,
+		minRuns,
+		deltaDefinition: "|a - b| / min(a, b) * 100 over all unordered run pairs",
+		headlineStatistic: HEADLINE_STATISTIC,
+		decisionRule: DECISION_RULE,
+		p95Method:
+			"nearest-rank (no interpolation), reported as a secondary column",
+		stddevMethod: "sample (n-1)",
+		runs: usable.map((read) => ({
+			name: read.run.name,
+			index: read.run.index,
+		})),
+		excludedRuns: excluded.map((read) => read.run.name),
+		runCount,
+		pairsPerTask,
+		// "Collected" means at least one run produced usable tasks. A suite that is
+		// present-but-broken everywhere is NOT collected and is counted separately,
+		// so `k/7` can never quietly include a suite that contributed nothing.
+		suitesCollected: suiteReports.filter(
+			(suite) => suite.status === "ok" || suite.status === "partial",
+		).length,
+		suitesUnreadableEverywhere: suiteReports
+			.filter((suite) => suite.status === "unreadable-everywhere")
+			.map((suite) => suite.file),
+		suitesKnown: SUITES.length,
+		// Single source of truth: every refusal above goes through `blocking`, so
+		// the verdict has exactly one place to be wrong and one place to pin.
+		trustworthy: blocking.length === 0,
+		blockingCount: blocking.length,
+		problems,
+		suites: suiteReports,
+		summary,
+	};
+};
+
+const cell = (value) => String(value).replace(/\|/g, "\\|");
+
+const fmt = (value, digits) =>
+	value === null || value === undefined ? "-" : value.toFixed(digits);
+
+const flagsFor = (task, stats, runCount) => {
+	const flags = [];
+	if (!task.complete)
+		flags.push(
+			`**n=${task.n}/${runCount}** (absent: ${task.absentIn.join(", ")})`,
+		);
+	if (stats.status === "invalid")
+		flags.push(
+			`**invalid**: ${stats.invalidSamples
+				.map((entry) => `${entry.run} ${entry.reason}`)
+				.join("; ")}`,
+		);
+	if (stats.status === "insufficient-samples")
+		flags.push("**no spread** (fewer than 2 samples)");
+	if (stats.noVariationResolved)
+		flags.push(
+			"`no variation resolved` (identical in every run -- may be below measurement resolution)",
+		);
+	return flags.join("<br>") || "";
+};
+
+export const renderMarkdown = (report) => {
+	const lines = [];
+	const push = (line = "") => lines.push(line);
+
+	push("# Benchmark A/A noise floor");
+	push();
+	if (report.trustworthy)
+		push(
+			`**Verdict: TRUSTWORTHY** — ${report.runCount} usable run(s) of identical code (minimum ${report.minRuns}), ${report.suitesCollected}/${report.suitesKnown} suite(s) collected.`,
+		);
+	else
+		push(
+			`**Verdict: NOT TRUSTWORTHY** — ${report.blockingCount} blocking problem(s). Any floor below is likely to be **understated**, which would make real regressions look like noise and noise look like wins. Fix the problems and re-run before quoting a number.`,
+		);
+	push();
+	push(`- Results directory: \`${report.resultsDir}\``);
+	push(
+		`- Usable runs: ${report.runCount} (\`--min-runs ${report.minRuns}\`)${
+			report.runs.length > 0
+				? ` — ${report.runs.map((run) => run.name).join(", ")}`
+				: ""
+		}`,
+	);
+	if (report.excludedRuns.length > 0)
+		push(`- Excluded runs: ${report.excludedRuns.join(", ")}`);
+	push(`- Suites collected: ${report.suitesCollected}/${report.suitesKnown}`);
+	if (report.suitesUnreadableEverywhere.length > 0)
+		push(
+			`- **Suites present but unreadable in every run: ${report.suitesUnreadableEverywhere.join(", ")}** — their tasks are missing from the headline below, which therefore reads LOW.`,
+		);
+	push(`- Pairs compared per task: ${report.pairsPerTask}`);
+	push();
+
+	push("## How to read this");
+	push();
+	push(
+		"Every run here is the **same commit**. Any spread is measurement noise, not code.",
+	);
+	push();
+	push(
+		`\`|Δ%|\` is \`${report.deltaDefinition}\`. \`benchmarks.yml\` divides by the base run, but either run of an A/A pair could have been the base, so this reports the larger of the two readings — a floor that reads low is the dangerous direction. This also makes \`mean_ms\` and \`hz\` yield the same \`|Δ%|\`; their \`CV\` still differs, which is why both are listed.`,
+	);
+	push();
+	push(
+		`The headline is the **observed maximum** \`|Δ%|\`, not the p95. The max never understates what was actually seen, and it is monotone in the run count — pairs from N+1 runs contain the pairs from N — so adding runs can only reveal more tail. Nearest-rank p95 over \`C(N,2)\` pairs is **not** monotone: it equals the maximum up to 6 runs and steps down at 7, so quoting it would let extra measurement shrink the published floor.`,
+	);
+	push();
+	push(
+		`p95 is ${report.p95Method}; stddev is ${report.stddevMethod}; \`CV\` is \`stddev / mean\` as a percent.`,
+	);
+	push();
+	push(`To use it: ${report.decisionRule}`);
+	push();
+	push(
+		"So an A/B run showing +7% on task T is noise if T's A/A max is 12%, and worth investigating if T's A/A max is 0.4%.",
+	);
+	push();
+
+	for (const [heading, severity] of [
+		["Blocking problems", "blocking"],
+		["Warnings", "warning"],
+		["Findings", "note"],
+	]) {
+		const entries = report.problems.filter(
+			(problem) => problem.severity === severity,
+		);
+		if (entries.length === 0) continue;
+		push(`## ${heading} (${entries.length})`);
+		push();
+		for (const problem of entries.slice(0, MAX_LISTED_PROBLEMS))
+			push(`- \`${problem.code}\` ${problem.message}`);
+		if (entries.length > MAX_LISTED_PROBLEMS)
+			push(
+				`- …and ${entries.length - MAX_LISTED_PROBLEMS} more (see the JSON report)`,
+			);
+		push();
+	}
+
+	push("## Headline: how big is noise?");
+	push();
+	push(
+		"Aggregated over the per-task **max** `|Δ%|`. This is the number to quote.",
+	);
+	push();
+	push(
+		"| metric | tasks measured | median max \\|Δ\\| | worst max \\|Δ\\| | worst task | max > 5% | max > 10% | no variation resolved |",
+	);
+	push("|---|---:|---:|---:|---|---:|---:|---:|");
+	for (const metric of METRICS) {
+		const stats = report.summary[metric.key];
+		push(
+			`| ${metric.label} | ${stats.tasksMeasured} | ${fmt(stats.medianOfMax, 2)}% | ${fmt(stats.worstMax, 2)}% | ${
+				stats.worstTask
+					? cell(`${stats.worstTask.suite} › ${stats.worstTask.task}`)
+					: "-"
+			} | ${stats.tasksAbove5Pct} | ${stats.tasksAbove10Pct} | ${stats.noVariationTasks} |`,
+		);
+	}
+	push();
+	push(
+		`### Secondary: p95 over ${report.pairsPerTask} pair(s) per task — not authoritative`,
+	);
+	push();
+	push(
+		report.summary[METRICS[0].key].p95IsJustTheMaximum
+			? `> [!NOTE]\n> \`ceil(0.95 × ${report.pairsPerTask}) = ${report.pairsPerTask}\`, so this p95 **is** the maximum above and adds nothing. At 7+ runs it would step below the maximum instead, which is why it is not the headline.`
+			: `> [!NOTE]\n> With ${report.pairsPerTask} pairs this p95 sits below the observed maximum. It is shown for shape only; a floor quoted from it would understate the worst A/A gap actually measured.`,
+	);
+	push();
+	push("| metric | median p95 \\|Δ\\| | worst p95 \\|Δ\\| |");
+	push("|---|---:|---:|");
+	for (const metric of METRICS) {
+		const stats = report.summary[metric.key];
+		push(
+			`| ${metric.label} | ${fmt(stats.medianOfP95, 2)}% | ${fmt(stats.worstP95, 2)}% |`,
+		);
+	}
+	push();
+
+	for (const suite of report.suites) {
+		push(`## ${suite.title} (\`${suite.file}\`)`);
+		push();
+		if (suite.status === "not-collected") {
+			push(
+				`_Not collected in any run (${suite.reason}); no floor is reported for this suite._`,
+			);
+			push();
+			continue;
+		}
+		if (suite.status === "unreadable-everywhere") {
+			push(
+				`> [!CAUTION]\n> **Present but unreadable in every run** — ${suite.reason}. This suite contributed nothing to the headline, so the headline is understated by whatever its tasks would have added. Reasons: ${suite.missingReasons
+					.map((entry) => `${entry.run} ${entry.reason} (${entry.detail})`)
+					.join("; ")}.`,
+			);
+			push();
+			continue;
+		}
+		if (suite.status === "partial") {
+			push(
+				`> [!WARNING]\n> Usable in ${suite.presentIn.length}/${report.runCount} run(s); missing or unreadable in ${suite.missingReasons
+					.map((entry) => `${entry.run} (${entry.reason})`)
+					.join(", ")}.`,
+			);
+			push();
+		}
+		for (const metric of METRICS) {
+			push(`### ${metric.label}`);
+			push();
+			push(
+				"| Task | n | mean | stddev | CV % | min | max | median \\|Δ\\| % | p95 \\|Δ\\| % | max \\|Δ\\| % | flags |",
+			);
+			push("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|");
+			for (const task of suite.tasks) {
+				const stats = task.metrics[metric.key];
+				push(
+					`| ${cell(task.name)} | ${task.n}/${report.runCount} | ${fmt(stats.mean, metric.digits)} | ${fmt(stats.stddev, metric.digits)} | ${fmt(stats.cv_pct, 2)} | ${fmt(stats.min, metric.digits)} | ${fmt(stats.max, metric.digits)} | ${fmt(stats.median_abs_delta_pct, 2)} | ${fmt(stats.p95_abs_delta_pct, 2)} | ${fmt(stats.max_abs_delta_pct, 2)} | ${flagsFor(task, stats, report.runCount)} |`,
+				);
+			}
+			push();
+		}
+	}
+
+	push("---");
+	push();
+	push(
+		report.trustworthy
+			? "Exit status 0: the report is trustworthy."
+			: "Exit status 1: the report was produced but is **not** trustworthy — see the blocking problems above.",
+	);
+	return lines.join("\n");
+};
+
+export const runCli = (
+	argv,
+	{ log = console.log, logError = console.error } = {},
+) => {
+	let options;
+	try {
+		options = parseArgs(argv);
+	} catch (error) {
+		if (!(error instanceof UsageError)) throw error;
+		logError(error.message);
+		logError(USAGE);
+		return 2;
+	}
+
+	const root = path.resolve(options.resultsDir);
+	let stats;
+	try {
+		stats = fs.statSync(root);
+	} catch {
+		logError(`Results directory does not exist: ${root}`);
+		logError(USAGE);
+		return 2;
+	}
+	if (!stats.isDirectory()) {
+		logError(`Not a directory: ${root}`);
+		logError(USAGE);
+		return 2;
+	}
+
+	const report = analyze({ resultsDir: root, minRuns: options.minRuns });
+	const jsonOut = path.resolve(options.jsonOut);
+	fs.mkdirSync(path.dirname(jsonOut), { recursive: true });
+	fs.writeFileSync(jsonOut, `${JSON.stringify(report, null, 2)}\n`);
+	log(renderMarkdown(report));
+	if (!report.trustworthy) {
+		logError(
+			`noise-floor: ${report.blockingCount} blocking problem(s); the measured floor would be understated. Report written to ${jsonOut}`,
+		);
+		return 1;
+	}
+	logError(`noise-floor: report written to ${jsonOut}`);
+	return 0;
+};
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+)
+	process.exitCode = runCli(process.argv.slice(2));

--- a/scripts/bench/noise-floor.spec.mjs
+++ b/scripts/bench/noise-floor.spec.mjs
@@ -1,0 +1,1328 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	analyze,
+	median,
+	p95IsJustTheMaximum,
+	pairwiseAbsDeltasPct,
+	percentileNearestRank,
+	renderMarkdown,
+	runCli,
+} from "./noise-floor.mjs";
+
+const withFixture = (body) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "peerbit-noise-floor-"));
+	try {
+		return body(root);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+};
+
+const writeSuite = (root, run, file, body) => {
+	const dir = path.join(root, run);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, file),
+		typeof body === "string" ? body : JSON.stringify(body, null, 2),
+	);
+};
+
+const task = (name, meanMs) => ({
+	name,
+	hz: meanMs > 0 ? 1000 / meanMs : 0,
+	mean_ms: meanMs,
+	rme: 1.5,
+	samples: 10,
+});
+
+const suite = (...tasks) => ({ name: "fixture", tasks, meta: {} });
+
+// The REAL document-put.json shape, copied field-for-field from
+// packages/programs/data/document/document/benchmark/document-put.ts: a BenchRow
+// list under `rows`, no `tasks` anywhere, `opsPerSecond` instead of `hz` and
+// `totalPutMs` instead of `mean_ms`. The six other suites emit tinybench's
+// `tasks`; this one never has.
+const documentPutRow = (name, totalPutMs, iterations = 10) => ({
+	name,
+	iterations,
+	payloadBytes: 1024,
+	// document-put.ts: Math.round((iterations / profile.totalPutMs) * 1000).
+	opsPerSecond: Math.round((iterations / totalPutMs) * 1000),
+	cleanupMs: 0,
+	serializeMs: 1.5,
+	existingHeadLookupMs: 0.25,
+	sharedAppendMs: Math.round(totalPutMs * 60) / 100,
+	logAppendMs: Math.round(totalPutMs * 40) / 100,
+	documentIndexPutMs: Math.round(totalPutMs * 20) / 100,
+	documentIndexTransformMs: 0.1,
+	documentBackendIndexPutMs: Math.round(totalPutMs * 10) / 100,
+	totalPutMs,
+});
+
+const documentPutSuite = (...rows) => ({
+	name: "document-put",
+	rows,
+	meta: {
+		payloadBytes: 1024,
+		warmupIterations: 2,
+		iterations: 10,
+		profileDeep: false,
+		profileNativeBackbone: false,
+		coordinateWalFlushBytes: 0,
+		coordinateWalFlushIntervalMs: 0,
+	},
+});
+
+// Lets a fixture hold values JSON.stringify cannot express (Infinity) or that a
+// broken benchmark would emit verbatim (null, 0, "12").
+const rawSuite = (rows) =>
+	`{"name":"fixture","tasks":[${rows
+		.map(
+			(row) =>
+				`{"name":${JSON.stringify(row.name)},"mean_ms":${row.mean_ms},"hz":${row.hz}}`,
+		)
+		.join(",")}]}`;
+
+const findSuite = (report, file) =>
+	report.suites.find((entry) => entry.file === file);
+
+const findTask = (report, file, name) =>
+	findSuite(report, file).tasks.find((entry) => entry.name === name);
+
+const codes = (report, severity) =>
+	report.problems
+		.filter((problem) => problem.severity === severity)
+		.map((problem) => problem.code);
+
+const captureCli = (argv) => {
+	const stdout = [];
+	const stderr = [];
+	const code = runCli(argv, {
+		log: (line) => stdout.push(String(line)),
+		logError: (line) => stderr.push(String(line)),
+	});
+	return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n") };
+};
+
+const round6 = (value) => Number(value.toFixed(6));
+
+const forEachNumber = (value, visit) => {
+	if (typeof value === "number") visit(value);
+	else if (Array.isArray(value))
+		for (const item of value) forEachNumber(item, visit);
+	else if (value && typeof value === "object")
+		for (const item of Object.values(value)) forEachNumber(item, visit);
+};
+
+test("pairwise |Δ| uses min(a,b) and matches a hand-computed fixture", () => {
+	// 100, 110, 90 -> pairs 10/100, 10/90, 20/90 = 10%, 11.111111%, 22.222222%.
+	assert.deepEqual(
+		pairwiseAbsDeltasPct([100, 110, 90]).map(round6),
+		[10, 11.111111, 22.222222],
+	);
+	// Nearest rank, never interpolated: p95 of 1..20 is the 19th value, not 19.05.
+	const twenty = Array.from({ length: 20 }, (_, index) => index + 1);
+	assert.equal(percentileNearestRank(twenty, 0.95), 19);
+	assert.equal(
+		percentileNearestRank([10, 11.111111, 22.222222], 0.95),
+		22.222222,
+	);
+	assert.equal(median([50, 100, 200]), 100);
+	assert.equal(median([1, 2, 3, 4]), 2.5);
+
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, true);
+		assert.equal(report.pairsPerTask, 3);
+
+		const stats = findTask(report, "pid-convergence.json", "T").metrics.mean_ms;
+		assert.equal(stats.status, "ok");
+		assert.equal(stats.n, 3);
+		assert.equal(stats.pairs, 3);
+		assert.equal(stats.mean, 100);
+		assert.equal(stats.min, 90);
+		assert.equal(stats.max, 110);
+		assert.equal(stats.median_abs_delta_pct, 11.111111);
+		assert.equal(stats.p95_abs_delta_pct, 22.222222);
+		assert.equal(stats.max_abs_delta_pct, 22.222222);
+
+		// min(a,b) makes the floor invariant under hz = 1000/mean_ms...
+		const hz = findTask(report, "pid-convergence.json", "T").metrics.hz;
+		assert.deepEqual(
+			[hz.median_abs_delta_pct, hz.p95_abs_delta_pct, hz.max_abs_delta_pct],
+			[
+				stats.median_abs_delta_pct,
+				stats.p95_abs_delta_pct,
+				stats.max_abs_delta_pct,
+			],
+		);
+		// ...while the dispersion statistics are not, which is why both metrics
+		// are reported.
+		assert.notEqual(hz.cv_pct, stats.cv_pct);
+	});
+});
+
+test("stddev is the sample (n-1) form and CV is stddev/mean as a percent", () => {
+	withFixture((root) => {
+		// 2, 4, 6 -> mean 4, sample stddev 2, CV 50%.
+		for (const [run, meanMs] of [
+			["run-1", 2],
+			["run-2", 4],
+			["run-3", 6],
+		])
+			writeSuite(root, run, "document-put.json", suite(task("put", meanMs)));
+
+		const stats = analyze({ resultsDir: root, minRuns: 3 });
+		const put = findTask(stats, "document-put.json", "put").metrics.mean_ms;
+		assert.equal(put.mean, 4);
+		assert.equal(put.stddev, 2);
+		assert.equal(put.cv_pct, 50);
+		// Pairs: 2/2, 4/2, 2/4 -> 100%, 200%, 50%.
+		assert.equal(put.median_abs_delta_pct, 100);
+		assert.equal(put.max_abs_delta_pct, 200);
+		assert.equal(stats.summary.mean_ms.worstP95, 200);
+		assert.equal(stats.summary.mean_ms.tasksAbove10Pct, 1);
+	});
+});
+
+test("refuses to publish a floor built from fewer than --min-runs usable runs", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+
+		const { code, stdout, stderr } = captureCli([root]);
+		assert.equal(code, 1);
+
+		const report = JSON.parse(
+			fs.readFileSync(path.join(root, "noise-floor.json"), "utf8"),
+		);
+		assert.equal(report.minRuns, 3);
+		assert.equal(report.runCount, 2);
+		assert.equal(report.trustworthy, false);
+		const problem = report.problems.find(
+			(entry) => entry.code === "insufficient-runs",
+		);
+		assert.ok(problem, "expected an insufficient-runs problem");
+		assert.equal(problem.severity, "blocking");
+		assert.match(problem.message, /Only 2 usable run\(s\), need at least 3/);
+		assert.match(stdout, /NOT TRUSTWORTHY/);
+		assert.match(stdout, /insufficient-runs/);
+		assert.match(stderr, /blocking problem/);
+
+		// A third run clears it, and only then does the same data pass.
+		writeSuite(root, "run-3", "pid-convergence.json", suite(task("T", 90)));
+		assert.equal(captureCli([root]).code, 0);
+		// ...and an explicitly higher bar still refuses it.
+		const stricter = captureCli([root, "--min-runs", "5"]);
+		assert.equal(stricter.code, 1);
+		assert.match(stricter.stdout, /Only 3 usable run\(s\), need at least 5/);
+	});
+});
+
+test("refuses --min-runs below 2 instead of clamping it", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+
+		for (const argv of [
+			[root, "--min-runs", "1"],
+			[root, "--min-runs=0"],
+		]) {
+			const { code, stdout, stderr } = captureCli(argv);
+			assert.equal(code, 2, `expected a usage error for ${argv.join(" ")}`);
+			assert.match(stderr, /--min-runs must be at least 2/);
+			assert.match(stderr, /no spread to measure/);
+			assert.equal(stdout, "", "a refused invocation must not print a report");
+			assert.equal(
+				fs.existsSync(path.join(root, "noise-floor.json")),
+				false,
+				"a refused invocation must not write a report",
+			);
+		}
+
+		assert.equal(captureCli([root, "--min-runs", "two"]).code, 2);
+		assert.equal(captureCli([root, "--min-runs"]).code, 2);
+		assert.equal(captureCli([root, "--nonsense"]).code, 2);
+		assert.equal(captureCli([]).code, 2);
+	});
+});
+
+test("a task missing from some runs is blocking and its n is visible", () => {
+	withFixture((root) => {
+		writeSuite(
+			root,
+			"run-1",
+			"pid-convergence.json",
+			suite(task("A", 100), task("B", 50), task("C", 20)),
+		);
+		writeSuite(
+			root,
+			"run-2",
+			"pid-convergence.json",
+			suite(task("A", 104), task("B", 55)),
+		);
+		writeSuite(root, "run-3", "pid-convergence.json", suite(task("A", 96)));
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		assert.equal(report.runCount, 3);
+
+		const a = findTask(report, "pid-convergence.json", "A");
+		assert.equal(a.n, 3);
+		assert.equal(a.complete, true);
+		assert.equal(a.metrics.mean_ms.status, "ok");
+
+		const b = findTask(report, "pid-convergence.json", "B");
+		assert.equal(b.n, 2);
+		assert.equal(b.complete, false);
+		assert.deepEqual(b.absentIn, ["run-3"]);
+		assert.equal(b.metrics.mean_ms.pairs, 1);
+
+		const c = findTask(report, "pid-convergence.json", "C");
+		assert.equal(c.n, 1);
+		assert.deepEqual(c.absentIn, ["run-2", "run-3"]);
+		assert.equal(c.metrics.mean_ms.status, "insufficient-samples");
+		// A single sample has unknown spread; reporting 0 would read as "stable".
+		assert.equal(c.metrics.mean_ms.stddev, null);
+		assert.equal(c.metrics.mean_ms.cv_pct, null);
+		assert.equal(c.metrics.mean_ms.max_abs_delta_pct, null);
+
+		const missing = report.problems.filter(
+			(problem) => problem.code === "task-missing-in-run",
+		);
+		assert.deepEqual(
+			missing.map((problem) => `${problem.task}@${problem.run}`).sort(),
+			["B@run-3", "C@run-2", "C@run-3"],
+		);
+		assert.ok(missing.every((problem) => problem.severity === "blocking"));
+
+		const markdown = renderMarkdown(report);
+		assert.match(markdown, /\| B \| 2\/3 \|/);
+		assert.match(markdown, /\*\*n=2\/3\*\* \(absent: run-3\)/);
+		assert.match(markdown, /\*\*n=1\/3\*\* \(absent: run-2, run-3\)/);
+	});
+});
+
+test("a missing, empty, unparseable or task-less suite file is blocking, not skipped", () => {
+	const brokenRun3 = [
+		{ label: "missing", body: undefined, reason: "missing" },
+		{ label: "empty", body: "", reason: "empty" },
+		{ label: "unparseable", body: "{not json", reason: "unparseable" },
+		{
+			label: "no tasks",
+			body: { name: "fixture", tasks: [] },
+			reason: "no-tasks",
+		},
+		{
+			label: "tasks is not an array",
+			body: { name: "fixture", tasks: {} },
+			reason: "unparseable",
+		},
+	];
+
+	for (const broken of brokenRun3)
+		withFixture((root) => {
+			for (const [run, meanMs] of [
+				["run-1", 100],
+				["run-2", 110],
+				["run-3", 90],
+			]) {
+				// pid-convergence is healthy everywhere, so run-3 stays usable and the
+				// sweep's absence cannot be written off as a dead run.
+				writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+				if (run !== "run-3")
+					writeSuite(
+						root,
+						run,
+						"sync-batch-sweep.json",
+						suite(task("batch 256", meanMs)),
+					);
+			}
+			if (broken.body !== undefined)
+				writeSuite(root, "run-3", "sync-batch-sweep.json", broken.body);
+
+			const report = analyze({ resultsDir: root, minRuns: 3 });
+			const sweep = findSuite(report, "sync-batch-sweep.json");
+			assert.equal(report.trustworthy, false, broken.label);
+			assert.equal(sweep.status, "partial", broken.label);
+			assert.deepEqual(sweep.presentIn, ["run-1", "run-2"], broken.label);
+			assert.deepEqual(sweep.missingIn, ["run-3"], broken.label);
+
+			const problem = report.problems.find(
+				(entry) =>
+					entry.code === "suite-missing-in-run" &&
+					entry.suite === "sync-batch-sweep.json",
+			);
+			assert.ok(problem, broken.label);
+			assert.equal(problem.severity, "blocking", broken.label);
+			assert.equal(problem.run, "run-3", broken.label);
+			assert.equal(problem.reason, broken.reason, broken.label);
+
+			// The surviving runs must not be quietly promoted to a full sample.
+			const batch = findTask(report, "sync-batch-sweep.json", "batch 256");
+			assert.equal(batch.n, 2, broken.label);
+			assert.equal(batch.complete, false, broken.label);
+			assert.match(
+				renderMarkdown(report),
+				/missing or unreadable in run-3/,
+				broken.label,
+			);
+			// The healthy suite in the same runs is still reported.
+			assert.equal(
+				findTask(report, "pid-convergence.json", "T").metrics.mean_ms.status,
+				"ok",
+				broken.label,
+			);
+		});
+});
+
+test("a run directory with no readable suite is excluded and blocking", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+		fs.mkdirSync(path.join(root, "run-4"));
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.runCount, 3);
+		assert.deepEqual(report.excludedRuns, ["run-4"]);
+		assert.equal(report.trustworthy, false);
+		assert.ok(codes(report, "blocking").includes("unusable-run"));
+		// The exclusion must not turn into "T is missing from run-4" noise.
+		assert.equal(findTask(report, "pid-convergence.json", "T").complete, true);
+	});
+});
+
+test("zero, null, non-numeric and infinite values invalidate a metric instead of becoming 0%", () => {
+	withFixture((root) => {
+		// Every value is written as raw JSON text: Infinity has no JSON.stringify
+		// form, and `null` / `0` / `"12"` are exactly what a half-failed
+		// benchmark writes (`mean_ms: task.result?.mean ?? null`,
+		// `hz: mean_ms > 0 ? 1000 / mean_ms : 0`).
+		const rows = (ok, zero, nul, inf, str) => [
+			{ name: "ok-task", mean_ms: ok, hz: ok },
+			{ name: "zero-task", mean_ms: zero, hz: zero },
+			{ name: "null-task", mean_ms: nul, hz: nul },
+			{ name: "inf-task", mean_ms: inf, hz: inf },
+			{ name: "string-task", mean_ms: str, hz: str },
+		];
+		writeSuite(
+			root,
+			"run-1",
+			"chunk-transfer.json",
+			rawSuite(rows("10", "10", "10", "10", "10")),
+		);
+		writeSuite(
+			root,
+			"run-2",
+			"chunk-transfer.json",
+			rawSuite(rows("10.5", "0", "10.5", "10.5", "10.5")),
+		);
+		writeSuite(
+			root,
+			"run-3",
+			"chunk-transfer.json",
+			rawSuite(rows("9.8", "9.8", "null", "1e999", '"12"')),
+		);
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+
+		const expected = [
+			["zero-task", "run-2", "not positive (0)"],
+			["null-task", "run-3", "missing (null)"],
+			["inf-task", "run-3", "Infinity"],
+			["string-task", "run-3", "non-numeric (string)"],
+		];
+		for (const [name, run, reason] of expected)
+			for (const metric of ["mean_ms", "hz"]) {
+				const stats = findTask(report, "chunk-transfer.json", name).metrics[
+					metric
+				];
+				assert.equal(stats.status, "invalid", `${name}.${metric}`);
+				assert.deepEqual(
+					stats.invalidSamples,
+					[{ run, reason }],
+					`${name}.${metric}`,
+				);
+				// No 0%, no Infinity, no NaN leaking into the floor.
+				assert.equal(stats.max_abs_delta_pct, null, `${name}.${metric}`);
+				assert.equal(stats.p95_abs_delta_pct, null, `${name}.${metric}`);
+				assert.equal(stats.cv_pct, null, `${name}.${metric}`);
+				assert.equal(stats.noVariationResolved, false, `${name}.${metric}`);
+			}
+
+		const blocking = report.problems.filter(
+			(problem) => problem.code === "invalid-metric-value",
+		);
+		assert.equal(blocking.length, expected.length * 2);
+		assert.ok(blocking.every((problem) => problem.severity === "blocking"));
+
+		// The healthy task in the same suite is still measured.
+		assert.equal(
+			findTask(report, "chunk-transfer.json", "ok-task").metrics.mean_ms.status,
+			"ok",
+		);
+
+		// Nothing anywhere in the serialised report is NaN or Infinity.
+		const serialised = JSON.parse(JSON.stringify(report));
+		forEachNumber(serialised, (value) =>
+			assert.ok(
+				Number.isFinite(value),
+				`non-finite number in the report: ${value}`,
+			),
+		);
+		// "Infinity" may appear as a diagnostic reason, but never as a rendered
+		// statistic: every invalid cell must be "-".
+		const markdown = renderMarkdown(report);
+		assert.doesNotMatch(markdown, /\|\s*-?(NaN|Infinity)\s*\|/);
+		assert.match(
+			markdown,
+			/\| inf-task \| 3\/3 \| - \| - \| - \| - \| - \| - \| - \| - \|/,
+		);
+		assert.match(markdown, /\*\*invalid\*\*: run-2 not positive \(0\)/);
+		assert.match(markdown, /\*\*invalid\*\*: run-3 Infinity/);
+	});
+});
+
+test("a task with no resolved variation is labelled without claiming determinism", () => {
+	withFixture((root) => {
+		for (const run of ["run-1", "run-2", "run-3"])
+			writeSuite(
+				root,
+				run,
+				"pid-convergence.json",
+				suite(task("PID convergence (model)", 12.5)),
+			);
+
+		const { code, stdout } = captureCli([root]);
+		assert.equal(code, 0, "a deterministic benchmark is not a failure");
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		const stats = findTask(
+			report,
+			"pid-convergence.json",
+			"PID convergence (model)",
+		).metrics.mean_ms;
+		assert.equal(stats.status, "ok");
+		assert.equal(stats.n, 3);
+		assert.equal(stats.max_abs_delta_pct, 0);
+		assert.equal(stats.p95_abs_delta_pct, 0);
+		assert.equal(stats.cv_pct, 0);
+		assert.equal(stats.noVariationResolved, true);
+
+		const notes = report.problems.filter(
+			(problem) => problem.code === "no-variation-resolved",
+		);
+		assert.equal(notes.length, 2, "one note per metric");
+		assert.ok(notes.every((note) => note.severity === "note"));
+		assert.match(notes[0].message, /identical .* in all 3 runs/);
+		// The note must describe the OBSERVATION and refuse to name a cause. A
+		// zero floor is indistinguishable from variation below the source's
+		// rounding step (document-put emits round(opsPerSecond)), so claiming
+		// "deterministic" would bless every later A/B delta on this task.
+		assert.match(notes[0].message, /below the resolution/i);
+		assert.doesNotMatch(
+			notes[0].message,
+			/deterministic|reproducible|real observation/i,
+			"must not assert a cause the data cannot distinguish",
+		);
+		assert.equal(report.summary.mean_ms.noVariationTasks, 1);
+		assert.equal(report.summary.mean_ms.worstP95, 0);
+
+		assert.match(stdout, /`no variation resolved`/);
+		assert.match(stdout, /TRUSTWORTHY/);
+	});
+});
+
+test("output ordering is deterministic and independent of filesystem order", () => {
+	withFixture((root) => {
+		// Created out of order, with task names written in reverse.
+		for (const [run, meanMs] of [
+			["run-10", 90],
+			["run-2", 110],
+			["run-1", 100],
+		])
+			writeSuite(
+				root,
+				run,
+				"pid-convergence.json",
+				suite(task("zeta", meanMs), task("mid", meanMs), task("alpha", meanMs)),
+			);
+
+		const first = analyze({ resultsDir: root, minRuns: 3 });
+		const second = analyze({ resultsDir: root, minRuns: 3 });
+
+		// run-10 sorts after run-2, not between run-1 and run-2.
+		assert.deepEqual(
+			first.runs.map((run) => run.name),
+			["run-1", "run-2", "run-10"],
+		);
+		assert.deepEqual(
+			findSuite(first, "pid-convergence.json").tasks.map((entry) => entry.name),
+			["alpha", "mid", "zeta"],
+		);
+		assert.deepEqual(
+			first.suites.map((entry) => entry.file),
+			second.suites.map((entry) => entry.file),
+		);
+		assert.equal(JSON.stringify(first), JSON.stringify(second));
+		assert.equal(renderMarkdown(first), renderMarkdown(second));
+		// No wall clock anywhere in the computed output.
+		assert.doesNotMatch(
+			JSON.stringify(first),
+			/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/,
+			"the report must not embed a timestamp",
+		);
+	});
+});
+
+test("suites nobody collected warn; unknown files in a run warn; neither blocks", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+		fs.writeFileSync(
+			path.join(root, "run-2", "rateless-iblt-startsync-cach.json"),
+			"{}",
+		);
+
+		const { code, stdout } = captureCli([
+			root,
+			"--json-out",
+			path.join(root, "nested", "report.json"),
+		]);
+		assert.equal(code, 0);
+
+		const report = JSON.parse(
+			fs.readFileSync(path.join(root, "nested", "report.json"), "utf8"),
+		);
+		assert.equal(report.trustworthy, true);
+		assert.equal(report.suitesCollected, 1);
+		assert.equal(report.suitesKnown, 7);
+		assert.equal(
+			report.problems.filter(
+				(problem) => problem.code === "suite-not-collected",
+			).length,
+			6,
+		);
+		const unknown = report.problems.find(
+			(problem) => problem.code === "unrecognized-file",
+		);
+		assert.equal(unknown.severity, "warning");
+		assert.match(unknown.message, /rateless-iblt-startsync-cach\.json/);
+		assert.match(stdout, /Suites collected: 1\/7/);
+		assert.match(stdout, /_Not collected in any run/);
+		assert.equal(fs.existsSync(path.join(root, "noise-floor.json")), false);
+	});
+});
+
+test("duplicate task rows within one run are blocking", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(
+				root,
+				run,
+				"file-ingest.json",
+				suite(
+					task("ingest", meanMs),
+					...(run === "run-2" ? [task("ingest", 4000)] : []),
+				),
+			);
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		const problem = report.problems.find(
+			(entry) => entry.code === "duplicate-task",
+		);
+		assert.equal(problem.severity, "blocking");
+		assert.equal(problem.run, "run-2");
+		// The first row wins, so the duplicate cannot silently inflate the floor.
+		assert.equal(
+			findTask(report, "file-ingest.json", "ingest").metrics.mean_ms.max,
+			110,
+		);
+	});
+});
+
+test("an empty results directory is reported, not treated as a clean run", () => {
+	withFixture((root) => {
+		const { code, stdout } = captureCli([root]);
+		assert.equal(code, 1);
+		assert.match(stdout, /NOT TRUSTWORTHY/);
+		const report = JSON.parse(
+			fs.readFileSync(path.join(root, "noise-floor.json"), "utf8"),
+		);
+		assert.equal(report.runCount, 0);
+		assert.ok(codes(report, "blocking").includes("no-runs"));
+		assert.ok(codes(report, "blocking").includes("insufficient-runs"));
+		assert.equal(report.summary.mean_ms.tasksMeasured, 0);
+	});
+
+	const missing = captureCli([
+		path.join(os.tmpdir(), "peerbit-noise-floor-does-not-exist"),
+	]);
+	assert.equal(missing.code, 2);
+	assert.match(missing.stderr, /Results directory does not exist/);
+});
+
+// --- D1: document-put.json is a `rows` file, not a `tasks` file -------------
+
+test("document-put's real `rows` shape is read, with totalPutMs/opsPerSecond as the two metrics", () => {
+	withFixture((root) => {
+		// 10 iterations, so opsPerSecond is exactly 10000/totalPutMs and the
+		// reciprocal invariance of |Δ%| is exact rather than rounded.
+		for (const [run, totalPutMs] of [
+			["run-1", 100],
+			["run-2", 125],
+			["run-3", 200],
+		])
+			writeSuite(
+				root,
+				run,
+				"document-put.json",
+				documentPutSuite(
+					documentPutRow("put 1024b", totalPutMs),
+					documentPutRow("native-ceiling", totalPutMs * 2),
+				),
+			);
+
+		const { code } = captureCli([root]);
+		assert.equal(code, 0, "the real document-put shape must not be rejected");
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		const put = findSuite(report, "document-put.json");
+		assert.equal(put.status, "ok");
+		// Task names come from the row's own `name`, and every row is a task.
+		assert.deepEqual(
+			put.tasks.map((entry) => entry.name),
+			["native-ceiling", "put 1024b"],
+		);
+
+		const mean = findTask(report, "document-put.json", "put 1024b").metrics
+			.mean_ms;
+		assert.equal(mean.status, "ok");
+		assert.equal(mean.n, 3);
+		// mean_ms is read from totalPutMs: 100, 125, 200.
+		assert.equal(mean.min, 100);
+		assert.equal(mean.max, 200);
+		// Pairs: 25/100, 100/100, 75/125 -> 25%, 100%, 60%.
+		assert.equal(mean.median_abs_delta_pct, 60);
+		assert.equal(mean.max_abs_delta_pct, 100);
+
+		const hz = findTask(report, "document-put.json", "put 1024b").metrics.hz;
+		assert.equal(hz.status, "ok");
+		// hz is read from opsPerSecond: 100, 80, 50 ops/s.
+		assert.equal(hz.min, 50);
+		assert.equal(hz.max, 100);
+		// Exactly proportional to 1/totalPutMs, so the floor is identical...
+		assert.equal(hz.median_abs_delta_pct, mean.median_abs_delta_pct);
+		assert.equal(hz.max_abs_delta_pct, mean.max_abs_delta_pct);
+		// ...while CV is not reciprocal-invariant, which is why both are kept.
+		assert.notEqual(hz.cv_pct, mean.cv_pct);
+
+		// The suite reaches the headline instead of silently leaving it.
+		assert.equal(report.summary.mean_ms.tasksMeasured, 2);
+		assert.equal(report.summary.mean_ms.worstMax, 100);
+		assert.equal(report.suitesCollected, 1);
+	});
+});
+
+test("a `rows` row without totalPutMs or opsPerSecond is blocking and names the field", () => {
+	for (const field of ["totalPutMs", "opsPerSecond"])
+		withFixture((root) => {
+			for (const [run, totalPutMs] of [
+				["run-1", 100],
+				["run-2", 125],
+				["run-3", 200],
+			]) {
+				const row = documentPutRow("put 1024b", totalPutMs);
+				if (run === "run-2") delete row[field];
+				writeSuite(root, run, "document-put.json", documentPutSuite(row));
+			}
+
+			const { code } = captureCli([root]);
+			assert.equal(code, 1, field);
+
+			const report = analyze({ resultsDir: root, minRuns: 3 });
+			assert.equal(report.trustworthy, false, field);
+			const metric = field === "totalPutMs" ? "mean_ms" : "hz";
+			const stats = findTask(report, "document-put.json", "put 1024b").metrics[
+				metric
+			];
+			// Not skipped, not coerced to 0, not averaged over the two survivors.
+			assert.equal(stats.status, "invalid", field);
+			assert.deepEqual(
+				stats.invalidSamples,
+				[{ run: "run-2", reason: "missing (absent field)" }],
+				field,
+			);
+			assert.equal(stats.max_abs_delta_pct, null, field);
+
+			const problem = report.problems.find(
+				(entry) => entry.code === "invalid-metric-value",
+			);
+			assert.equal(problem.severity, "blocking", field);
+			assert.equal(problem.sourceField, field);
+			assert.match(problem.message, new RegExp(`row field "${field}"`), field);
+			// The other metric of the same row is untouched.
+			const other = field === "totalPutMs" ? "hz" : "mean_ms";
+			assert.equal(
+				findTask(report, "document-put.json", "put 1024b").metrics[other]
+					.status,
+				"ok",
+				field,
+			);
+		});
+});
+
+test("a suite file with neither `tasks` nor `rows` is unparseable, not empty of tasks", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		]) {
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+			writeSuite(
+				root,
+				run,
+				"file-ingest.json",
+				run === "run-3"
+					? { name: "file-ingest", meta: {} }
+					: suite(task("ingest", meanMs)),
+			);
+		}
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		const problem = report.problems.find(
+			(entry) =>
+				entry.code === "suite-missing-in-run" &&
+				entry.suite === "file-ingest.json",
+		);
+		assert.equal(problem.reason, "unparseable");
+		assert.match(problem.message, /no `tasks` array and no `rows` array/);
+	});
+
+	// `tasks` wins when a file somehow carries both.
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "document-put.json", {
+				name: "document-put",
+				tasks: [task("from-tasks", meanMs)],
+				rows: [documentPutRow("from-rows", meanMs)],
+			});
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.deepEqual(
+			findSuite(report, "document-put.json").tasks.map((entry) => entry.name),
+			["from-tasks"],
+		);
+	});
+});
+
+// --- D2: present-but-unreadable everywhere is a collection failure ----------
+
+test("a suite unreadable in EVERY run is blocking and exits non-zero, with the reason in the JSON", () => {
+	const broken = [
+		{ label: "empty", body: "", reason: "empty" },
+		{ label: "unparseable", body: "{not json", reason: "unparseable" },
+		{
+			label: "wrong shape",
+			body: { name: "chunk-transfer", meta: {} },
+			reason: "unparseable",
+		},
+		{
+			label: "zero tasks",
+			body: { name: "chunk-transfer", tasks: [] },
+			reason: "no-tasks",
+		},
+	];
+
+	for (const kind of broken)
+		withFixture((root) => {
+			// A quiet suite and a noisy one. The noisy one is the whole point: it is
+			// the task that sets the headline, so losing it is what understates.
+			for (const [run, quiet, noisy] of [
+				["run-1", 1000, 1000],
+				["run-2", 1001, 1600],
+				["run-3", 1000.5, 1200],
+			]) {
+				writeSuite(
+					root,
+					run,
+					"pid-convergence.json",
+					suite(task("quiet", quiet)),
+				);
+				writeSuite(
+					root,
+					run,
+					"chunk-transfer.json",
+					suite(task("noisy", noisy)),
+				);
+			}
+
+			// Healthy baseline: the noisy task sets a 60% headline.
+			const healthy = analyze({ resultsDir: root, minRuns: 3 });
+			assert.equal(healthy.trustworthy, true, kind.label);
+			assert.equal(healthy.summary.mean_ms.tasksMeasured, 2, kind.label);
+			assert.equal(healthy.summary.mean_ms.worstMax, 60, kind.label);
+
+			// Now break the noisy suite in EVERY run.
+			for (const run of ["run-1", "run-2", "run-3"])
+				writeSuite(root, run, "chunk-transfer.json", kind.body);
+
+			const { code, stdout, stderr } = captureCli([root]);
+			assert.equal(
+				code,
+				1,
+				`${kind.label}: a systematically broken suite must exit non-zero`,
+			);
+			assert.match(stderr, /blocking problem/, kind.label);
+
+			const report = JSON.parse(
+				fs.readFileSync(path.join(root, "noise-floor.json"), "utf8"),
+			);
+			assert.equal(report.trustworthy, false, kind.label);
+			// The headline really did collapse; the point is that it is now loud.
+			assert.equal(report.summary.mean_ms.tasksMeasured, 1, kind.label);
+			assert.equal(report.summary.mean_ms.worstMax, 0.1, kind.label);
+
+			const suiteReport = findSuite(report, "chunk-transfer.json");
+			assert.equal(suiteReport.status, "unreadable-everywhere", kind.label);
+			assert.match(suiteReport.reason, /present but unreadable/, kind.label);
+			assert.deepEqual(
+				suiteReport.missingReasons.map((entry) => entry.reason),
+				[kind.reason, kind.reason, kind.reason],
+				kind.label,
+			);
+			assert.ok(
+				suiteReport.missingReasons.every((entry) => entry.detail),
+				`${kind.label}: every missing run must carry a detail`,
+			);
+			// It must NOT be counted as collected.
+			assert.equal(report.suitesCollected, 1, kind.label);
+			assert.deepEqual(
+				report.suitesUnreadableEverywhere,
+				["chunk-transfer.json"],
+				kind.label,
+			);
+
+			const problems = report.problems.filter(
+				(entry) => entry.code === "suite-unreadable-everywhere",
+			);
+			assert.equal(problems.length, 3, kind.label);
+			assert.ok(
+				problems.every((entry) => entry.severity === "blocking"),
+				kind.label,
+			);
+			assert.ok(
+				problems.every((entry) => entry.suite === "chunk-transfer.json"),
+				kind.label,
+			);
+			assert.equal(problems[0].reason, kind.reason, kind.label);
+			// And it must not be filed as a benign deselection.
+			assert.equal(
+				report.problems.filter(
+					(entry) =>
+						entry.code === "suite-not-collected" &&
+						entry.suite === "chunk-transfer.json",
+				).length,
+				0,
+				kind.label,
+			);
+
+			assert.match(stdout, /NOT TRUSTWORTHY/, kind.label);
+			assert.match(
+				stdout,
+				/Suites present but unreadable in every run: chunk-transfer\.json/,
+				kind.label,
+			);
+			assert.match(stdout, /Present but unreadable in every run/, kind.label);
+		});
+});
+
+test("a suite that is unreadable in some runs and absent in the rest is still blocking", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+		// Present-but-broken in run-1 only; simply absent from run-2 and run-3.
+		writeSuite(root, "run-1", "file-ingest.json", "{not json");
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		const suiteReport = findSuite(report, "file-ingest.json");
+		assert.equal(suiteReport.status, "unreadable-everywhere");
+		assert.deepEqual(
+			suiteReport.missingReasons.map((entry) => `${entry.run}:${entry.reason}`),
+			["run-1:unparseable", "run-2:missing", "run-3:missing"],
+		);
+		const problems = report.problems.filter(
+			(entry) => entry.code === "suite-unreadable-everywhere",
+		);
+		// Only the run where the file actually existed is accused.
+		assert.equal(problems.length, 1);
+		assert.equal(problems[0].run, "run-1");
+	});
+});
+
+test("a suite genuinely absent (ENOENT) everywhere stays a warning, and says why", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+
+		const { code, stdout } = captureCli([root]);
+		assert.equal(code, 0, "a deselected suite is not a failure");
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		const suiteReport = findSuite(report, "document-put.json");
+		assert.equal(suiteReport.status, "not-collected");
+		assert.match(suiteReport.reason, /absent \(file not found\) in every/);
+		assert.deepEqual(
+			suiteReport.missingReasons.map((entry) => entry.reason),
+			["missing", "missing", "missing"],
+		);
+		const warning = report.problems.find(
+			(entry) =>
+				entry.code === "suite-not-collected" &&
+				entry.suite === "document-put.json",
+		);
+		assert.equal(warning.severity, "warning");
+		assert.equal(warning.reason, "missing");
+		assert.equal(report.suitesUnreadableEverywhere.length, 0);
+		assert.match(
+			stdout,
+			/Not collected in any run \(absent \(file not found\)/,
+		);
+	});
+});
+
+// --- D3: the headline summary itself ---------------------------------------
+
+test("the headline aggregates per-task maxima and names the worst task", () => {
+	withFixture((root) => {
+		// Three tasks with deliberately different spreads, across two suites, so
+		// both the aggregate and the identity of the worst task are observable.
+		//   steady   1000, 1002, 1001 -> max 0.2%
+		//   middling 1000, 1070, 1030 -> max 7%
+		//   wild     1000, 1750, 1200 -> max 75%
+		for (const [run, steady, middling, wild] of [
+			["run-1", 1000, 1000, 1000],
+			["run-2", 1002, 1070, 1750],
+			["run-3", 1001, 1030, 1200],
+		]) {
+			writeSuite(
+				root,
+				run,
+				"pid-convergence.json",
+				suite(task("steady", steady), task("middling", middling)),
+			);
+			writeSuite(root, run, "chunk-transfer.json", suite(task("wild", wild)));
+		}
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, true);
+
+		const perTask = (file, name) =>
+			findTask(report, file, name).metrics.mean_ms.max_abs_delta_pct;
+		assert.equal(perTask("pid-convergence.json", "steady"), 0.2);
+		assert.equal(perTask("pid-convergence.json", "middling"), 7);
+		assert.equal(perTask("chunk-transfer.json", "wild"), 75);
+
+		const summary = report.summary.mean_ms;
+		assert.equal(summary.tasksMeasured, 3);
+		// Median of {0.2, 7, 75}. NOT the min (0.2) and NOT the max (75).
+		assert.equal(summary.medianOfMax, 7);
+		assert.equal(summary.worstMax, 75);
+		assert.deepEqual(summary.worstTask, {
+			suite: "chunk-transfer.json",
+			task: "wild",
+		});
+		assert.equal(summary.tasksAbove5Pct, 2);
+		assert.equal(summary.tasksAbove10Pct, 1);
+		assert.equal(summary.noVariationTasks, 0);
+		// The secondary p95 aggregate is pinned too, at its own values.
+		assert.equal(summary.medianOfP95, 7);
+		assert.equal(summary.worstP95, 75);
+		// hz is reciprocal-invariant, so the same aggregate must fall out of it.
+		assert.equal(report.summary.hz.medianOfMax, 7);
+		assert.deepEqual(report.summary.hz.worstTask, summary.worstTask);
+
+		// ...and the rendered headline carries all three numbers.
+		const markdown = renderMarkdown(report);
+		assert.match(
+			markdown,
+			/\| mean_ms \| 3 \| 7\.00% \| 75\.00% \| chunk-transfer\.json › wild \| 2 \| 1 \| 0 \|/,
+		);
+		assert.match(markdown, /median max \\\|Δ\\\|/);
+		assert.match(markdown, /Secondary: p95 over 3 pair\(s\) per task/);
+	});
+
+	// A tie is broken by (suite, task) so the named worst task is stable, and the
+	// tie-break must not be able to pick the quiet task instead.
+	withFixture((root) => {
+		for (const [run, wild] of [
+			["run-1", 1000],
+			["run-2", 1750],
+			["run-3", 1200],
+		]) {
+			writeSuite(root, run, "chunk-transfer.json", suite(task("wild", wild)));
+			writeSuite(root, run, "file-ingest.json", suite(task("wild", wild)));
+			writeSuite(root, run, "pid-convergence.json", suite(task("calm", 1000)));
+		}
+
+		const summary = analyze({ resultsDir: root, minRuns: 3 }).summary.mean_ms;
+		assert.equal(summary.worstMax, 75);
+		assert.deepEqual(summary.worstTask, {
+			suite: "chunk-transfer.json",
+			task: "wild",
+		});
+		// {0, 75, 75} -> median 75, so a "median" that quietly became a min or a
+		// mean would not survive here either.
+		assert.equal(summary.medianOfMax, 75);
+	});
+});
+
+test("tasks without a name are blocking, and a file of only unnamed rows has no tasks", () => {
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(
+				root,
+				run,
+				"pid-convergence.json",
+				// The unnamed entry cannot be matched across runs, so it is refused
+				// rather than positionally guessed at.
+				`{"name":"fixture","tasks":[{"name":"T","mean_ms":${meanMs},"hz":${1000 / meanMs}},{"mean_ms":1,"hz":1000}]}`,
+			);
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		const problems = report.problems.filter(
+			(entry) => entry.code === "unnamed-task",
+		);
+		assert.equal(problems.length, 3, "one per run");
+		assert.ok(problems.every((entry) => entry.severity === "blocking"));
+		assert.match(problems[0].message, /1 task\(s\) without a name/);
+		// The named task in the same file is still measured.
+		assert.equal(
+			findTask(report, "pid-convergence.json", "T").metrics.mean_ms.status,
+			"ok",
+		);
+	});
+
+	// Unnamed rows in the `rows` shape count the same way, and a file made only
+	// of them is "no-tasks" rather than silently empty.
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		]) {
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+			const anonymous = documentPutRow("put", meanMs);
+			delete anonymous.name;
+			writeSuite(root, run, "document-put.json", documentPutSuite(anonymous));
+		}
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(report.trustworthy, false);
+		assert.equal(
+			findSuite(report, "document-put.json").status,
+			"unreadable-everywhere",
+		);
+		const problem = report.problems.find(
+			(entry) => entry.code === "suite-unreadable-everywhere",
+		);
+		assert.equal(problem.reason, "no-tasks");
+		assert.match(
+			problem.detail,
+			/zero named rows \(1 entr\(y\/ies\) had no name\)/,
+		);
+	});
+});
+
+test("the coarse-p95 note appears exactly when nearest-rank p95 is the maximum", () => {
+	// Derived, not a hard-coded pair count: ceil(0.95 * pairs) === pairs.
+	assert.equal(p95IsJustTheMaximum(0), false);
+	assert.equal(p95IsJustTheMaximum(10), true);
+	assert.equal(p95IsJustTheMaximum(19), true);
+	assert.equal(p95IsJustTheMaximum(20), false);
+	assert.equal(p95IsJustTheMaximum(21), false);
+
+	const noteFor = (runCount) =>
+		withFixture((root) => {
+			for (let index = 1; index <= runCount; index++)
+				writeSuite(
+					root,
+					`run-${index}`,
+					"pid-convergence.json",
+					suite(task("T", 100 + index)),
+				);
+			return analyze({ resultsDir: root, minRuns: 3 });
+		});
+
+	// 3 runs -> 3 pairs: the "p95" is the maximum and says so.
+	const coarse = noteFor(3);
+	const note = coarse.problems.find((entry) => entry.code === "coarse-p95");
+	assert.equal(note.severity, "note");
+	assert.equal(note.pairs, 3);
+	assert.match(note.message, /ceil\(0\.95 \* 3\) = 3/);
+	assert.match(note.message, /the headline is the max either way/);
+	assert.equal(coarse.summary.mean_ms.p95IsJustTheMaximum, true);
+	assert.equal(coarse.summary.mean_ms.pairsPerTask, 3);
+	assert.match(renderMarkdown(coarse), /so this p95 \*\*is\*\* the maximum/);
+
+	// 7 runs -> 21 pairs: p95 finally separates from the maximum, so the note
+	// disappears and the report stops claiming the two are the same.
+	const fine = noteFor(7);
+	assert.equal(
+		fine.problems.filter((entry) => entry.code === "coarse-p95").length,
+		0,
+	);
+	assert.equal(fine.summary.mean_ms.p95IsJustTheMaximum, false);
+	assert.equal(fine.summary.mean_ms.pairsPerTask, 21);
+	assert.match(
+		renderMarkdown(fine),
+		/this p95 sits below the observed maximum/,
+	);
+});
+
+// --- D4: the headline must not shrink when runs are added ------------------
+
+test("adding runs never lowers the headline, though it does lower the p95", () => {
+	withFixture((root) => {
+		const write = (run, meanMs) =>
+			writeSuite(root, run, "pid-convergence.json", suite(task("T", meanMs)));
+		// One outlier pair (90 vs 110) sets the true worst A/A gap at 22.22%.
+		for (const [run, meanMs] of [
+			["run-1", 90],
+			["run-2", 100],
+			["run-3", 100],
+			["run-4", 100],
+			["run-5", 110],
+		])
+			write(run, meanMs);
+
+		const five = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(five.pairsPerTask, 10);
+		assert.equal(five.summary.mean_ms.worstMax, 22.222222);
+		assert.equal(five.summary.mean_ms.worstP95, 22.222222);
+		assert.equal(five.summary.mean_ms.p95IsJustTheMaximum, true);
+
+		// Two more runs of the SAME code, contributing no new extreme.
+		write("run-6", 100);
+		write("run-7", 100);
+
+		const seven = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(seven.pairsPerTask, 21);
+		// The defect this pins: p95 HALVES on unchanged data purely because the
+		// nearest rank moved off the last element.
+		assert.equal(seven.summary.mean_ms.worstP95, 11.111111);
+		assert.equal(seven.summary.mean_ms.p95IsJustTheMaximum, false);
+		// The headline does not move, because pairs only accumulate.
+		assert.equal(seven.summary.mean_ms.worstMax, 22.222222);
+		assert.ok(
+			seven.summary.mean_ms.worstMax >= five.summary.mean_ms.worstMax,
+			"more runs must never lower the headline for unchanged data",
+		);
+		assert.ok(
+			seven.summary.mean_ms.medianOfMax >= five.summary.mean_ms.medianOfMax,
+			"more runs must never lower the median headline either",
+		);
+		assert.ok(
+			seven.summary.mean_ms.worstP95 < five.summary.mean_ms.worstP95,
+			"the p95 is expected to fall here; that is why it is not the headline",
+		);
+
+		// The decision rule the report states must point at the max, and the
+		// headline table must carry it.
+		const markdown = renderMarkdown(seven);
+		assert.match(markdown, /\| mean_ms \| 1 \| 22\.22% \| 22\.22% \|/);
+		assert.match(markdown, /exceeds T's A\/A max \\?\|Δ%\\?\|/);
+		assert.match(markdown, /observed maximum/);
+		assert.match(seven.headlineStatistic, /^max \|Δ%\|/);
+		assert.match(seven.decisionRule, /max \|Δ%\|/);
+	});
+});
+
+test("byte-identical run directories are called out instead of yielding a silent 0% floor", () => {
+	withFixture((root) => {
+		for (const run of ["run-1", "run-2", "run-3"])
+			writeSuite(root, run, "file-ingest.json", suite(task("ingest", 12.5)));
+
+		const { code, stdout } = captureCli([root]);
+		// Still a warning, not a refusal: a genuinely deterministic model suite
+		// can legitimately emit the same bytes twice.
+		assert.equal(code, 0);
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		const warning = report.problems.find(
+			(entry) => entry.code === "duplicate-run-input",
+		);
+		assert.equal(warning.severity, "warning");
+		assert.deepEqual(warning.runs, ["run-1", "run-2", "run-3"]);
+		assert.match(warning.message, /fabricated 0%/);
+		assert.match(stdout, /duplicate-run-input/);
+	});
+
+	// Control: real runs differ, so no warning.
+	withFixture((root) => {
+		for (const [run, meanMs] of [
+			["run-1", 100],
+			["run-2", 110],
+			["run-3", 90],
+		])
+			writeSuite(root, run, "file-ingest.json", suite(task("ingest", meanMs)));
+
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(
+			report.problems.filter((entry) => entry.code === "duplicate-run-input")
+				.length,
+			0,
+		);
+	});
+});


### PR DESCRIPTION
## The problem

`benchmarks.yml` prints a per-task `Δ mean %` for a PR's base vs head and says nothing about how large a Δ has to be before it means anything. The only guidance was folklore: identical code moving ±10%.

The folklore was optimistic. Two merged refactors that changed no behaviour, re-derived from their own uploaded artifacts:

| PR | n | median \|Δ\| | p90 | max |
|---|---|---|---|---|
| [#1182](https://github.com/dao-xyz/peerbit/pull/1182) | 45 | 4.7% | 14.2% | **155.9%** |
| [#1176](https://github.com/dao-xyz/peerbit/pull/1176) | 45 | 5.3% | 21.5% | 43.5% |

A **156% "regression"** on a byte-identical handler extraction.

It is measurement, not code — the direction is a coin flip. #1182 was 12 slower vs 33 faster with a median of **−3.3%**; #1176 was 24 vs 21 with a median of +0.6%. Two refactors landing on opposite sides of zero is what noise looks like. And the mean is the wrong statistic on a distribution with that tail.

It is also very unevenly distributed, which is the useful part:

| suite | max \|Δ\| #1182 / #1176 |
|---|---|
| `sync-batch-sweep` | 3.7% / 3.4% |
| `pid-convergence` | 4.7% / 3.4% |
| `rateless-iblt-sender-startsync` | 4.4% / 0.9% |
| `rateless-iblt-startsync-cache` | 11.4% / 14.4% |
| `file-ingest` | **155.9% / 43.5%** |

Three of five suites hold inside ~5% on identical-behaviour code. `file-ingest` carries the entire tail.

## What this adds

`workflow_dispatch` job that builds one commit once, runs the suites N times, and reports per (suite, task, metric) the distribution of `|Δ%|` over all `C(N,2)` unordered run pairs.

**The headline is the observed maximum, not the p95.** Understating a noise floor is the catastrophic direction — it makes every perf claim look significant — and the max is the only one of the three that cannot understate what was actually observed. It is also monotone in the run count, where nearest-rank p95 over `C(N,2)` pairs is not: it equals the maximum up to 6 runs and steps down at 7, so quoting p95 would let *more measurement shrink the published floor*. That was a real defect in an earlier revision, caught by review and pinned by a test. p95 remains as a secondary column, always labelled with its pair count.

`|Δ%|` divides by `min(a, b)` rather than a nominated base: either run of an A/A pair could have been the base, so this reports the larger of the two readings. It also makes the floor invariant under the reciprocal, so `mean_ms` and `hz` agree.

## Every degradation path is blocking

A floor computed from the runs that happened to survive is biased toward stability, so the script never averages over whatever it found. Blocking: fewer than `--min-runs` usable runs; `--min-runs < 2`; a suite present but unreadable; a task missing from some runs; `null`/`NaN`/`Infinity`/`<= 0` values.

This was not theoretical. An earlier revision treated "suite unreadable in every run" as a warning, so a systematically broken suite quietly left the denominator — measured on a fixture, the headline fell from **55.56% to 2.02%** (a 27× understatement) while still printing `trustworthy: true` and exiting 0. It now exits non-zero and names the suite.

## Two things it refuses to claim

- A zero floor is `no variation resolved`, **never** `deterministic`. Identical values are indistinguishable from variation below the source's rounding step, and `document-put` emits `round(opsPerSecond)` — 0.05% at 2000 ops/s but 4% at 24. It names the observation and refuses to name the cause.
- A suite absent everywhere says it cannot tell deselection from a step that never wrote its file, because it does not read the job metadata.

Both replaced messages that asserted causes the code cannot observe.

## Bugs found in existing code (noted, not fixed here)

- **`document-put.json` has never had the assumed shape.** It emits `{rows:[{name, opsPerSecond, totalPutMs, ...}]}`, never tinybench's `{tasks:[...]}`. `benchmarks.yml:482` reads `.tasks`, so its **"document: put" A/B table has been rendering empty since it was added** — a benchmark costing CI time every run and displaying nothing. This PR teaches the reporter both shapes; fixing `benchmarks.yml` is a separate change.
- **`pid-convergence`'s `memory-limited (2 peers, 25% cap)` emits `mean_ms = null`** in all four real artifacts. The A/B report renders it as `-`. Surfaced by running this tool end-to-end against the real #1182/#1176 outputs.

## Verification

24 tests, wired into CI via `node --test scripts/bench/*.spec.mjs` — globbed, because an unrun spec would defeat a tool whose entire purpose is refusing to publish an understated number.

Mutation-verified: restoring the `deterministic` claim turns the label test red; reverting the fail-open turns 3 red; `medianOfMax → min`, reversed worst-task sort, and `max → p95` in the summary each kill the spec.

Green with exit statuses captured directly, not through a pipe: `node --test scripts/bench/*.spec.mjs` (24/24), `prettier --check`, `eslint`, `test-release-security-contracts.mjs`, `yaml.safe_load` on both workflows.

Run end-to-end against the real artifacts it correctly reported **NOT TRUSTWORTHY** with 8 blocking problems (the `null` task above) rather than quietly publishing a number.

No changeset: `.github/**` and `scripts/**` under the private root package.

## After merge

Dispatch it on `master`. Note the table at the top is a **proxy** — those are two different PRs, not repeats of one commit, so it is an upper bound. The real per-task floor comes from the job itself.
