### PR TITLE
ci: judge each A/B benchmark delta against its own measured noise floor

### DIFF
--- a/.github/workflows/benchmark-noise-floor.yml
+++ b/.github/workflows/benchmark-noise-floor.yml
@@ -221,6 +221,15 @@ jobs:
               repeats: Number(process.env.NOISE_FLOOR_REPEATS),
               selected_suites: process.env.NOISE_FLOOR_SELECTED.split(","),
               run_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+              // When this measurement was taken. It exists because a floor ages:
+              // a baseline emitted from this directory is committed to the repo
+              // (scripts/bench/noise-floor.mjs --emit-baseline) and a reader has
+              // to be able to ask how old it is. This step runs before the first
+              // benchmark, so it is the START of the measurement, which is the
+              // conservative end to quote. Absent this field the emitter falls
+              // back to metadata.json's mtime and labels it as such -- correct,
+              // but weaker provenance than a recorded timestamp.
+              measured_at: new Date().toISOString(),
             };
 
             writeFileSync(

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -192,6 +192,27 @@ jobs:
         run: |
           echo "Benchmarks are only supported for same-repo branches (forks are skipped for security)."
 
+      # The noise floor is workflow tooling, not PR content, so it is fetched
+      # from the dispatched ref rather than from either benchmark checkout: the
+      # baseline that the reporter below understands is the one that ships with
+      # this workflow file. bench-head is never a source -- a PR that shipped its
+      # own baseline could set every floor to 999% and make its own regression
+      # render as "within noise".
+      #
+      # Sparse, and continue-on-error: a missing or failed baseline checkout must
+      # degrade the report to UNKNOWN, never fail the benchmark job.
+      - name: Checkout noise-floor baseline
+        if: always() && steps.pr.outputs.same_repo == 'true'
+        continue-on-error: true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          path: bench-floor
+          sparse-checkout: scripts/bench/noise-floor-baseline.json
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Checkout base
         if: steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.run_any == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -410,75 +431,316 @@ jobs:
         run: |
           node <<'NODE'
             const fs = require('node:fs');
+            const path = require('node:path');
 
             fs.mkdirSync('bench-results', { recursive: true });
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const selected = process.env.BENCH_SELECTED_SUITES || 'none';
+
             const advisory =
               '> [!WARNING]\n> Advisory/untrusted output: PR head code runs in the same runner and workspace as the base benchmark and can modify results, metadata, and this report before upload. Reproduce material findings independently before merging.\n\n';
 
+            const errorMessage = (error) =>
+              error instanceof Error && error.message ? error.message : String(error);
+
+            const writeReport = (text) => {
+              try {
+                fs.writeFileSync('bench-results/report.md', text);
+              } catch (error) {
+                console.error(`report write failed: ${errorMessage(error)}`);
+              }
+            };
+
+            // Advisory first, before anything below can throw: even a crash has to
+            // leave the warning on disk for the upload step.
+            writeReport(`# Benchmarks\n\n${advisory}`);
+
+            const isPlainObject = (value) =>
+              typeof value === 'object' && value !== null && !Array.isArray(value);
+            const finiteOrNull = (value) =>
+              typeof value === 'number' && Number.isFinite(value) ? value : null;
+            const numberOrNull = (value) => {
+              if (value === null || value === undefined) return null;
+              const parsed = Number(value);
+              return Number.isFinite(parsed) ? parsed : null;
+            };
+
+            // Everything interpolated into the report from a file is squeezed onto
+            // one line and length-capped first: a stray newline or pipe would break
+            // the table or the blockquote it lands in.
+            const safeText = (value, max = 120) => {
+              if (typeof value !== 'string') return null;
+              const cleaned = value.replace(/[\r\n|`]/g, ' ').trim();
+              if (cleaned.length === 0) return null;
+              return cleaned.length > max ? `${cleaned.slice(0, max)}...` : cleaned;
+            };
+
+            const shortSha = (value) => {
+              const text = safeText(value, 64);
+              if (text === null) return null;
+              return /^[0-9a-f]{7,40}$/i.test(text) ? text.slice(0, 12) : text;
+            };
+
+            const safeUrl = (value) => {
+              const text = safeText(value, 300);
+              if (text === null) return null;
+              return /^https:\/\/[^\s<>()]+$/.test(text) ? text : null;
+            };
+
+            // Task names come from PR-produced JSON; a stray pipe or newline would
+            // break the table they are rendered into.
+            const cell = (value) =>
+              String(value).replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+
+            // `file` is both the results filename and the key the noise-floor
+            // baseline rows are keyed by, so it is named once and everything
+            // derives from it. A typo here turns tasks UNKNOWN rather than
+            // silently blessing them, which is the safe failure direction.
             const suites = [
               {
+                file: 'rateless-iblt-startsync-cache.json',
                 title: 'shared-log: StartSync local decoder cache',
-                base: 'bench-results/base/rateless-iblt-startsync-cache.json',
-                head: 'bench-results/head/rateless-iblt-startsync-cache.json',
               },
               {
+                file: 'rateless-iblt-sender-startsync.json',
                 title: 'shared-log: sender StartSync setup (onMaybeMissingEntries)',
-                base: 'bench-results/base/rateless-iblt-sender-startsync.json',
-                head: 'bench-results/head/rateless-iblt-sender-startsync.json',
               },
               {
+                file: 'sync-batch-sweep.json',
                 title: 'shared-log: sync catch-up batch sweep (including large-edge batch)',
-                base: 'bench-results/base/sync-batch-sweep.json',
-                head: 'bench-results/head/sync-batch-sweep.json',
               },
               {
+                file: 'pid-convergence.json',
                 title: 'shared-log: PID convergence (model)',
-                base: 'bench-results/base/pid-convergence.json',
-                head: 'bench-results/head/pid-convergence.json',
               },
+              { file: 'document-put.json', title: 'document: put' },
               {
-                title: 'document: put',
-                base: 'bench-results/base/document-put.json',
-                head: 'bench-results/head/document-put.json',
-              },
-              {
+                file: 'chunk-transfer.json',
                 title: 'transport: multi-hop chunk transfer',
-                base: 'bench-results/base/chunk-transfer.json',
-                head: 'bench-results/head/chunk-transfer.json',
               },
-              {
-                title: 'document: chunked file-ingest',
-                base: 'bench-results/base/file-ingest.json',
-                head: 'bench-results/head/file-ingest.json',
-              },
+              { file: 'file-ingest.json', title: 'document: chunked file-ingest' },
             ];
+
+            // ----------------------------------------------------------------
+            // Noise-floor baseline (scripts/bench/noise-floor.mjs --emit-baseline).
+            //
+            // The floor is workflow tooling, not PR content, so it is read from
+            // the dispatched ref first and from the PR base second. bench-head is
+            // deliberately NOT a source: a PR that shipped its own baseline could
+            // set every floor to 999% and make its own regression render as
+            // "within noise".
+            // ----------------------------------------------------------------
+            const BASELINE_FILE = 'scripts/bench/noise-floor-baseline.json';
+            const BASELINE_SCHEMA = 'peerbit-bench-noise-floor-baseline/1';
+            const baselineCandidates = [
+              { path: `bench-floor/${BASELINE_FILE}`, origin: 'workflow-ref checkout' },
+              { path: `bench-base/${BASELINE_FILE}`, origin: 'PR base checkout' },
+              { path: BASELINE_FILE, origin: 'workspace root' },
+            ];
+
+            // TWO SHAPES, BOTH ACCEPTED. The emitter has published the floors as a
+            // suite-keyed object and as a flat row array; both are structurally
+            // unambiguous, so both are read rather than guessed at. Guessing wrong
+            // leaves every row UNKNOWN while the file looks perfectly well-formed,
+            // which is the one failure mode this whole feature exists to prevent.
+            //
+            //   object: { "<suite>.json": { "<task>": { mean_ms, hz, n, unusable? } } }
+            //   array : [ { suite, task, n, max_abs_delta_pct: { mean_ms, hz } } ]
+            //
+            // Maps, not rebuilt objects: a task really can be named "1000"
+            // (RIBLT_SIZES produces exactly that), and JS reorders integer-like
+            // keys ahead of every string key. A Map also cannot be reached by a
+            // `__proto__` key coming out of JSON.
+            const readFloorTable = (tasksField) => {
+              const bySuite = new Map();
+              let rowCount = 0;
+              const put = (suite, task, entry) => {
+                if (typeof suite !== 'string' || typeof task !== 'string') return;
+                if (!isPlainObject(entry)) return;
+                if (!bySuite.has(suite)) bySuite.set(suite, new Map());
+                bySuite.get(suite).set(task, entry);
+                rowCount += 1;
+              };
+              if (Array.isArray(tasksField)) {
+                for (const row of tasksField) {
+                  if (!isPlainObject(row)) continue;
+                  const floors = isPlainObject(row.max_abs_delta_pct)
+                    ? { ...row.max_abs_delta_pct, unusable: row.unusable, n: row.n }
+                    : row;
+                  put(row.suite, row.task, floors);
+                }
+              } else if (isPlainObject(tasksField)) {
+                for (const [suite, suiteTasks] of Object.entries(tasksField)) {
+                  if (!isPlainObject(suiteTasks)) continue;
+                  for (const [task, entry] of Object.entries(suiteTasks)) put(suite, task, entry);
+                }
+              }
+              return { bySuite, rowCount };
+            };
+
+            // Provenance has been spelled both camelCase and snake_case. Read
+            // both; a header that says "unknown ref" next to a real measurement
+            // teaches readers to distrust the annotation itself.
+            const pick = (object, ...keys) => {
+              if (!isPlainObject(object)) return null;
+              for (const key of keys) {
+                const value = object[key];
+                if (value !== null && value !== undefined) return value;
+              }
+              return null;
+            };
+
+            const loadBaseline = () => {
+              const looked = [];
+              for (const candidate of baselineCandidates) {
+                looked.push(`\`${candidate.path}\``);
+                if (!fs.existsSync(candidate.path)) continue;
+                let parsed;
+                try {
+                  parsed = JSON.parse(fs.readFileSync(candidate.path, 'utf8'));
+                } catch (error) {
+                  return {
+                    ok: false,
+                    reason: `\`${candidate.path}\` is unparseable (${errorMessage(error)})`,
+                  };
+                }
+                if (!isPlainObject(parsed)) {
+                  return { ok: false, reason: `\`${candidate.path}\` is not a JSON object` };
+                }
+                // A future schema may mean different things by the same field
+                // names, so an unrecognised one is refused rather than guessed at.
+                if (parsed.schema !== BASELINE_SCHEMA) {
+                  const declared = safeText(parsed.schema, 60) ?? String(parsed.schema);
+                  return {
+                    ok: false,
+                    reason: `\`${candidate.path}\` declares schema \`${declared}\`; this report only understands \`${BASELINE_SCHEMA}\``,
+                  };
+                }
+                // The committed placeholder has status "not-yet-measured" and no
+                // task entries. It is a real file with no floors in it, and it
+                // must read as "no floor", never as "everything is fine".
+                if (parsed.status !== 'measured') {
+                  const status = safeText(parsed.status, 40) ?? 'unknown';
+                  return {
+                    ok: false,
+                    reason: `\`${candidate.path}\` is status \`${status}\` and carries no measured floors`,
+                  };
+                }
+                const { bySuite, rowCount } = readFloorTable(parsed.tasks);
+                if (rowCount === 0) {
+                  return {
+                    ok: false,
+                    reason: `\`${candidate.path}\` carries no usable (suite, task) rows`,
+                  };
+                }
+                return {
+                  ok: true,
+                  source: candidate,
+                  provenance: isPlainObject(parsed.provenance) ? parsed.provenance : {},
+                  bySuite,
+                  rowCount,
+                };
+              }
+              return { ok: false, reason: `no baseline found; looked in ${looked.join(', ')}` };
+            };
+
+            let baseline;
+            try {
+              baseline = loadBaseline();
+            } catch (error) {
+              baseline = { ok: false, reason: `baseline unreadable (${errorMessage(error)})` };
+            }
+
+            const suiteRows = (file) =>
+              baseline.ok ? baseline.bySuite.get(file) ?? null : null;
+
+            // The emitter publishes `null` for a metric whose floor it could not
+            // measure and records the reason in `unusable`. null is UNKNOWN and is
+            // never read as 0 -- a 0% floor would clear every later delta on that
+            // task forever. Exact task-name match only: a renamed task must land in
+            // UNKNOWN, not inherit the floor of the task it used to be.
+            const floorFor = (rows, suiteFile, taskName, metricKey) => {
+              if (!baseline.ok) return { floor: null, reason: 'no baseline' };
+              if (rows === null) return { floor: null, reason: 'suite not in baseline' };
+              const row = rows.get(taskName);
+              if (row === undefined) return { floor: null, reason: 'task not in baseline' };
+              const value = finiteOrNull(row[metricKey]);
+              if (value === null || value <= 0) {
+                const why = isPlainObject(row.unusable)
+                  ? safeText(row.unusable[metricKey], 40)
+                  : null;
+                return { floor: null, reason: why === null ? 'no floor measured' : `no floor: ${why}` };
+              }
+              return { floor: value, reason: null };
+            };
+
+            const WITHIN = 'within';
+            const ABOVE = 'above';
+            const UNKNOWN = 'unknown';
+
+            // scripts/bench/noise-floor.mjs defines the floor as
+            // |a - b| / min(a, b) * 100, so the comparison uses that same
+            // statistic rather than the signed, base-divided Δ in the neighbouring
+            // column. The two agree when head is the slower side, and this one is
+            // the larger when head is the faster side. Leaning high is the safe
+            // direction: a floor that reads low blesses every perf claim.
+            const floorMagnitude = (a, b) => {
+              if (a === null || b === null) return null;
+              const low = Math.min(a, b);
+              if (!Number.isFinite(low) || low <= 0) return null;
+              return (Math.abs(a - b) / low) * 100;
+            };
+
+            const classify = (baseValue, headValue, floorInfo) => {
+              const magnitude = floorMagnitude(baseValue, headValue);
+              if (magnitude === null) return { state: UNKNOWN, detail: 'no comparable Δ' };
+              if (floorInfo.floor === null) return { state: UNKNOWN, detail: floorInfo.reason };
+              return {
+                state: magnitude <= floorInfo.floor ? WITHIN : ABOVE,
+                magnitude,
+                floor: floorInfo.floor,
+              };
+            };
+
+            const renderVerdict = (verdict) => {
+              if (verdict.state === WITHIN) {
+                return `within (${verdict.magnitude.toFixed(2)}% <= ${verdict.floor.toFixed(2)}%)`;
+              }
+              if (verdict.state === ABOVE) {
+                return `**ABOVE FLOOR** (${verdict.magnitude.toFixed(2)}% > ${verdict.floor.toFixed(2)}%)`;
+              }
+              return `**UNKNOWN** (${verdict.detail})`;
+            };
+
+            // ABOVE beats UNKNOWN beats within. A task the floor cannot speak for
+            // must never be counted as clean.
+            const worstState = (states) =>
+              states.includes(ABOVE) ? ABOVE : states.includes(UNKNOWN) ? UNKNOWN : WITHIN;
 
             const readJson = (file) => {
               try {
-                return JSON.parse(fs.readFileSync(file, 'utf8'));
+                const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+                if (!isPlainObject(parsed)) {
+                  return { tasks: [], __parseError: 'top-level JSON is not an object' };
+                }
+                return parsed;
               } catch (error) {
-                return {
-                  tasks: [],
-                  __parseError: error instanceof Error ? error.message : String(error),
-                };
+                return { tasks: [], __parseError: errorMessage(error) };
               }
             };
 
             const format = (value, digits = 3) => {
-              if (value === null || value === undefined || Number.isNaN(value)) return '-';
-              return Number(value).toFixed(digits);
+              const parsed = numberOrNull(value);
+              if (parsed === null) return '-';
+              return parsed.toFixed(digits);
             };
 
             const formatPercent = (value) => {
-              if (value === null || value === undefined || Number.isNaN(value)) return '-';
+              if (value === null || value === undefined || !Number.isFinite(value)) return '-';
               const sign = value > 0 ? '+' : '';
               return `${sign}${value.toFixed(2)}%`;
             };
 
-            const formatSuite = (baseJson, headJson) => {
+            const formatSuite = (suite, baseJson, headJson) => {
+              const rows = suiteRows(suite.file);
               const baseTasks = Array.isArray(baseJson.tasks) ? baseJson.tasks : [];
               const headTasks = Array.isArray(headJson.tasks) ? headJson.tasks : [];
               const baseMap = new Map(baseTasks.filter((t) => typeof t?.name === 'string').map((t) => [t.name, t]));
@@ -486,68 +748,260 @@ jobs:
               const taskNames = Array.from(new Set([...baseMap.keys(), ...headMap.keys()]));
               taskNames.sort();
 
+              const counts = { [WITHIN]: 0, [ABOVE]: 0, [UNKNOWN]: 0 };
+              const aboveTasks = [];
+              const unknownTasks = [];
+
               const lines = [];
-              lines.push('| Task | base mean (ms) | head mean (ms) | Δ mean | base ops/s | head ops/s | Δ ops/s |');
-              lines.push('|---|---:|---:|---:|---:|---:|---:|');
+              lines.push(
+                '| Task | base mean (ms) | head mean (ms) | Δ mean | mean vs floor | base ops/s | head ops/s | Δ ops/s | ops/s vs floor |',
+              );
+              lines.push('|---|---:|---:|---:|:---|---:|---:|---:|:---|');
 
               for (const name of taskNames) {
                 const b = baseMap.get(name);
                 const h = headMap.get(name);
-                const baseMean = b?.mean_ms ?? null;
-                const headMean = h?.mean_ms ?? null;
-                const baseHz = b?.hz ?? null;
-                const headHz = h?.hz ?? null;
+                const baseMean = numberOrNull(b?.mean_ms);
+                const headMean = numberOrNull(h?.mean_ms);
+                const baseHz = numberOrNull(b?.hz);
+                const headHz = numberOrNull(h?.hz);
 
                 const meanDelta =
-                  baseMean != null && headMean != null ? ((headMean - baseMean) / baseMean) * 100 : null;
-                const hzDelta = baseHz != null && headHz != null ? ((headHz - baseHz) / baseHz) * 100 : null;
+                  baseMean !== null && headMean !== null && baseMean !== 0
+                    ? ((headMean - baseMean) / baseMean) * 100
+                    : null;
+                const hzDelta =
+                  baseHz !== null && headHz !== null && baseHz !== 0
+                    ? ((headHz - baseHz) / baseHz) * 100
+                    : null;
+
+                const meanVerdict = classify(baseMean, headMean, floorFor(rows, suite.file, name, 'mean_ms'));
+                const hzVerdict = classify(baseHz, headHz, floorFor(rows, suite.file, name, 'hz'));
+                const state = worstState([meanVerdict.state, hzVerdict.state]);
+                counts[state] += 1;
+                if (state === ABOVE) aboveTasks.push(name);
+                if (state === UNKNOWN) unknownTasks.push(name);
 
                 lines.push(
-                  `| ${name} | ${format(baseMean, 6)} | ${format(headMean, 6)} | ${formatPercent(meanDelta)} | ${format(baseHz, 0)} | ${format(headHz, 0)} | ${formatPercent(hzDelta)} |`,
+                  `| ${cell(name)} | ${format(baseMean, 6)} | ${format(headMean, 6)} | ${formatPercent(meanDelta)} | ${renderVerdict(meanVerdict)} | ${format(baseHz, 0)} | ${format(headHz, 0)} | ${formatPercent(hzDelta)} | ${renderVerdict(hzVerdict)} |`,
                 );
               }
 
-              return lines.join('\n');
+              const notes = [];
+              if (taskNames.length === 0) {
+                // Also the symptom of a suite whose JSON is not the tinybench
+                // { tasks: [...] } shape at all -- document-put.json emits `rows`.
+                notes.push(
+                  '_No comparable tasks were parsed from this suite. An empty table is missing data, not agreement._',
+                );
+              } else {
+                if (baseline.ok && rows === null) {
+                  notes.push(
+                    `_The baseline has no rows for \`${suite.file}\`, so every task above is **UNKNOWN**._`,
+                  );
+                }
+                notes.push(
+                  `_${taskNames.length} task(s): ${counts[WITHIN]} within noise, ${counts[ABOVE]} **ABOVE FLOOR**, ${counts[UNKNOWN]} **UNKNOWN**._`,
+                );
+              }
+
+              return {
+                table: lines.join('\n'),
+                notes,
+                counts,
+                taskCount: taskNames.length,
+                aboveTasks,
+                unknownTasks,
+              };
             };
 
-            let body =
-              '# Benchmarks\n\n' +
-              advisory +
-              'Run: ' +
-              runUrl +
-              '\n\nSelected: ' +
-              selected +
-              '\n\n';
-            // Write the warning before parsing any PR-produced JSON so even a
-            // malformed benchmark result leaves an advisory report to upload.
-            fs.writeFileSync('bench-results/report.md', body);
-
-            let includedSuites = 0;
-            for (const suite of suites) {
-              const baseExists = fs.existsSync(suite.base);
-              const headExists = fs.existsSync(suite.head);
-              if (!baseExists && !headExists) continue;
-
-              const baseJson = baseExists ? readJson(suite.base) : { tasks: [] };
-              const headJson = headExists ? readJson(suite.head) : { tasks: [] };
-              body += `### ${suite.title}\n\n`;
-              body += formatSuite(baseJson, headJson);
-              if (baseJson.__parseError || headJson.__parseError) {
-                body += '\n\n';
-                body += [
-                  baseJson.__parseError ? `base parse error: ${baseJson.__parseError}` : null,
-                  headJson.__parseError ? `head parse error: ${headJson.__parseError}` : null,
-                ].filter(Boolean).join(' • ');
+            const buildFloorSection = () => {
+              const out = ['## Noise floor', ''];
+              if (!baseline.ok) {
+                out.push('> [!CAUTION]');
+                out.push(`> **No noise-floor baseline was available** - ${baseline.reason}.`);
+                out.push('> Nothing below has been cleared as noise: every task reads **UNKNOWN**, and a Δ of');
+                out.push('> any size may be pure run-to-run variance. Dispatch');
+                out.push('> `.github/workflows/benchmark-noise-floor.yml`, then regenerate');
+                out.push(`> \`${BASELINE_FILE}\` with \`node scripts/bench/noise-floor.mjs <results-dir> --emit-baseline ${BASELINE_FILE}\`.`);
+                out.push('');
+                return out.join('\n');
               }
-              body += `\n\n`;
-              includedSuites += 1;
-            }
 
-            if (includedSuites === 0) {
-              body += '_No matching benchmark suites ran for this PR._\n';
-            }
+              const p = baseline.provenance;
+              const ref = safeText(pick(p, 'ref')) ?? 'unknown ref';
+              const sha = shortSha(pick(p, 'sha'));
+              const measuredAt = safeText(pick(p, 'measuredAt', 'measured_at')) ?? 'unknown date';
+              const measuredAtSource = safeText(pick(p, 'measuredAtSource', 'measured_at_source'), 40);
+              const runs = finiteOrNull(pick(p, 'runs'));
+              const pairs = finiteOrNull(pick(p, 'pairsPerTask', 'pairs_per_task'));
+              const url = safeUrl(pick(p, 'runUrl', 'run_url'));
 
-            fs.writeFileSync('bench-results/report.md', body);
+              out.push('Every Δ below is judged against a **measured** floor: the largest |Δ%| that repeated');
+              out.push('runs of *identical* code produced for that same (suite, task, metric).');
+              out.push('');
+              out.push(`- Baseline: \`${BASELINE_FILE}\`, read from the ${baseline.source.origin}`);
+              out.push(
+                `- Measured on: \`${ref}\`${sha === null ? '' : ` @ \`${sha}\``} - ${measuredAt}${measuredAtSource === null ? '' : ` (${measuredAtSource})`}`,
+              );
+              out.push(
+                `- Runs: ${runs === null ? 'unknown' : runs}${pairs === null ? '' : ` (${pairs} pair(s) per task)`}, ${baseline.rowCount} (suite, task) row(s)`,
+              );
+              out.push(`- Measurement run: ${url === null ? '_not recorded_' : url}`);
+              out.push('');
+              out.push('> [!IMPORTANT]');
+              out.push('> **`within noise` is not proof that nothing changed.** The floor is measured by');
+              out.push('> building ONCE and repeating the run, so it **excludes build-to-build variance**;');
+              out.push('> this job builds base and head separately. The floor is therefore a **lower bound**');
+              out.push('> on the noise in this comparison.');
+              out.push('>');
+              out.push('> The floor is an absolute |Δ%| while the Δ columns are signed: a -40% "improvement"');
+              out.push('> on a task with a 38% floor is exactly as much noise as +40%. **ABOVE FLOOR** means');
+              out.push('> the magnitude falls outside the floor in *either* direction; it does not by itself');
+              out.push('> mean regression.');
+              out.push('>');
+              out.push('> The `vs floor` columns quote the statistic the floor is defined by,');
+              out.push('> `|base - head| / min(base, head) * 100`, which is why they can read slightly larger');
+              out.push('> than the signed, base-divided Δ beside them.');
+              out.push('');
+              out.push(
+                'Legend: `within (x% <= f%)` is inside the floor measured for that task; `**ABOVE FLOOR**` is outside it and is the row worth reading; `**UNKNOWN**` means no floor exists for this (suite, task, metric) - a new task, a renamed task, a stale baseline, or a metric the A/A run could not resolve. **UNKNOWN is not "fine".**',
+              );
+              out.push('');
+              return out.join('\n');
+            };
+
+            const listNames = (names, limit = 20) => {
+              const shown = names.slice(0, limit).map((name) => `\`${cell(name)}\``);
+              const extra = names.length - shown.length;
+              return shown.join(', ') + (extra > 0 ? `, and ${extra} more` : '');
+            };
+
+            const buildSummary = (rows) => {
+              const out = ['## Noise-floor summary', ''];
+              out.push('| Suite | tasks | within noise | ABOVE FLOOR | UNKNOWN |');
+              out.push('|---|---:|---:|---:|---:|');
+
+              const total = { [WITHIN]: 0, [ABOVE]: 0, [UNKNOWN]: 0 };
+              let totalTasks = 0;
+              for (const row of rows) {
+                out.push(
+                  `| ${cell(row.title)} | ${row.taskCount} | ${row.counts[WITHIN]} | ${row.counts[ABOVE]} | ${row.counts[UNKNOWN]} |`,
+                );
+                total[WITHIN] += row.counts[WITHIN];
+                total[ABOVE] += row.counts[ABOVE];
+                total[UNKNOWN] += row.counts[UNKNOWN];
+                totalTasks += row.taskCount;
+              }
+              out.push(
+                `| **Total** | **${totalTasks}** | **${total[WITHIN]}** | **${total[ABOVE]}** | **${total[UNKNOWN]}** |`,
+              );
+              out.push('');
+
+              // A suite that produced no comparable tasks reads as `0 | 0 | 0 | 0`
+              // in the table above, which looks like a clean sweep. Name it.
+              const emptySuites = rows.filter((row) => row.taskCount === 0).map((row) => row.file);
+              if (emptySuites.length > 0) {
+                out.push(
+                  `**No comparable tasks** (missing data, not agreement): ${listNames(emptySuites)}`,
+                );
+                out.push('');
+              }
+
+              const qualify = (row, name) => `${row.file} > ${name}`;
+              const aboveAll = rows.flatMap((row) => row.aboveTasks.map((name) => qualify(row, name)));
+              const unknownAll = rows.flatMap((row) => row.unknownTasks.map((name) => qualify(row, name)));
+
+              if (aboveAll.length > 0) {
+                out.push(`**Above their floor**, read these first: ${listNames(aboveAll)}`);
+                out.push('');
+              } else if (baseline.ok && totalTasks > 0) {
+                out.push(
+                  '_No task exceeded its measured floor. That is a lower bound, not a clean bill of health - the floor excludes build-to-build variance._',
+                );
+                out.push('');
+              }
+
+              if (unknownAll.length > 0) {
+                out.push(`**No floor, so not cleared**: ${listNames(unknownAll)}`);
+                out.push('');
+              }
+
+              return out.join('\n');
+            };
+
+            const render = () => {
+              const [owner, repo] = (process.env.GITHUB_REPOSITORY || '/').split('/');
+              const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+              const selected = process.env.BENCH_SELECTED_SUITES || 'none';
+
+              const header =
+                '# Benchmarks\n\n' +
+                advisory +
+                'Run: ' +
+                runUrl +
+                '\n\nSelected: ' +
+                selected +
+                '\n\n' +
+                buildFloorSection() +
+                '\n';
+
+              // Write the warning and the floor caveats before parsing any
+              // PR-produced JSON, so even a malformed benchmark result leaves an
+              // advisory report to upload.
+              writeReport(header);
+
+              const rows = [];
+              let suitesBody = '';
+              for (const suite of suites) {
+                const basePath = `bench-results/base/${suite.file}`;
+                const headPath = `bench-results/head/${suite.file}`;
+                const baseExists = fs.existsSync(basePath);
+                const headExists = fs.existsSync(headPath);
+                if (!baseExists && !headExists) continue;
+
+                const baseJson = baseExists ? readJson(basePath) : { tasks: [] };
+                const headJson = headExists ? readJson(headPath) : { tasks: [] };
+                const rendered = formatSuite(suite, baseJson, headJson);
+                rows.push({ title: suite.title, file: suite.file, ...rendered });
+
+                suitesBody += `### ${suite.title}\n\n`;
+                suitesBody += rendered.table;
+                suitesBody += '\n\n';
+                if (rendered.notes.length > 0) {
+                  // Blank line between notes: two adjacent italic lines would
+                  // otherwise render as one run-on paragraph.
+                  suitesBody += `${rendered.notes.join('\n\n')}\n\n`;
+                }
+                if (baseJson.__parseError || headJson.__parseError) {
+                  suitesBody += [
+                    baseJson.__parseError ? `base parse error: ${baseJson.__parseError}` : null,
+                    headJson.__parseError ? `head parse error: ${headJson.__parseError}` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' • ');
+                  suitesBody += '\n\n';
+                }
+              }
+
+              if (rows.length === 0) {
+                return `${header}_No matching benchmark suites ran for this PR._\n`;
+              }
+
+              return header + buildSummary(rows) + '\n' + suitesBody;
+            };
+
+            // A report is never a gate; this step runs under `if: always()` for a
+            // reason. Whatever happens above, exit 0 and leave the most complete
+            // report that could be built.
+            try {
+              writeReport(render());
+            } catch (error) {
+              writeReport(
+                `# Benchmarks\n\n${advisory}> [!CAUTION]\n> The benchmark report failed to render (${errorMessage(error)}).\n> No Δ in this run was compared against the noise floor.\n`,
+              );
+              console.error(`benchmark report rendering failed: ${errorMessage(error)}`);
+            }
           NODE
 
       - name: Upload benchmark results

--- a/scripts/bench/noise-floor-baseline.json
+++ b/scripts/bench/noise-floor-baseline.json
@@ -1,0 +1,46 @@
+{
+  "decisionRule": "An A/B delta on task T is evidence only if it exceeds T's A/A max |Δ%|. Compare against the max column, not the p95 column.",
+  "deltaDefinition": "|a - b| / min(a, b) * 100 over all unordered run pairs",
+  "headline": {
+    "hz": {
+      "medianOfMax": null,
+      "tasksAbove10Pct": 0,
+      "tasksAbove5Pct": 0,
+      "tasksMeasured": 0,
+      "worstMax": null,
+      "worstTask": null
+    },
+    "mean_ms": {
+      "medianOfMax": null,
+      "tasksAbove10Pct": 0,
+      "tasksAbove5Pct": 0,
+      "tasksMeasured": 0,
+      "worstMax": null,
+      "worstTask": null
+    }
+  },
+  "headlineStatistic": "max |Δ%| observed across all unordered run pairs (never the p95: see the header comment)",
+  "note": "PLACEHOLDER. No A/A measurement has been committed yet: `tasks` is empty, so every tasks[<suite file>][<task name>] lookup misses and every A/B delta must read as UNKNOWN. Nothing here may be used to call a delta noise. Replace this file wholesale with the output of `node scripts/bench/noise-floor.mjs <results-dir> --emit-baseline scripts/bench/noise-floor-baseline.json`, run against a completed artifact from .github/workflows/benchmark-noise-floor.yml. That emitter refuses untrustworthy, partial and provenance-less measurements, so a file with status \"measured\" and a filled-in provenance block is one that passed those checks. Once measured, compare an A/B |Δ%| against `mean_ms` or `hz` on the matching entry; a null floor stays UNKNOWN and is never read as 0.",
+  "provenance": {
+    "distinctRuns": 0,
+    "generator": "scripts/bench/noise-floor.mjs --emit-baseline",
+    "measuredAt": null,
+    "measuredAtSource": null,
+    "minRuns": null,
+    "pairsPerTask": 0,
+    "ref": null,
+    "repeatsRequested": null,
+    "runUrl": null,
+    "runs": 0,
+    "selectedSuites": [],
+    "sha": null,
+    "sourceReportSchema": null,
+    "suitesCollected": 0,
+    "suitesKnown": 7,
+    "tasksPublished": 0
+  },
+  "rounding": "floors are rounded to 2 decimals AWAY from zero, so a published floor is never below the floor that was measured",
+  "schema": "peerbit-bench-noise-floor-baseline/1",
+  "status": "not-yet-measured",
+  "tasks": {}
+}

--- a/scripts/bench/noise-floor.mjs
+++ b/scripts/bench/noise-floor.mjs
@@ -11,6 +11,7 @@
 //
 // Usage:
 //   node scripts/bench/noise-floor.mjs <results-dir> [--min-runs <n>] [--json-out <path>]
+//                                      [--emit-baseline <path>]
 //
 // <results-dir> holds run-1/ ... run-N/, each containing the suite JSON files
 // benchmarks.yml already writes (same names).
@@ -153,17 +154,107 @@
 //
 // Output is a pure function of the input files: no timestamps, no randomness,
 // every list explicitly sorted.
+//
+// ---------------------------------------------------------------------------
+// THE COMMITTABLE BASELINE (--emit-baseline <path>)
+//
+// The report above lives for 14 days in an artifact. The A/B job that actually
+// needs it -- .github/workflows/benchmarks.yml, which prints a per-task "Δ mean"
+// with nothing to judge it against -- runs on every PR and cannot reach an
+// artifact. So `--emit-baseline` distils a completed results directory into one
+// small file (scripts/bench/noise-floor-baseline.json) that IS committed and can
+// be read at PR time.
+//
+// THE SHAPE IS A CONTRACT WITH A CONSUMER THAT ALREADY EXISTS. benchmarks.yml's
+// reporter indexes the file by the suite FILE name -- the same string it uses to
+// find bench-results/{base,head}/<file>.json -- and then by the exact task name
+// it is already rendering, and reads the metric straight off that entry:
+//
+//     tasks: { "<suite>.json": { "<task name>": { mean_ms, hz, n, unusable? } } }
+//     provenance: { ref, sha, runUrl, measuredAt, runs, pairsPerTask, ... }
+//
+// so `mean_ms` / `hz` are direct properties of the task entry (not nested one
+// level deeper), and provenance is camelCase like the report's own fields, not
+// metadata.json's snake_case. Both of those are the consumer's spelling; a
+// producer that invents its own would leave every row UNKNOWN forever while
+// looking perfectly well-formed. `n` and `unusable` ride along in the same
+// entry, ignored by that reader and there for a human.
+//
+// (One caveat this file cannot fix from here: JS object key order puts
+// integer-like keys first regardless of insertion order, so a benchmark task
+// literally named "1000" would sort ahead of the rest. Output stays
+// byte-deterministic either way -- that ordering is specified, not arbitrary --
+// it just would not be alphabetical. No current suite names a task that way.)
+//
+// A BASELINE IS COMMITTED, SO IT OUTLIVES ITS EXCUSES. That asymmetry drives
+// every rule below:
+//
+//   * Provenance is mandatory, and it is READ, never invented. ref, sha,
+//     run_url, repeats and the selected suites all come from the results
+//     directory's own metadata.json (written by benchmark-noise-floor.yml's
+//     "Record run metadata" step). Absent, unreadable, not that kind of
+//     directory, or carrying a run_url like "undefined/undefined/actions/runs/
+//     undefined" -- which is exactly what that step produces when it is run
+//     outside Actions -- and this refuses with exit 2. A number a reader cannot
+//     trace to a commit and a run is worse than no number: it cannot be
+//     re-measured, aged out, or argued with.
+//
+//   * measured_at prefers metadata.json's own `measured_at`; when the workflow
+//     that wrote the directory predates that field, it falls back to the file's
+//     mtime and SAYS SO in measured_at_source. A labelled weaker source beats
+//     both a fabricated timestamp and no date at all.
+//
+//   * It refuses to emit from a NOT TRUSTWORTHY report (exit 1). The whole
+//     failure mode this file exists to prevent is a floor that reads low, and
+//     baking one into the repo makes it permanent and invisible.
+//
+//   * It refuses below BASELINE_MIN_RUNS usable runs even when --min-runs was
+//     set lower, and refuses when metadata.json asked for more repeats than
+//     produced usable runs. A partial run is a non-random subset -- the repeats
+//     that finished -- and its floor reads low.
+//
+//   * A floor of 0 is emitted as null, not as 0. `noVariationResolved` means no
+//     variation was RESOLVED (see above); committing it as a hard 0% would let
+//     every later A/B delta on that task clear the bar forever. null routes the
+//     consumer to its "unknown" path, and the reason survives in `unusable` so
+//     nothing is hidden. Same for never-measurable / invalid / single-sample
+//     metrics.
+//
+//   * Rounding is to 2 decimals AWAY from zero, never toward it: a 2.7249%
+//     measured floor is published as 2.73%, so rounding can never turn noise
+//     into a signal.
+//
+// The placeholder committed at scripts/bench/noise-floor-baseline.json has this
+// exact shape with status "not-yet-measured", zero tasks and null provenance, so
+// the consuming workflow always has a file to read and its "unknown" branch is
+// exercisable before any measurement lands.
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const USAGE =
-	"Usage: node scripts/bench/noise-floor.mjs <results-dir> [--min-runs <n>] [--json-out <path>]";
+	"Usage: node scripts/bench/noise-floor.mjs <results-dir> [--min-runs <n>] [--json-out <path>] [--emit-baseline <path>]";
 
 const DEFAULT_MIN_RUNS = 3;
 const ABSOLUTE_MIN_RUNS = 2;
 const DEFAULT_REPORT_NAME = "noise-floor.json";
+const METADATA_NAME = "metadata.json";
+const METADATA_KIND = "benchmark-noise-floor";
+const BASELINE_SCHEMA = "peerbit-bench-noise-floor-baseline/1";
+const BASELINE_DIGITS = 2;
+// Stricter than DEFAULT_MIN_RUNS is free here and ABSOLUTE_MIN_RUNS is not
+// enough: 2 runs give ONE pair, so the "max" is a single observation with no
+// tail at all. A report may be published from that; a committed baseline may
+// not.
+const BASELINE_MIN_RUNS = 3;
+// Exactly the shape benchmark-noise-floor.yml builds:
+// `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`.
+// Run that step outside Actions and every variable interpolates as the literal
+// string "undefined"; this pattern is what stops the resulting nonsense from
+// being committed as provenance.
+const RUN_URL_PATTERN = /^https:\/\/\S+\/actions\/runs\/\d+$/;
+const SHA_PATTERN = /^[0-9a-f]{7,64}$/;
 const P95_FRACTION = 0.95;
 const MAX_LISTED_PROBLEMS = 50;
 const SCHEMA = "peerbit-bench-noise-floor/2";
@@ -211,6 +302,17 @@ const METRICS = [
 
 export class UsageError extends Error {}
 
+// Refusal to publish a COMMITTED baseline. `exitCode` separates the two causes a
+// caller can act on differently: 2 means the directory is not a noise-floor
+// results directory (its metadata is missing or malformed), 1 means it is one
+// and the measurement in it is not good enough to commit.
+export class BaselineRefusal extends Error {
+	constructor(message, exitCode) {
+		super(message);
+		this.exitCode = exitCode;
+	}
+}
+
 const ensure = (condition, message) => {
 	if (!condition) throw new Error(message);
 };
@@ -224,6 +326,7 @@ export const parseArgs = (argv) => {
 	let resultsDir;
 	let minRuns = DEFAULT_MIN_RUNS;
 	let jsonOut;
+	let emitBaseline;
 	const pending = [...argv];
 
 	const takeValue = (flag, inline) => {
@@ -252,6 +355,8 @@ export const parseArgs = (argv) => {
 			minRuns = parsed;
 		} else if (flag === "--json-out") {
 			jsonOut = takeValue(flag, inline);
+		} else if (flag === "--emit-baseline") {
+			emitBaseline = takeValue(flag, inline);
 		} else if (argument.startsWith("-")) {
 			throw new UsageError(`Unknown option: ${argument}`);
 		} else if (resultsDir === undefined) {
@@ -266,6 +371,7 @@ export const parseArgs = (argv) => {
 		resultsDir,
 		minRuns,
 		jsonOut: jsonOut ?? path.join(resultsDir, DEFAULT_REPORT_NAME),
+		emitBaseline,
 	};
 };
 
@@ -565,9 +671,22 @@ export const analyze = ({ resultsDir, minRuns = DEFAULT_MIN_RUNS }) => {
 	// identical bytes twice -- see the `deterministic` handling below.
 	const signatures = new Map();
 	for (const read of usable) {
+		// Signature over NORMALISED measurements, not raw bytes. A byte digest is
+		// defeated by any re-serialise - pretty-printing, key order, a trailing
+		// newline - and what matters is whether two run directories carry the same
+		// numbers, not whether one writer produced both. A hand-made copy that has
+		// been round-tripped through JSON.parse/stringify is exactly the case that
+		// must not slip through, because buildBaseline now refuses on this.
 		const parts = [...read.suites.entries()]
-			.filter(([, suite]) => suite.digest !== null)
-			.map(([file, suite]) => `${file}\u0000${suite.digest}`)
+			.filter(([, suite]) => suite.tasks.size > 0)
+			.map(([file, suite]) =>
+				[
+					file,
+					...[...suite.tasks.values()]
+						.map((task) => `${task.name}=${task.mean_ms}/${task.hz}`)
+						.sort(byName),
+				].join("\u0000"),
+			)
 			.sort(byName);
 		if (parts.length === 0) continue;
 		const signature = crypto
@@ -588,6 +707,11 @@ export const analyze = ({ resultsDir, minRuns = DEFAULT_MIN_RUNS }) => {
 		);
 
 	const runCount = usable.length;
+	// Directories, not measurements. `signatures` groups runs by their normalised
+	// contents, so its size is how many INDEPENDENT measurements we actually have.
+	// buildBaseline refuses on this rather than on runCount: a padded results
+	// directory would otherwise commit a baseline asserting a run count it never had.
+	const distinctRunCount = signatures.size > 0 ? signatures.size : usable.length;
 	if (discovered.length === 0)
 		add(
 			"blocking",
@@ -977,6 +1101,7 @@ export const analyze = ({ resultsDir, minRuns = DEFAULT_MIN_RUNS }) => {
 		})),
 		excludedRuns: excluded.map((read) => read.run.name),
 		runCount,
+		distinctRunCount,
 		pairsPerTask,
 		// "Collected" means at least one run produced usable tasks. A suite that is
 		// present-but-broken everywhere is NOT collected and is counted separately,
@@ -1197,6 +1322,257 @@ export const renderMarkdown = (report) => {
 	return lines.join("\n");
 };
 
+// Rounds AWAY from zero, never toward it. `Number(x.toFixed(2))` alone would
+// publish a measured 2.7249% floor as 2.72%, and a subsequent A/B delta of
+// 2.73% would then read as "above the floor" on the strength of a rounding
+// step. toFixed first (not `Math.ceil(x * 100) / 100`, which turns 1.1 into
+// 1.11 because 1.1 * 100 is 110.00000000000001), then nudge by one unit in the
+// last place only when the rounded value actually landed below the input.
+export const ceilTo = (value, digits) => {
+	if (value === null || value === undefined) return null;
+	const rounded = Number(value.toFixed(digits));
+	if (rounded >= value) return rounded;
+	return Number((rounded + 10 ** -digits).toFixed(digits));
+};
+
+// Byte-stable serialisation: object keys sorted at every depth, two-space
+// indent, trailing newline. Sorting here rather than at construction means the
+// order is a property of the writer, so a later field added anywhere still lands
+// in the same place. (Suite and task names are data, and JS hoists integer-like
+// keys ahead of the rest on output -- deterministic, just not alphabetical.)
+const sortKeysDeep = (value) => {
+	if (Array.isArray(value)) return value.map(sortKeysDeep);
+	if (value !== null && typeof value === "object")
+		return Object.fromEntries(
+			Object.keys(value)
+				.sort(byName)
+				.map((key) => [key, sortKeysDeep(value[key])]),
+		);
+	return value;
+};
+
+export const stringifyBaseline = (baseline) =>
+	`${JSON.stringify(sortKeysDeep(baseline), null, 2)}\n`;
+
+// The provenance source. Read from the results directory, never synthesised:
+// benchmark-noise-floor.yml's "Record run metadata" step writes this file before
+// a single benchmark runs, precisely so the numbers can be traced back to a ref,
+// a commit and a run.
+export const readMeasurementMetadata = (resultsDir) => {
+	const file = path.join(resultsDir, METADATA_NAME);
+	// The standing sentence comes BEFORE the list, so a bulleted complaint is
+	// never mistaken for carrying it.
+	const refuse = (detail, list = []) =>
+		new BaselineRefusal(
+			`${file}: ${detail}. A committed baseline without provenance cannot be traced to a commit, re-measured, or aged out, so it is worse than no baseline; refusing to emit one.${list
+				.map((entry) => `\n  - ${entry}`)
+				.join("")}`,
+			2,
+		);
+
+	let raw;
+	let stats;
+	try {
+		raw = fs.readFileSync(file, "utf8");
+		stats = fs.statSync(file);
+	} catch (error) {
+		throw refuse(
+			error.code === "ENOENT"
+				? `not found (benchmark-noise-floor.yml writes it into the results directory; a hand-assembled directory has to carry one too)`
+				: `unreadable (${error.message})`,
+		);
+	}
+
+	let parsed;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw refuse(`JSON parse error: ${error.message}`);
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+		throw refuse("is not a JSON object");
+
+	const complaints = [];
+	if (parsed.kind !== METADATA_KIND)
+		complaints.push(
+			`kind must be "${METADATA_KIND}" (got ${JSON.stringify(parsed.kind)}) -- this does not look like a noise-floor results directory`,
+		);
+	if (typeof parsed.ref !== "string" || parsed.ref.trim() === "")
+		complaints.push("ref must be a non-empty string");
+	if (typeof parsed.sha !== "string" || !SHA_PATTERN.test(parsed.sha))
+		complaints.push(
+			`sha must be a hex commit id (got ${JSON.stringify(parsed.sha)})`,
+		);
+	if (!Number.isInteger(parsed.repeats) || parsed.repeats < ABSOLUTE_MIN_RUNS)
+		complaints.push(
+			`repeats must be a whole number >= ${ABSOLUTE_MIN_RUNS} (got ${JSON.stringify(parsed.repeats)})`,
+		);
+	if (
+		!Array.isArray(parsed.selected_suites) ||
+		parsed.selected_suites.length === 0 ||
+		parsed.selected_suites.some(
+			(entry) => typeof entry !== "string" || entry.trim() === "",
+		)
+	)
+		complaints.push("selected_suites must be a non-empty array of strings");
+	if (typeof parsed.run_url !== "string" || !RUN_URL_PATTERN.test(parsed.run_url))
+		complaints.push(
+			`run_url must look like https://<host>/<owner>/<repo>/actions/runs/<id> (got ${JSON.stringify(parsed.run_url)}); a metadata step run outside Actions emits "undefined/undefined/actions/runs/undefined" here, and that must never be committed as provenance`,
+		);
+	// Optional, and only because the workflow that produced the first artifacts
+	// did not write it. When it is present it is authoritative; when it is not,
+	// the mtime stands in and the baseline says which one it used.
+	if (
+		parsed.measured_at !== undefined &&
+		(typeof parsed.measured_at !== "string" ||
+			Number.isNaN(Date.parse(parsed.measured_at)))
+	)
+		complaints.push(
+			`measured_at, when present, must be an ISO-8601 timestamp (got ${JSON.stringify(parsed.measured_at)})`,
+		);
+	if (complaints.length > 0)
+		throw refuse(
+			`${complaints.length} problem(s) with the recorded run metadata`,
+			complaints,
+		);
+
+	const measuredAt = parsed.measured_at ?? stats.mtime.toISOString();
+	return {
+		kind: parsed.kind,
+		ref: parsed.ref,
+		sha: parsed.sha,
+		repeats: parsed.repeats,
+		selected_suites: [...parsed.selected_suites],
+		run_url: parsed.run_url,
+		measured_at: measuredAt,
+		measured_at_source:
+			parsed.measured_at === undefined
+				? `${METADATA_NAME} mtime (the run that wrote it recorded no measured_at field)`
+				: `${METADATA_NAME} field measured_at`,
+	};
+};
+
+// Why a metric publishes no floor. All four route a consumer to its "unknown"
+// branch; they are distinguished so the baseline can say WHICH kind of nothing
+// it is holding. "no-variation-resolved" is the dangerous one -- it has a
+// number, 0, and that number must not be published as a floor.
+const unusableReason = (stats) => {
+	if (!stats) return "unmeasured";
+	if (stats.status !== "ok") return stats.status;
+	return stats.noVariationResolved ? "no-variation-resolved" : null;
+};
+
+export const buildBaseline = ({ report, metadata }) => {
+	const tasks = {};
+	let taskCount = 0;
+	let withFloor = 0;
+	for (const suite of report.suites) {
+		if (suite.tasks.length === 0) continue;
+		const bySuite = {};
+		for (const task of suite.tasks) {
+			const entry = { n: task.n };
+			const unusable = {};
+			for (const metric of METRICS) {
+				const stats = task.metrics[metric.key];
+				const reason = unusableReason(stats);
+				if (reason === null) {
+					entry[metric.key] = ceilTo(stats.max_abs_delta_pct, BASELINE_DIGITS);
+					withFloor += 1;
+				} else {
+					// The key is still present, holding null. benchmarks.yml's
+					// taskFloor() requires a finite value > 0, so an omitted key and
+					// a 0 would both be wrong in the same direction; null is the only
+					// value that routes it to UNKNOWN.
+					entry[metric.key] = null;
+					unusable[metric.key] = reason;
+				}
+			}
+			if (Object.keys(unusable).length > 0) entry.unusable = unusable;
+			bySuite[task.name] = entry;
+			taskCount += 1;
+		}
+		tasks[suite.file] = bySuite;
+	}
+
+	const refusals = [];
+	if (!report.trustworthy)
+		refusals.push(
+			`the report is NOT TRUSTWORTHY (${report.blockingCount} blocking problem(s)); every blocking problem this script raises is one that can bias the floor DOWNWARD, and a floor committed too low silently blesses every later perf claim`,
+		);
+	if (report.runCount < BASELINE_MIN_RUNS)
+		refusals.push(
+			`only ${report.runCount} usable run(s); a committed baseline needs at least ${BASELINE_MIN_RUNS} (${ABSOLUTE_MIN_RUNS} runs give a single pair, so the "max" would be one observation with no tail)`,
+		);
+	if (report.distinctRunCount < BASELINE_MIN_RUNS)
+		refusals.push(
+			`${report.runCount} run director(ies) carry only ${report.distinctRunCount} distinct measurement(s); duplicated runs contribute a fabricated 0% to every pair, which drags the max DOWN, and the committed file would still claim runs: ${report.runCount}. A baseline is read for months after the results directory is gone, so it must not assert a run count it never had`,
+		);
+	if (report.runCount < metadata.repeats)
+		refusals.push(
+			`${METADATA_NAME} asked for ${metadata.repeats} repeat(s) but only ${report.runCount} produced a usable run; the repeats that finished are not a random subset of the repeats that were asked for, so their floor reads low. Re-run this with --min-runs ${metadata.repeats} to see what went missing`,
+		);
+	if (withFloor === 0)
+		refusals.push(
+			"not one (suite, task, metric) produced a usable floor, so the baseline would answer \"unknown\" for every row it was consulted about; that is what the not-yet-measured placeholder is for",
+		);
+	if (refusals.length > 0)
+		throw new BaselineRefusal(
+			refusals.map((entry) => `  - ${entry}`).join("\n"),
+			1,
+		);
+
+	const headline = {};
+	for (const metric of METRICS) {
+		const stats = report.summary[metric.key];
+		headline[metric.key] = {
+			tasksMeasured: stats.tasksMeasured,
+			medianOfMax: ceilTo(stats.medianOfMax, BASELINE_DIGITS),
+			worstMax: ceilTo(stats.worstMax, BASELINE_DIGITS),
+			worstTask: stats.worstTask
+				? { suite: stats.worstTask.suite, task: stats.worstTask.task }
+				: null,
+			tasksAbove5Pct: stats.tasksAbove5Pct,
+			tasksAbove10Pct: stats.tasksAbove10Pct,
+		};
+	}
+
+	return {
+		schema: BASELINE_SCHEMA,
+		status: "measured",
+		note: "Per-task A/A noise floor: the largest |Δ%| that IDENTICAL code produced between two runs. Look an entry up as tasks[<suite file>][<task name>] and compare the A/B |Δ%| against `mean_ms` or `hz` on it. A null floor means no floor was measured for that metric (see `unusable`) and MUST be treated as unknown, never as 0 -- in particular `no-variation-resolved` means the runs agreed to the source's own rounding step, which is not the same as a benchmark that cannot move.",
+		decisionRule: DECISION_RULE,
+		deltaDefinition: report.deltaDefinition,
+		headlineStatistic: HEADLINE_STATISTIC,
+		rounding: `floors are rounded to ${BASELINE_DIGITS} decimals AWAY from zero, so a published floor is never below the floor that was measured`,
+		provenance: {
+			generator: "scripts/bench/noise-floor.mjs --emit-baseline",
+			sourceReportSchema: report.schema,
+			ref: metadata.ref,
+			sha: metadata.sha,
+			runUrl: metadata.run_url,
+			measuredAt: metadata.measured_at,
+			measuredAtSource: metadata.measured_at_source,
+			selectedSuites: metadata.selected_suites,
+			repeatsRequested: metadata.repeats,
+			runs: report.runCount,
+			// Recorded, not merely checked. The refusal above only rejects a results
+			// directory whose distinct count falls below BASELINE_MIN_RUNS, so some
+			// duplication can still pass - and a legitimately deterministic model
+			// suite really can emit two identical runs. Committing both numbers keeps
+			// the file honest about what it is: `runs` is directories, `distinctRuns`
+			// is independent measurements, and only the second bounds the tail.
+			distinctRuns: report.distinctRunCount,
+			pairsPerTask: report.pairsPerTask,
+			minRuns: report.minRuns,
+			suitesCollected: report.suitesCollected,
+			suitesKnown: report.suitesKnown,
+			tasksPublished: taskCount,
+		},
+		headline,
+		tasks,
+	};
+};
+
 export const runCli = (
 	argv,
 	{ log = console.log, logError = console.error } = {},
@@ -1231,6 +1607,33 @@ export const runCli = (
 	fs.mkdirSync(path.dirname(jsonOut), { recursive: true });
 	fs.writeFileSync(jsonOut, `${JSON.stringify(report, null, 2)}\n`);
 	log(renderMarkdown(report));
+
+	// Additive, not a separate mode: the markdown above is the diagnosis, and a
+	// refusal to emit a baseline is exactly when a reader most needs it printed
+	// next to the reason.
+	if (options.emitBaseline !== undefined) {
+		let baseline;
+		try {
+			baseline = buildBaseline({
+				report,
+				metadata: readMeasurementMetadata(root),
+			});
+		} catch (error) {
+			if (!(error instanceof BaselineRefusal)) throw error;
+			logError(
+				`noise-floor: refusing to emit a committable baseline from ${root}:`,
+			);
+			logError(error.message);
+			return error.exitCode;
+		}
+		const baselineOut = path.resolve(options.emitBaseline);
+		fs.mkdirSync(path.dirname(baselineOut), { recursive: true });
+		fs.writeFileSync(baselineOut, stringifyBaseline(baseline));
+		logError(
+			`noise-floor: baseline written to ${baselineOut} (${baseline.provenance.tasksPublished} task(s), measured at ${baseline.provenance.sha} in ${baseline.provenance.runUrl})`,
+		);
+	}
+
 	if (!report.trustworthy) {
 		logError(
 			`noise-floor: ${report.blockingCount} blocking problem(s); the measured floor would be understated. Report written to ${jsonOut}`,

--- a/scripts/bench/noise-floor.spec.mjs
+++ b/scripts/bench/noise-floor.spec.mjs
@@ -5,12 +5,16 @@ import path from "node:path";
 import test from "node:test";
 import {
 	analyze,
+	buildBaseline,
+	ceilTo,
 	median,
 	p95IsJustTheMaximum,
 	pairwiseAbsDeltasPct,
 	percentileNearestRank,
+	readMeasurementMetadata,
 	renderMarkdown,
 	runCli,
+	stringifyBaseline,
 } from "./noise-floor.mjs";
 
 const withFixture = (body) => {
@@ -107,6 +111,72 @@ const captureCli = (argv) => {
 	});
 	return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n") };
 };
+
+// Field-for-field what .github/workflows/benchmark-noise-floor.yml's "Record run
+// metadata" step writes into the results directory. The baseline emitter reads
+// its entire provenance from here, so a fixture that drifts from that step is a
+// test that proves nothing.
+const METADATA = {
+	kind: "benchmark-noise-floor",
+	note: "One commit, one build, repeated runs.",
+	ref: "master",
+	sha: "b776198cd0bb1a2c3d4e5f60718293a4b5c6d7e8",
+	repeats: 3,
+	selected_suites: ["shared-log", "transport", "document"],
+	run_url: "https://github.com/dao-xyz/peerbit/actions/runs/31844749062",
+	measured_at: "2026-08-15T09:00:00.000Z",
+};
+
+const writeMetadata = (root, overrides = {}) => {
+	const metadata = { ...METADATA, ...overrides };
+	// An explicit `undefined` in `overrides` means "this run wrote no such
+	// field", which is how the artifacts predating `measured_at` look.
+	for (const [key, value] of Object.entries(overrides))
+		if (value === undefined) delete metadata[key];
+	fs.writeFileSync(
+		path.join(root, "metadata.json"),
+		typeof overrides.raw === "string"
+			? overrides.raw
+			: `${JSON.stringify(metadata, null, 2)}\n`,
+	);
+	return metadata;
+};
+
+// Three runs of one suite plus the metadata the emitter demands: the smallest
+// input a committable baseline is allowed to come from.
+const baselineFixture = (root, means = [100, 101, 102.7249], overrides = {}) => {
+	means.forEach((meanMs, index) =>
+		writeSuite(
+			root,
+			`run-${index + 1}`,
+			"pid-convergence.json",
+			suite(task("T", meanMs)),
+		),
+	);
+	return writeMetadata(root, overrides);
+};
+
+const readBaseline = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+// Exactly how .github/workflows/benchmarks.yml reads a floor: index by the suite
+// FILE name, then by the task name, then take the metric straight off the entry.
+// Going through this helper rather than poking at the object keeps the tests
+// honest about the contract that matters.
+const consumerFloor = (baseline, file, taskName, metricKey) => {
+	const floors = baseline.tasks[file];
+	if (!floors || !Object.hasOwn(floors, taskName)) return null;
+	const entry = floors[taskName];
+	if (!entry || !Object.hasOwn(entry, metricKey)) return null;
+	const value = entry[metricKey];
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
+		? value
+		: null;
+};
+
+const COMMITTED_BASELINE = new URL(
+	"./noise-floor-baseline.json",
+	import.meta.url,
+);
 
 const round6 = (value) => Number(value.toFixed(6));
 
@@ -1391,5 +1461,480 @@ test("a metric invalid in EVERY run warns; invalid in only SOME runs still block
 		);
 		// The always-zero lag is still only a warning even in this run.
 		assert.ok(!blocking.includes("metric-never-measurable"));
+	});
+});
+
+// --------------------------------------------------------------------------
+// --emit-baseline: the committable file.
+
+test("the emitted baseline carries the per-task floor, rounded away from zero", () => {
+	// Rounding a floor DOWN would let the rounding step itself turn noise into a
+	// signal: a task whose identical code moved 2.7249% must not be published as
+	// 2.72%, because a later A/B delta of 2.73% would then read as "above the
+	// floor". 1.1 is the float trap -- Math.ceil(1.1 * 100) / 100 is 1.11.
+	assert.equal(ceilTo(2.7249, 2), 2.73);
+	assert.equal(ceilTo(2.72, 2), 2.72);
+	assert.equal(ceilTo(1.1, 2), 1.1);
+	assert.equal(ceilTo(0, 2), 0);
+	assert.equal(ceilTo(null, 2), null);
+
+	withFixture((root) => {
+		baselineFixture(root);
+		const out = path.join(root, "baseline.json");
+		const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 0);
+
+		const baseline = readBaseline(out);
+		assert.equal(baseline.schema, "peerbit-bench-noise-floor-baseline/1");
+		assert.equal(baseline.status, "measured");
+		assert.equal(baseline.provenance.tasksPublished, 1);
+
+		// 100 vs 102.7249 is the widest pair, so the floor is 2.7249% -> 2.73%,
+		// and |Δ%| is reciprocal-invariant so hz reports the same number. Read the
+		// way the consumer reads it: tasks[<suite file>][<task name>][<metric>].
+		assert.equal(consumerFloor(baseline, "pid-convergence.json", "T", "mean_ms"), 2.73);
+		assert.equal(consumerFloor(baseline, "pid-convergence.json", "T", "hz"), 2.73);
+		const entry = baseline.tasks["pid-convergence.json"].T;
+		assert.equal(entry.n, 3);
+		// `unusable` is present only when something is unusable.
+		assert.equal("unusable" in entry, false);
+		// A task the baseline has never heard of stays unknown -- no inheriting
+		// the floor of a neighbour, and no suite-level default.
+		assert.equal(consumerFloor(baseline, "pid-convergence.json", "T2", "mean_ms"), null);
+		assert.equal(consumerFloor(baseline, "file-ingest.json", "T", "mean_ms"), null);
+
+		// The A/A report's own numbers travel with it, so a reader can see how
+		// wide the whole distribution was without the artifact.
+		assert.equal(baseline.headline.mean_ms.tasksMeasured, 1);
+		assert.equal(baseline.headline.mean_ms.worstMax, 2.73);
+		assert.deepEqual(baseline.headline.mean_ms.worstTask, {
+			suite: "pid-convergence.json",
+			task: "T",
+		});
+		assert.equal(baseline.provenance.runs, 3);
+		assert.equal(baseline.provenance.pairsPerTask, 3);
+		assert.match(stderr, /baseline written to/);
+	});
+});
+
+test("the baseline is byte-deterministic with sorted keys and stable task order", () => {
+	withFixture((root) => {
+		// Two suites whose order in the SUITES list is the REVERSE of their
+		// alphabetical order (sync-batch-sweep is declared before pid-convergence),
+		// and tasks written in reverse order within a file. Anything that leans on
+		// discovery order instead of sorting therefore shows up as a diff.
+		for (const [run, offset] of [
+			["run-1", 0],
+			["run-2", 1],
+			["run-3", 3],
+		]) {
+			writeSuite(
+				root,
+				run,
+				"sync-batch-sweep.json",
+				suite(task("zeta", 10 + offset), task("alpha", 20 + offset)),
+			);
+			writeSuite(
+				root,
+				run,
+				"pid-convergence.json",
+				suite(task("beta", 30 + offset)),
+			);
+		}
+		writeMetadata(root);
+
+		const first = path.join(root, "one.json");
+		const second = path.join(root, "two.json");
+		assert.equal(captureCli([root, "--emit-baseline", first]).code, 0);
+		assert.equal(captureCli([root, "--emit-baseline", second]).code, 0);
+		const bytes = fs.readFileSync(first, "utf8");
+		assert.equal(bytes, fs.readFileSync(second, "utf8"));
+
+		// Keys sorted at every depth -- including the suite and task names, which
+		// are data -- independent of the SUITES declaration order, so reordering
+		// that list can never produce a committed diff with no content in it.
+		const baseline = JSON.parse(bytes);
+		const sorted = (value) => [...Object.keys(value)].sort();
+		assert.deepEqual(Object.keys(baseline.tasks), [
+			"pid-convergence.json",
+			"sync-batch-sweep.json",
+		]);
+		assert.deepEqual(Object.keys(baseline.tasks["sync-batch-sweep.json"]), [
+			"alpha",
+			"zeta",
+		]);
+		assert.deepEqual(Object.keys(baseline), sorted(baseline));
+		assert.deepEqual(
+			Object.keys(baseline.provenance),
+			sorted(baseline.provenance),
+		);
+
+		// Two-space indent, trailing newline, and the serialiser rather than the
+		// construction order is what guarantees the ordering, so the committed
+		// file re-serialises to itself byte for byte.
+		assert.equal(stringifyBaseline(baseline), bytes);
+		assert.ok(bytes.endsWith("}\n"));
+	});
+});
+
+test("provenance is read from metadata.json, never invented", () => {
+	withFixture((root) => {
+		baselineFixture(root);
+		const out = path.join(root, "baseline.json");
+		assert.equal(captureCli([root, "--emit-baseline", out]).code, 0);
+
+		const { provenance } = readBaseline(out);
+		// Every one of these is quoted straight from the file the workflow wrote.
+		// A baseline whose ref/sha/run URL came from the machine that happened to
+		// run the emitter would point at the wrong commit entirely. The camelCase
+		// spelling is the consumer's: benchmarks.yml reads p.runUrl / p.measuredAt
+		// / p.pairsPerTask, and a snake_case producer renders "unknown date" and
+		// "_not recorded_" while looking perfectly well-formed.
+		assert.equal(provenance.ref, METADATA.ref);
+		assert.equal(provenance.sha, METADATA.sha);
+		assert.equal(provenance.runUrl, METADATA.run_url);
+		assert.equal(provenance.measuredAt, METADATA.measured_at);
+		assert.match(provenance.measuredAtSource, /field measured_at/);
+		assert.deepEqual(provenance.selectedSuites, METADATA.selected_suites);
+		assert.equal(provenance.repeatsRequested, METADATA.repeats);
+		assert.equal(provenance.runs, 3);
+		assert.equal(provenance.pairsPerTask, 3);
+		assert.equal(provenance.suitesKnown, 7);
+		assert.equal(provenance.suitesCollected, 1);
+		assert.equal(
+			provenance.generator,
+			"scripts/bench/noise-floor.mjs --emit-baseline",
+		);
+	});
+
+	// The artifacts measured before the workflow recorded a timestamp still have
+	// to yield a dated baseline, so the file's own mtime stands in -- and says
+	// so, because a weaker source a reader can see beats a fabricated one.
+	withFixture((root) => {
+		baselineFixture(root, [100, 101, 102], { measured_at: undefined });
+		// Pinned to a distinctly past mtime on purpose: a fixture written moments
+		// ago has an mtime of ~now, so a fallback that quietly used `new Date()`
+		// would pass by coincidence.
+		const metadataFile = path.join(root, "metadata.json");
+		const measured = new Date("2026-02-03T04:05:06.789Z");
+		fs.utimesSync(metadataFile, measured, measured);
+
+		const out = path.join(root, "baseline.json");
+		assert.equal(captureCli([root, "--emit-baseline", out]).code, 0);
+
+		const { provenance } = readBaseline(out);
+		assert.equal(provenance.measuredAt, "2026-02-03T04:05:06.789Z");
+		assert.equal(
+			provenance.measuredAt,
+			fs.statSync(metadataFile).mtime.toISOString(),
+		);
+		assert.match(provenance.measuredAtSource, /mtime/);
+	});
+});
+
+test("a floor of zero is published as unknown, never as a usable 0%", () => {
+	withFixture((root) => {
+		// Three shapes in one suite: a task that never moved, a task whose metric
+		// is structurally 0 in every run (chunk-transfer's completion lags), and a
+		// task that actually varied.
+		const rows = (moving) => [
+			{ name: "identical", mean_ms: "12.5", hz: "80" },
+			{ name: "lag", mean_ms: "0", hz: "null" },
+			{ name: "moving", mean_ms: moving, hz: `${1000 / Number(moving)}` },
+		];
+		writeSuite(root, "run-1", "chunk-transfer.json", rawSuite(rows("10")));
+		writeSuite(root, "run-2", "chunk-transfer.json", rawSuite(rows("11")));
+		writeSuite(root, "run-3", "chunk-transfer.json", rawSuite(rows("12")));
+		writeMetadata(root);
+
+		const out = path.join(root, "baseline.json");
+		assert.equal(captureCli([root, "--emit-baseline", out]).code, 0);
+		const baseline = readBaseline(out);
+
+		// A committed 0 would be permanent permission: benchmarks.yml's taskFloor()
+		// accepts any finite value >= 0, so every later A/B delta on that task
+		// would clear it. Identical runs mean no variation was RESOLVED, which is
+		// not the same as a task that cannot move -- so the floor must read as
+		// unknown, and the reason has to survive somewhere a human can see it.
+		const floors = baseline.tasks["chunk-transfer.json"];
+		assert.equal(
+			consumerFloor(baseline, "chunk-transfer.json", "identical", "mean_ms"),
+			null,
+		);
+		assert.equal(floors.identical.unusable.mean_ms, "no-variation-resolved");
+		assert.equal(floors.identical.unusable.hz, "no-variation-resolved");
+
+		assert.equal(
+			consumerFloor(baseline, "chunk-transfer.json", "lag", "mean_ms"),
+			null,
+		);
+		assert.equal(floors.lag.unusable.mean_ms, "never-measurable");
+
+		// The real one still publishes a floor: 10 -> 12 is 20%.
+		assert.equal(
+			consumerFloor(baseline, "chunk-transfer.json", "moving", "mean_ms"),
+			20,
+		);
+
+		// Nothing anywhere in the file is a zero floor, and the key is present
+		// holding null rather than dropped -- both readings have to be unknown.
+		for (const [name, entry] of Object.entries(floors))
+			for (const metric of ["mean_ms", "hz"]) {
+				assert.ok(Object.hasOwn(entry, metric), `${name} dropped ${metric}`);
+				assert.notEqual(entry[metric], 0, `${name} published a 0% floor`);
+			}
+	});
+});
+
+test("refuses to emit a baseline from a NOT TRUSTWORTHY report", () => {
+	withFixture((root) => {
+		// A task that appears in only two of three runs: blocking, because the
+		// runs that produced it are the runs where nothing went wrong.
+		writeSuite(root, "run-1", "pid-convergence.json", suite(task("T", 100)));
+		writeSuite(root, "run-2", "pid-convergence.json", suite(task("T", 101)));
+		writeSuite(
+			root,
+			"run-3",
+			"pid-convergence.json",
+			suite(task("T", 102), task("only-here", 5)),
+		);
+		writeMetadata(root);
+
+		const out = path.join(root, "baseline.json");
+		const { code, stdout, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 1);
+		// Refusing must leave NOTHING behind: a half-written baseline would be
+		// committed as readily as a good one.
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /refusing to emit a committable baseline/);
+		assert.match(stderr, /NOT TRUSTWORTHY/);
+		// The diagnosis is still printed, which is the whole point of publishing
+		// the report even when it is unusable.
+		assert.match(stdout, /task-missing-in-run/);
+
+		// Control: with the stray task removed the same directory emits.
+		writeSuite(root, "run-3", "pid-convergence.json", suite(task("T", 102)));
+		assert.equal(captureCli([root, "--emit-baseline", out]).code, 0);
+		assert.equal(fs.existsSync(out), true);
+	});
+});
+
+test("refuses a baseline from too few runs, or from a partial run", () => {
+	// Two runs give ONE pair, so the "max" is a single observation with no tail.
+	// The REPORT may be published from that; a committed file may not, and
+	// --min-runs 2 must not be able to buy its way past that.
+	withFixture((root) => {
+		baselineFixture(root, [100, 110], { repeats: 2 });
+		const out = path.join(root, "baseline.json");
+
+		const plain = captureCli([root, "--min-runs", "2"]);
+		assert.equal(plain.code, 0, "the report itself is publishable");
+
+		const { code, stderr } = captureCli([
+			root,
+			"--min-runs",
+			"2",
+			"--emit-baseline",
+			out,
+		]);
+		assert.equal(code, 1);
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /only 2 usable run\(s\); a committed baseline needs/);
+	});
+
+	// A run that asked for 4 repeats and produced 3 is a NON-RANDOM subset --
+	// the repeats that finished -- and its floor reads low. The report cannot see
+	// this on its own: --min-runs 3 makes it trustworthy. metadata.json can.
+	withFixture((root) => {
+		baselineFixture(root, [100, 101, 102], { repeats: 4 });
+		const out = path.join(root, "baseline.json");
+
+		assert.equal(captureCli([root]).code, 0, "the report itself is publishable");
+		const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 1);
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /asked for 4 repeat\(s\) but only 3/);
+	});
+
+	// Every task unmeasurable: the file would answer "unknown" for every row it
+	// was ever consulted about, which is the placeholder's job, not a
+	// measurement's.
+	withFixture((root) => {
+		for (const run of ["run-1", "run-2", "run-3"])
+			writeSuite(
+				root,
+				run,
+				"chunk-transfer.json",
+				rawSuite([{ name: "lag", mean_ms: "0", hz: "null" }]),
+			);
+		writeMetadata(root);
+		const out = path.join(root, "baseline.json");
+		const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 1);
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /not one \(suite, task, metric\) produced a usable floor/);
+	});
+
+	// The same refusal is what stops copied run directories from being committed
+	// as a floor of zeros. analyze() only WARNS about byte-identical runs (a
+	// deterministic model suite can legitimately produce them), so the report
+	// stays publishable -- but every metric comes out no-variation-resolved, and
+	// a file that blesses every future A/B delta on every task must not be
+	// committed on the strength of a warning nobody read.
+	withFixture((root) => {
+		for (const run of ["run-1", "run-2", "run-3"])
+			writeSuite(root, run, "file-ingest.json", suite(task("ingest", 12.5)));
+		writeMetadata(root);
+		const out = path.join(root, "baseline.json");
+
+		assert.equal(captureCli([root]).code, 0, "the report itself is publishable");
+		const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 1);
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /not one \(suite, task, metric\) produced a usable floor/);
+	});
+});
+
+test("refuses a baseline when metadata.json is absent, malformed or not ours", () => {
+	// Exit 2, not 1: the directory is not a noise-floor results directory at all,
+	// which is a different thing from a measurement that came out badly.
+	withFixture((root) => {
+		baselineFixture(root);
+		fs.rmSync(path.join(root, "metadata.json"));
+		const out = path.join(root, "baseline.json");
+		const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+		assert.equal(code, 2);
+		assert.equal(fs.existsSync(out), false);
+		assert.match(stderr, /metadata\.json: not found/);
+		assert.match(stderr, /cannot be traced to a commit/);
+	});
+
+	const cases = [
+		["unparseable", { raw: "{ not json" }, /JSON parse error/],
+		["not an object", { raw: "[]\n" }, /is not a JSON object/],
+		[
+			"another job's metadata",
+			{ kind: "benchmark-ab" },
+			/does not look like a noise-floor results directory/,
+		],
+		["no ref", { ref: "" }, /ref must be a non-empty string/],
+		["no sha", { sha: undefined }, /sha must be a hex commit id/],
+		["repeats as text", { repeats: "3" }, /repeats must be a whole number/],
+		[
+			"no suites",
+			{ selected_suites: [] },
+			/selected_suites must be a non-empty array/,
+		],
+		// This is what "Record run metadata" literally writes when it is run
+		// outside Actions: every GITHUB_* variable interpolates as "undefined".
+		[
+			"a run URL from outside Actions",
+			{ run_url: "undefined/undefined/actions/runs/undefined" },
+			/run_url must look like/,
+		],
+		[
+			"a non-ISO measured_at",
+			{ measured_at: "last tuesday" },
+			/measured_at, when present, must be an ISO-8601 timestamp/,
+		],
+	];
+	for (const [label, overrides, expected] of cases)
+		withFixture((root) => {
+			baselineFixture(root, [100, 101, 102], overrides);
+			const out = path.join(root, "baseline.json");
+			const { code, stderr } = captureCli([root, "--emit-baseline", out]);
+			assert.equal(code, 2, `${label} must be refused with exit 2`);
+			assert.equal(fs.existsSync(out), false, `${label} wrote a baseline`);
+			assert.match(stderr, expected, label);
+		});
+
+	// The reader is a plain function, so the refusal is available to callers that
+	// never touch the CLI.
+	withFixture((root) => {
+		baselineFixture(root);
+		assert.equal(readMeasurementMetadata(root).sha, METADATA.sha);
+		assert.throws(
+			() => readMeasurementMetadata(path.join(root, "run-1")),
+			(error) => error.exitCode === 2,
+		);
+	});
+});
+
+test("the committed placeholder has the emitted shape and answers unknown everywhere", () => {
+	const bytes = fs.readFileSync(COMMITTED_BASELINE, "utf8");
+	const placeholder = JSON.parse(bytes);
+
+	// It is a placeholder, loudly: nothing in it may be read as a measurement.
+	assert.equal(placeholder.status, "not-yet-measured");
+	assert.deepEqual(placeholder.tasks, {});
+	assert.equal(placeholder.provenance.ref, null);
+	assert.equal(placeholder.provenance.sha, null);
+	assert.equal(placeholder.provenance.runUrl, null);
+	assert.equal(placeholder.provenance.measuredAt, null);
+	assert.equal(placeholder.provenance.runs, 0);
+	assert.equal(placeholder.provenance.tasksPublished, 0);
+	for (const metric of ["mean_ms", "hz"]) {
+		assert.equal(placeholder.headline[metric].tasksMeasured, 0);
+		assert.equal(placeholder.headline[metric].worstMax, null);
+	}
+
+	// The consumer's "unknown" branch, exercised against the real committed file:
+	// `tasks` must be a plain OBJECT (an array reads to benchmarks.yml as a
+	// broken baseline, which is a louder and less accurate story than "nothing
+	// measured yet"), and every lookup through it must come back null.
+	assert.equal(Array.isArray(placeholder.tasks), false);
+	assert.equal(typeof placeholder.tasks, "object");
+	assert.notEqual(placeholder.tasks, null);
+	assert.equal(
+		consumerFloor(placeholder, "pid-convergence.json", "anything", "mean_ms"),
+		null,
+	);
+	// Committed in the emitter's own serialisation, so a hand-edit that breaks
+	// key order or indentation is caught here rather than in a review diff.
+	assert.equal(stringifyBaseline(placeholder), bytes);
+
+	// The consuming workflow reads one shape. If the emitter grows a field the
+	// placeholder does not have, the "not yet measured" path stops exercising the
+	// real thing and starts exercising a fossil.
+	const emitted = withFixture((root) => {
+		baselineFixture(root);
+		const out = path.join(root, "baseline.json");
+		assert.equal(captureCli([root, "--emit-baseline", out]).code, 0);
+		return readBaseline(out);
+	});
+	assert.deepEqual(Object.keys(placeholder), Object.keys(emitted));
+	assert.deepEqual(
+		Object.keys(placeholder.provenance),
+		Object.keys(emitted.provenance),
+	);
+	assert.deepEqual(Object.keys(placeholder.headline), Object.keys(emitted.headline));
+	for (const metric of ["mean_ms", "hz"])
+		assert.deepEqual(
+			Object.keys(placeholder.headline[metric]),
+			Object.keys(emitted.headline[metric]),
+		);
+	assert.equal(placeholder.schema, emitted.schema);
+	assert.equal(placeholder.decisionRule, emitted.decisionRule);
+	assert.equal(placeholder.deltaDefinition, emitted.deltaDefinition);
+	assert.equal(placeholder.headlineStatistic, emitted.headlineStatistic);
+	assert.equal(placeholder.rounding, emitted.rounding);
+	assert.equal(placeholder.provenance.generator, emitted.provenance.generator);
+	assert.equal(placeholder.provenance.suitesKnown, emitted.provenance.suitesKnown);
+	assert.notEqual(placeholder.status, emitted.status);
+});
+
+test("buildBaseline is callable without the CLI and refuses the same things", () => {
+	withFixture((root) => {
+		baselineFixture(root);
+		const report = analyze({ resultsDir: root, minRuns: 3 });
+		const metadata = readMeasurementMetadata(root);
+		assert.equal(
+			buildBaseline({ report, metadata }).provenance.tasksPublished,
+			1,
+		);
+		assert.throws(
+			() => buildBaseline({ report, metadata: { ...metadata, repeats: 9 } }),
+			(error) => error.exitCode === 1 && /only 3 produced/.test(error.message),
+		);
 	});
 });


