### PR TITLE
fix(bench): only block on invalid metrics that can bias the floor

### DIFF
--- a/scripts/bench/noise-floor.mjs
+++ b/scripts/bench/noise-floor.mjs
@@ -93,11 +93,28 @@
 //   * a task present in some runs only    -> blocking, and its n is printed
 //                                            next to its floor either way
 //   * null / NaN / Infinity / <= 0        -> the metric is marked invalid, not
-//                                            averaged over the valid subset. A
+//     in SOME runs                           averaged over the valid subset. A
 //                                            relative delta against a zero
 //                                            baseline is undefined; emitting
 //                                            Infinity or a 0% "floor" would be
 //                                            a lie in the dangerous direction.
+//                                            BLOCKING, because the runs that
+//                                            produced a number are the runs
+//                                            where nothing went wrong.
+//   * the same, but in EVERY run          -> warning, not blocking. It never
+//                                            reaches the summary, so it cannot
+//                                            bias the floor. Some of these are
+//                                            constants rather than failures:
+//                                            chunk-transfer's completion-LAG
+//                                            tasks are structurally 0 when the
+//                                            ordering runs the other way, and
+//                                            blocking on them made a clean
+//                                            transport run NOT TRUSTWORTHY
+//                                            (run 31827888077). Still listed
+//                                            loudly, and the note says the task
+//                                            tells you nothing about that
+//                                            metric -- its absence from the
+//                                            table is not evidence of stability.
 //   * a floor of exactly 0                -> labelled `no variation resolved`,
 //                                            never `deterministic`. Identical
 //                                            values across runs mean no
