### PR TITLE
ci: use heredocs for embedded node scripts, and guard the fragile form

### DIFF
--- a/.github/workflows/benchmark-noise-floor.yml
+++ b/.github/workflows/benchmark-noise-floor.yml
@@ -210,7 +210,7 @@ jobs:
           # bench-results/ is the results-dir handed to scripts/bench/noise-floor.mjs.
           # Non-run entries are expected there: the script's own default report
           # path is <results-dir>/noise-floor.json.
-          NOISE_FLOOR_SHA="$(git rev-parse HEAD)" node --input-type=module -e '
+          NOISE_FLOOR_SHA="$(git rev-parse HEAD)" node --input-type=module <<'NODE'
             import { writeFileSync } from "node:fs";
 
             const metadata = {
@@ -227,7 +227,7 @@ jobs:
               "bench-results/metadata.json",
               JSON.stringify(metadata, null, 2) + "\n",
             );
-          '
+          NODE
 
       # No `version:` here, deliberately, and this is the one place where copying
       # benchmarks.yml verbatim is WRONG rather than faithful.
@@ -398,7 +398,7 @@ jobs:
           # comparison, which is why its "document: put" table renders empty.
           # That is a separate change to a workflow this one only copies from.
           assert_suite_json() {
-            SUITE_JSON_FILE="$1" node --input-type=module -e '
+            SUITE_JSON_FILE="$1" node --input-type=module <<'NODE'
               import { readFileSync } from "node:fs";
 
               const file = process.env.SUITE_JSON_FILE;
@@ -459,7 +459,7 @@ jobs:
                   `::notice::${file}: ${unusable.length}/${rows.length} entr(ies) carry no finite ${durationField} and will publish no floor: ${unusable.join(", ")}`,
                 );
               }
-            '
+          NODE
           }
 
           # No pipes in either runner. A pipeline reports its LAST command's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,15 @@ jobs:
         run: |
           node --test scripts/validate-retired-domain-references.test.mjs
           node scripts/validate-retired-domain-references.mjs
+      # An apostrophe inside an inline `-e '...'` script silently ends the shell
+      # string and the rest is executed as commands. `bash -n` does not catch it
+      # (verified against the revision that failed run 31844749062), so the guard
+      # has to be structural.
+      - name: Validate workflow shell safety
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
+        run: |
+          node --test scripts/ci/check-workflow-shell-safety.test.mjs
+          node scripts/ci/check-workflow-shell-safety.mjs
       # Globbed, not enumerated: a spec added under tools/ must not be able to
       # sit unrun because nobody remembered to name it here. If the glob ever
       # matches nothing, bash passes it through literally and node --test fails

--- a/scripts/ci/check-workflow-shell-safety.mjs
+++ b/scripts/ci/check-workflow-shell-safety.mjs
@@ -1,0 +1,92 @@
+// Refuses inline single-quoted interpreter scripts in workflow `run:` blocks.
+//
+// WHY: `node --input-type=module -e '<script>'` ends at the first apostrophe in
+// the script -- including one inside a comment. The rest of the "script" is then
+// handed to the shell as commands. That is not a syntax error, so nothing warns:
+//
+//   run 31844749062 died with
+//     /home/runner/work/_temp/....sh: line 57: //: Is a directory
+//     Process completed with exit code 126
+//
+//   because a comment in the embedded JS read "that is the reporter's job".
+//
+// `bash -n` does NOT catch this -- verified against the broken revision, which
+// parses cleanly. The damage is semantic, not syntactic, so the only reliable
+// guard is structural: do not use the fragile form at all.
+//
+// The fix is a quoted heredoc, which benchmarks.yml already uses:
+//
+//   node --input-type=module <<'NODE'
+//   ...script, apostrophes and all...
+//   NODE
+//
+// 'NODE' is quoted so the shell performs no expansion inside, and a heredoc is
+// not a pipe, so the exit status still belongs to node. The terminator must sit
+// at the `run:` block's base indentation, because YAML dedents the block scalar
+// and a heredoc terminator has to start at column 0 of the resulting script.
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const WORKFLOW_DIR = ".github/workflows";
+
+// `cmd -e '` at the end of a line: the script body starts on the next line and
+// runs until a lone apostrophe. Covers node/python/ruby/perl alike.
+const INLINE_SCRIPT = /\s-e\s+'\s*$/;
+
+export const findInlineSingleQuotedScripts = (source, file) => {
+	const findings = [];
+	source.split("\n").forEach((line, index) => {
+		if (INLINE_SCRIPT.test(line))
+			findings.push({
+				file,
+				line: index + 1,
+				text: line.trim(),
+			});
+	});
+	return findings;
+};
+
+export const scanWorkflows = (root = process.cwd()) => {
+	const dir = path.join(root, WORKFLOW_DIR);
+	const files = readdirSync(dir).filter(
+		(name) => name.endsWith(".yml") || name.endsWith(".yaml"),
+	);
+	if (files.length === 0)
+		throw new Error(
+			`${WORKFLOW_DIR} contains no workflow files; this guard would pass by scanning nothing`,
+		);
+	return files.flatMap((name) =>
+		findInlineSingleQuotedScripts(
+			readFileSync(path.join(dir, name), "utf8"),
+			path.join(WORKFLOW_DIR, name),
+		),
+	);
+};
+
+const main = () => {
+	const findings = scanWorkflows();
+	if (findings.length === 0) {
+		console.log(
+			"check-workflow-shell-safety: no inline single-quoted scripts in workflow run: blocks",
+		);
+		return;
+	}
+	console.error(
+		"check-workflow-shell-safety: inline single-quoted interpreter scripts found.\n" +
+			"A single apostrophe anywhere in the script -- including inside a comment --\n" +
+			"terminates the shell string, and the remainder is executed as commands.\n" +
+			"bash -n does not catch it. Use a quoted heredoc instead:\n" +
+			"\n" +
+			"    node --input-type=module <<'NODE'\n" +
+			"    ...\n" +
+			"    NODE\n" +
+			"\n" +
+			"with the terminator at the run: block's base indentation.\n",
+	);
+	for (const finding of findings)
+		console.error(`  ${finding.file}:${finding.line}  ${finding.text}`);
+	process.exitCode = 1;
+};
+
+if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1])))
+	main();