### PR DESCRIPTION
`benchmarks.yml` prints a per-task `Δ mean %` and says nothing about how large a Δ has to be before it means anything. A byte-identical refactor once produced **+155.9%** in that table. Readers either panic or learn to ignore the report.

We now have a measured floor. On master, 4 runs, 27 tasks: **median 2.73%, worst 38.08%** — and tasks range from 0.7% to 38%, so a single global threshold would be useless. Each task is judged against **its own** floor.

## What lands

`noise-floor.mjs` gains `--emit-baseline`, distilling a completed results directory into a small committed file carrying provenance (ref, sha, runs, pairs, date, run URL). `benchmarks.yml` reads it and labels every row:

| state | meaning |
|---|---|
| within noise | `\|Δ\| <= ` that task's floor |
| **ABOVE FLOOR** | the rows worth reading |
| **UNKNOWN** | no baseline entry |

Real rendered output:

```
| ack: sender-after-receiver | +2.00%  | within (2.00% <= 5.00%)            |
| ack: receiver-after-sender | +40.00% | **ABOVE FLOOR** (40.00% > 5.00%)   |
| brand-new-task             | +2.00%  | **UNKNOWN** (task not in baseline) |
| ack: sender-after-receiver | +2.00%  | **UNKNOWN** (no baseline)          |
```

