### PR TITLE
ci: take pnpm from packageManager in the noise-floor job

### DIFF
--- a/.github/workflows/benchmark-noise-floor.yml
+++ b/.github/workflows/benchmark-noise-floor.yml
@@ -229,14 +229,30 @@ jobs:
             );
           '
 
+      # No `version:` here, deliberately, and this is the one place where copying
+      # benchmarks.yml verbatim is WRONG rather than faithful.
+      #
+      # pnpm/action-setup refuses to start when a version is given both as an
+      # input and as package.json's `packageManager`, and it looks for that
+      # package.json at the workspace root. benchmarks.yml checks the repo out
+      # into `path: bench-base`, so its root has no package.json and its
+      # `version: 10.24.0` is the only source the action can see. This job checks
+      # out at the root, so package.json IS visible and passing the input too is
+      # a hard error:
+      #
+      #   Error: Multiple versions of pnpm specified  (run 31825116300)
+      #
+      # Taking the version from `packageManager` is also simply better: one
+      # source of truth, and it carries the integrity hash. ci.yml does the same.
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: 10.24.0
           run_install: false
 
-      # Copied verbatim from benchmarks.yml, including the version pin and the
-      # target pre-install. No caching anywhere in this job: benchmarks.yml
+      # Copied from benchmarks.yml, including the target pre-install (but see the
+      # pnpm step above: its `version:` input is the one line that must NOT be
+      # copied, because this job checks out at the workspace root and that one
+      # differs by layout). No caching anywhere in this job: benchmarks.yml
       # caches nothing either, and a restore-keys-style cache could serve one
       # ref's compiled output to another ref's measurement, which would corrupt
       # the very quantity this job exists to measure.


### PR DESCRIPTION
The first dispatch ([run 31825116300](https://github.com/dao-xyz/peerbit/actions/runs/31825116300)) died in `Setup pnpm` before running anything:

```
Error: Multiple versions of pnpm specified:
  - version 10.24.0 in the GitHub Action config with the key "version"
  - version pnpm@10.24.0+sha512... in the package.json with the key "packageManager"
```

The step was copied verbatim from `benchmarks.yml`, where it works — but it works there because of a **layout** difference, not because the step is right. `benchmarks.yml` checks the repo out into `path: bench-base`, so the workspace root has no `package.json` and the action can only see its own `version:` input. This job checks out at the root, so both sources are visible and `pnpm/action-setup` refuses to start.

Verbatim copying is not fidelity when the surrounding context differs. Confirmed the config itself is unchanged: the action pin has not moved since 2026-01-18 and `packageManager` has been present since 2025-09-26, so nothing regressed — the two workflows simply never had the same layout.

Dropping the input and letting `packageManager` drive it is also the better of the two: one source of truth, and it carries the integrity hash. `ci.yml` already does exactly this.

Swept the rest of the job for the same class of divergence — every other path is `$GITHUB_WORKSPACE`-relative with no `bench-base` assumption, so this was the only one.

**The failure behaved as designed.** `Report noise floor` runs on the failure path rather than under `success()`, so the job published a clearly-labelled 0-repeat partial and refused to emit a number, instead of going silent after burning runner time.

Gates: `yaml.safe_load` ok, `prettier --check` 0, `test-release-security-contracts.mjs` 0, `node --test scripts/bench/*.spec.mjs` 0 (24/24).