### PR TITLE
ci: let the per-file assert allow a task that reports nothing

### DIFF
--- a/.github/workflows/benchmark-noise-floor.yml
+++ b/.github/workflows/benchmark-noise-floor.yml
@@ -420,25 +420,44 @@ jobs:
                 );
               }
 
-              // Only the fields the noise-floor reporter actually consumes are
-              // required. A half-written file loses them, which is the exact
-              // truncation this assert exists to catch.
+              // This assert answers exactly one question: is this file a whole
+              // benchmark result, or a truncated one? It must NOT also decide
+              // which metrics are measurable -- that is the reporter's job, and
+              // the reporter's rule is deliberately more subtle (a metric
+              // invalid in every run is a warning, because it cannot bias the
+              // floor; invalid in only some runs is blocking, because it can).
+              //
+              // Requiring EVERY row to be finite conflated the two and killed a
+              // healthy run: pid-convergence emits
+              // `mean_ms: null` for "memory-limited (2 peers, 25% cap)" on a
+              // perfectly good run -- present in all four historical artifacts
+              // too -- and that aborted repeat 1 of run 31830970341 after the
+              // whole build. A file is truncated when it has NO usable row, not
+              // when one task reports nothing.
               const durationField = isTasksShape ? "mean_ms" : "totalPutMs";
               const rateField = isTasksShape ? "hz" : "opsPerSecond";
+              const unusable = [];
+              let usable = 0;
               for (const row of rows) {
                 if (typeof row?.name !== "string") {
                   throw new Error(`${file} carries an entry without a name`);
                 }
-                if (!Number.isFinite(row?.[durationField])) {
-                  throw new Error(
-                    `${file} entry "${row.name}" has no finite ${durationField}`,
-                  );
-                }
-                if (!isTasksShape && !Number.isFinite(row?.[rateField])) {
-                  throw new Error(
-                    `${file} entry "${row.name}" has no finite ${rateField}`,
-                  );
-                }
+                const hasDuration = Number.isFinite(row?.[durationField]);
+                const hasRate = isTasksShape || Number.isFinite(row?.[rateField]);
+                if (hasDuration && hasRate) usable += 1;
+                else unusable.push(row.name);
+              }
+              if (usable === 0) {
+                throw new Error(
+                  `${file} has ${rows.length} entr(ies) but not one carries a finite ${durationField}; this is a truncated or failed benchmark, not a result`,
+                );
+              }
+              if (unusable.length > 0) {
+                // Surfaced, never silent: the reporter will classify these, and
+                // a task that reports nothing must not read as a stable task.
+                console.log(
+                  `::notice::${file}: ${unusable.length}/${rows.length} entr(ies) carry no finite ${durationField} and will publish no floor: ${unusable.join(", ")}`,
+                );
               }
             '
           }


### PR DESCRIPTION
The full 4-repeat run ([31830970341](https://github.com/dao-xyz/peerbit/actions/runs/31830970341)) built, verified its entrypoints, and then aborted partway through repeat 1:

```
Error: bench-results/run-1/pid-convergence.json entry "memory-limited (2 peers, 25% cap)" has no finite mean_ms
```

That task emits `mean_ms = null` on a healthy run. It is null in all four historical benchmark artifacts too, and `benchmarks.yml` has been rendering it as a dash for as long as it has existed. Nothing was wrong with the measurement.

## The two layers disagreed

[#1275](https://github.com/dao-xyz/peerbit/pull/1275) taught the **reporter** that a metric invalid in *every* run is a warning (it cannot bias the floor) while one invalid in *some* runs is blocking (it can). The workflow's own `assert_suite_json` still required **every** row to be finite — stricter, and it runs first, so the subtle rule never got a chance.

Each layer now answers one question:

- **the assert** — is this a whole benchmark result or a truncated one? It parses, has a non-empty `tasks`/`rows` array, every entry has a name, and **at least one** entry carries a finite duration.
- **the reporter** — which metrics are measurable, under the bias-aware rule.

Entries carrying nothing are surfaced as a `::notice::` naming them, so a task that reports nothing still cannot be read as a stable task.

## Verification

Ran the assert's **actual JS**, extracted from the workflow rather than paraphrased, against the real artifacts of the run it killed:

| input | result |
|---|---|
| the 4 real `run-1` files | **pass**, `pid-convergence` emits the notice |
| every task null | fail |
| empty file | fail |
| empty `tasks` array | fail |
| entry without a name | fail |
| one usable + one null | pass, `1/2 entr(ies) carry no finite mean_ms ... : a` |

(My first extraction attempt silently produced an empty script and reported four false passes — worth noting since it is the same class of bug this whole thread has been about. The numbers above are from a corrected harness.)

`yaml.safe_load` ok, `prettier --check` 0, `test-release-security-contracts.mjs` 0, `node --test scripts/bench/*.spec.mjs` 0.

**Follow-up, not fixed here:** `pid-convergence` emitting `null` for `memory-limited (2 peers, 25% cap)` is a real defect — that task has never reported a number in any artifact I can find.