**The third state is load-bearing.** New tasks, renamed tasks and a stale baseline all land there, and rendering them as "within noise" would be exactly the failure this work exists to prevent. A missing, unparseable or provenance-less baseline puts *every* row in UNKNOWN behind a `[!CAUTION]` box naming the paths searched — the report degrades loudly, never quietly, and never fails the job (it runs under `if: always()`).

The floor is compared against `|Δ|`, not the signed Δ: a **−40%** on a 38%-floor task is noise in the same way +40% is.

## Producer integrity

A committed baseline is read for months after the results directory is gone, so the emitter refuses rather than guesses:

- **not trustworthy, or fewer usable runs than were asked for** → refuse. A floor distilled from the runs that happened to survive reads low, and a low floor silently blesses every later perf claim.
- **fewer DISTINCT measurements than the minimum** → refuse, and record `distinctRuns` alongside `runs` so the file cannot claim a run count it never had.

The duplicate signature is now over **normalised measurements rather than raw bytes** — a byte digest is defeated by a re-serialise, which is precisely what a hand-made copy of a partial artifact looks like. Review found this: `duplicate-run-input` was only a *warning*, and `buildBaseline` never consulted it.

Verified both directions:

```
4 dirs / 2 distinct (one re-serialised) -> exit 1, "carry only 2 distinct measurement(s)", no file written
4 genuinely distinct runs               -> exit 0, baseline written, runs=4 distinctRuns=4
```