--- a/scripts/ci/check-workflow-shell-safety.test.mjs
+++ b/scripts/ci/check-workflow-shell-safety.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+import {
+	findInlineSingleQuotedScripts,
+	scanWorkflows,
+} from "./check-workflow-shell-safety.mjs";
+
+test("flags the exact form that broke run 31844749062", () => {
+	// Reconstructed from the revision that failed, indentation and all.
+	const broken = [
+		"        run: |",
+		"          assert_suite_json() {",
+		'            SUITE_JSON_FILE="$1" node --input-type=module -e \'',
+		"              // that is the reporter's job, and",
+		"              const parsed = JSON.parse(raw);",
+		"            '",
+		"          }",
+	].join("\n");
+	const findings = findInlineSingleQuotedScripts(broken, "x.yml");
+	assert.equal(findings.length, 1);
+	assert.equal(findings[0].line, 3);
+});
+
+test("accepts the quoted-heredoc form, apostrophes and all", () => {
+	const fixed = [
+		"        run: |",
+		"          node --input-type=module <<'NODE'",
+		"          // that is the reporter's job, and it is fine here",
+		'          console.log("don\'t panic");',
+		"          NODE",
+	].join("\n");
+	assert.deepEqual(findInlineSingleQuotedScripts(fixed, "x.yml"), []);
+});
+
+test("does not flag an -e flag that is not opening a script block", () => {
+	// `grep -e 'pattern'` and friends close on the same line; only a trailing
+	// quote opens a multi-line body.
+	const benign = [
+		"        run: |",
+		"          grep -e 'foo' file",
+		"          node -e 'console.log(1)'",
+	].join("\n");
+	assert.deepEqual(findInlineSingleQuotedScripts(benign, "x.yml"), []);
+});
+
+test("the repository's own workflows are clean", () => {
+	assert.deepEqual(
+		scanWorkflows().map((finding) => `${finding.file}:${finding.line}`),
+		[],
+	);
+});
+
+test("the checker exits non-zero when a workflow regresses", () => {
+	// Belt and braces: the module-level guard must actually fail the process,
+	// not merely return findings nobody reads.
+	const source = [
+		"import { findInlineSingleQuotedScripts } from './scripts/ci/check-workflow-shell-safety.mjs';",
+		"const broken = `run: |\\n  node -e '\\n  // it's here\\n  '`;",
+		"if (findInlineSingleQuotedScripts(broken, 'x.yml').length !== 1) process.exit(2);",
+	].join("\n");
+	const out = execFileSync(
+		process.execPath,
+		["--input-type=module", "-e", source],
+		{
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	assert.equal(out, "");
+});


### PR DESCRIPTION
Run [31844749062](https://github.com/dao-xyz/peerbit/actions/runs/31844749062) died in repeat 1:

```
/home/runner/work/_temp/....sh: line 57: //: Is a directory
Process completed with exit code 126
```

because a comment I added in [#1276](https://github.com/dao-xyz/peerbit/pull/1276) read `that is the reporter's job`. Inside `node --input-type=module -e '...'` that apostrophe **ends the shell string**, and everything after it is handed to the shell as commands. The job got *less* far than the run before it.

## Why this is a structural fix, not a deleted apostrophe

**It is invisible.** The result is valid bash, so nothing warns. I confirmed `bash -n` accepts the broken revision and the fixed one identically — the damage is semantic, not syntactic.

**It was invisible to my own verification.** I checked #1276 by extracting the JS and running `node /tmp/assert.mjs` directly — which bypasses the shell quoting entirely. I tested the logic and skipped the embedding, so the harness could not have caught the bug it existed to check. I had even hit exit 126 with this exact message locally and written it off as an extraction artifact.

**It is one apostrophe away at all times.** Any future comment containing "doesn't" or "the reporter's" re-breaks it.

## The fix

Both blocks move to a quoted heredoc — the form `benchmarks.yml` already uses:

```bash
node --input-type=module <<'NODE'
...script, apostrophes and all...
NODE
```

`'NODE'` is quoted so the shell expands nothing inside, and a heredoc is **not a pipe**, so the exit status still belongs to node (verified both directions: 0 on good input, 1 on bad). The terminator sits at the `run:` block base indentation, because YAML dedents the block scalar and a heredoc terminator must start at column 0 of the resulting script.

## The guard

`scripts/ci/check-workflow-shell-safety.mjs` bans the fragile form across every workflow. Verified against the **actual broken revision** — it reports both blocks, so it would have blocked this:

```
benchmark-noise-floor.yml:213 NOISE_FLOOR_SHA="$(git rev-parse HEAD)" node --input-type=module -e '
benchmark-noise-floor.yml:401 SUITE_JSON_FILE="$1" node --input-type=module -e '
```

5 tests, wired into CI next to the retired-domain guard. It also refuses to pass by scanning zero files.

## Verification

Re-ran the assert end to end **through the real shell** this time, not around it: all four real suite files from the killed run pass, truncated control still fails.

`yaml.safe_load` ok, guard 0, guard tests 0, `node --test scripts/bench/*.spec.mjs` 0, `prettier --check` 0, `eslint` 0, `test-release-security-contracts.mjs` 0 — all captured directly, not through a pipe.