@@ -729,30 +746,57 @@ export const analyze = ({ resultsDir, minRuns = DEFAULT_MIN_RUNS }) => {
 				}
 
 				if (invalid.length > 0) {
+					// Blocking is reserved for what can BIAS the floor downward.
+					//
+					// A metric invalid in only SOME runs is exactly that: the runs that
+					// produced a number are the runs where nothing went wrong, so a
+					// floor built from the survivors is biased toward stability.
+					//
+					// A metric invalid in EVERY run cannot bias anything -- it never
+					// reaches the summary in the first place. Some of these are real
+					// constants rather than failures: chunk-transfer's
+					// "silent: sender-after-receiver" and "ack: receiver-after-sender"
+					// are completion *lags* that are structurally 0 whenever the
+					// ordering runs the other way, and a relative delta against 0 is
+					// undefined no matter how healthy the benchmark is. Blocking on
+					// those made a clean transport run NOT TRUSTWORTHY (run
+					// 31827888077) and would have made the number unusable for the
+					// wrong reason.
+					//
+					// So it stays loud -- it is listed, and the task publishes no floor
+					// -- but it does not condemn the whole report.
+					const neverMeasurable = values.length === 0;
 					for (const entry of invalid) {
 						// Naming the underlying field matters for the `rows` shape: a
 						// document-put row that lost `totalPutMs` must not read as "the
 						// mean_ms was null", which points at the wrong thing.
 						const field = sourceFields.get(entry.run) ?? metric.key;
 						add(
-							"blocking",
-							"invalid-metric-value",
+							neverMeasurable ? "warning" : "blocking",
+							neverMeasurable
+								? "metric-never-measurable"
+								: "invalid-metric-value",
 							`${suite.file} task "${name}" has ${metric.key} = ${entry.reason} in ${entry.run}${
 								field === metric.key
 									? ""
 									: ` (read from the row field "${field}")`
-							}; a relative delta against it is undefined, so no floor is computed for this metric`,
+							}; a relative delta against it is undefined, so no floor is computed for this metric${
+								neverMeasurable
+									? `. It is ${entry.reason} in ALL ${invalid.length} run(s), so it cannot bias the floor -- but this task therefore tells you NOTHING about a regression in ${metric.key}, so do not read its absence from the table as stability`
+									: `. It is valid in ${values.length} of ${seenIn.length} run(s), and a floor built from only the runs that worked is biased toward stability`
+							}`,
 							{
 								suite: suite.file,
 								run: entry.run,
 								task: name,
 								metric: metric.key,
 								sourceField: field,
+								neverMeasurable,
 							},
 						);
 					}
 					metrics[metric.key] = {
-						status: "invalid",
+						status: neverMeasurable ? "never-measurable" : "invalid",
 						n: values.length,
 						invalidSamples: invalid,
 						mean: null,

--- a/scripts/bench/noise-floor.spec.mjs
+++ b/scripts/bench/noise-floor.spec.mjs
@@ -1326,3 +1326,70 @@ test("byte-identical run directories are called out instead of yielding a silent
 		);
 	});
 });
+
+// Real data, run 31827888077: chunk-transfer's completion-lag tasks are
+// structurally 0 whenever the ordering runs the other way, in every run. A
+// relative delta against 0 is undefined however healthy the benchmark is, so
+// blocking on them condemned an otherwise clean transport run. Blocking is for
+// what can BIAS the floor; a metric that never yields a value in any run never
+// reaches the summary, so it cannot.
+test("a metric invalid in EVERY run warns; invalid in only SOME runs still blocks", () => {
+	withFixture((root) => {
+		const rows = (lagAlwaysZero, sometimes) => [
+			{ name: "silent: sender-complete", mean_ms: "19.1", hz: "52.3" },
+			// The real shape: mean_ms 0 and hz null, in every run.
+			{
+				name: "silent: sender-after-receiver",
+				mean_ms: lagAlwaysZero,
+				hz: "null",
+			},
+			{ name: "flaky-task", mean_ms: sometimes, hz: sometimes },
+		];
+		writeSuite(root, "run-1", "chunk-transfer.json", rawSuite(rows("0", "10")));
+		writeSuite(root, "run-2", "chunk-transfer.json", rawSuite(rows("0", "11")));
+		writeSuite(root, "run-3", "chunk-transfer.json", rawSuite(rows("0", "12")));
+
+		const withFlakeOk = analyze({ resultsDir: root, minRuns: 3 });
+		// The always-zero lag alone must NOT condemn the report.
+		assert.equal(
+			withFlakeOk.trustworthy,
+			true,
+			"an always-invalid metric must not be blocking",
+		);
+		const lag = findTask(
+			withFlakeOk,
+			"chunk-transfer.json",
+			"silent: sender-after-receiver",
+		);
+		assert.equal(lag.metrics.mean_ms.status, "never-measurable");
+		assert.equal(lag.metrics.mean_ms.max_abs_delta_pct, null);
+		assert.ok(
+			codes(withFlakeOk, "warning").includes("metric-never-measurable"),
+			"it must still be listed loudly as a warning",
+		);
+		assert.ok(
+			!codes(withFlakeOk, "blocking").includes("metric-never-measurable"),
+		);
+		// And it must say the task tells you nothing, not merely that it is absent.
+		const note = withFlakeOk.problems.find(
+			(problem) => problem.code === "metric-never-measurable",
+		);
+		assert.match(note.message, /tells you NOTHING/);
+		assert.equal(note.neverMeasurable, true);
+
+		// Now make the OTHER task invalid in one run only: that biases the floor
+		// toward the runs that worked, so it must block.
+		writeSuite(root, "run-3", "chunk-transfer.json", rawSuite(rows("0", "0")));
+		const withFlakeBroken = analyze({ resultsDir: root, minRuns: 3 });
+		assert.equal(withFlakeBroken.trustworthy, false);
+		const blocking = codes(withFlakeBroken, "blocking");
+		assert.ok(blocking.includes("invalid-metric-value"));
+		assert.equal(
+			findTask(withFlakeBroken, "chunk-transfer.json", "flaky-task").metrics
+				.mean_ms.status,
+			"invalid",
+		);
+		// The always-zero lag is still only a warning even in this run.
+		assert.ok(!blocking.includes("metric-never-measurable"));
+	});
+});


### PR DESCRIPTION
The first clean noise-floor run ([31827888077](https://github.com/dao-xyz/peerbit/actions/runs/31827888077) — transport, 2 repeats) checked out, built, ran the repeats and produced a report. Then it declared itself **NOT TRUSTWORTHY** over eight blocking problems, all of them this:

```
chunk-transfer.json task "silent: sender-after-receiver" has mean_ms = not positive (0) in run-1
```

`silent: sender-after-receiver` and `ack: receiver-after-sender` are completion **lags**. They are structurally `0` whenever the ordering runs the other way — in every run, on a perfectly healthy benchmark. A relative delta against 0 is undefined regardless, so the report refused to publish any number because two derived metrics are constants.

## The rule was too blunt

Blocking should mean **"this can bias the floor downward"**:

| | |
|---|---|
| invalid in **some** runs | **blocking**, unchanged — the runs that produced a number are the runs where nothing went wrong, so a floor built from the survivors is biased toward stability |
| invalid in **every** run | **warning** — it never reaches the summary, so it cannot bias anything |

This is not a relaxation. The warning stays loud and says what the silence means: the task tells you **nothing** about a regression in that metric, so its absence from the table must not be read as stability.

## Evidence

Replaying run 31827888077's own artifact through the new rule flips it from exit 1 / NOT TRUSTWORTHY to exit 0 with real A/A numbers:

| task | max \|Δ\| |
|---|---|
| `silent: receiver-after-sender` | 0.95% |
| `silent: receiver-complete` | 1.85% |
| `ack: sender-after-receiver` | 4.54% |
| `ack: sender-complete` / `receiver-complete` | 5.20% |
| `silent: sender-complete` | 9.23% |

and the two lag tasks print `-` instead of a floor. (Two runs is one pair — the weakest possible estimate — but it is genuine A/A on one runner.)

## Verification

25 tests. Mutation-verified in **both** directions: forcing all-invalid back to blocking turns 1 red; making every invalid metric a warning turns 3 red.

`prettier --check` 0, `eslint` 0, `test-release-security-contracts.mjs` 0, all statuses captured directly rather than through a pipe.

Found by dispatching a cheap 2-repeat transport-only smoke run before committing hours to the full one.