## Status of the baseline itself

The committed file is still the **not-yet-measured placeholder**. The real one lands once the in-flight full-suite run ([31890449831](https://github.com/dao-xyz/peerbit/actions/runs/31890449831), which also validates yesterday's document close-race fix) finishes. Until then every row reads UNKNOWN — the honest answer, and it puts the path I most want correct into production first.

## Verification

34/34 spec (`node --test scripts/bench/*.spec.mjs`), `prettier --check` clean on all changed files, `check-workflow-shell-safety.mjs` and `test-release-security-contracts.mjs` both clean.

**One gap I could not close locally:** eslint cannot run against this worktree (no `node_modules`; pointing it at the main checkout's config makes it skip the files as ignored). CI is the check for that.

## Known, documented, not fixed here

- `document-put.json` writes `rows`, not `tasks`, so `formatSuite` renders **zero rows** for it — a 25% regression there would be invisible. Pre-existing on master; the baseline now measures a suite the report cannot read. Worth its own PR.
- Task names are the one PR-controlled field in the table; `cell()` strips `\r\n` but not a bare `\r`, and does not escape backticks or `<`.
- `bench-floor` checks out `github.sha`, which is only PR-immune because `benchmarks.yml` is `workflow_dispatch`-only. Under a `pull_request` trigger a PR could ship its own floor.