### PR TITLE
ci: commit the measured noise-floor baseline (7/7 suites)

### DIFF
--- a/scripts/bench/noise-floor-baseline.json
+++ b/scripts/bench/noise-floor-baseline.json
@@ -3,44 +3,391 @@
   "deltaDefinition": "|a - b| / min(a, b) * 100 over all unordered run pairs",
   "headline": {
     "hz": {
-      "medianOfMax": null,
-      "tasksAbove10Pct": 0,
-      "tasksAbove5Pct": 0,
-      "tasksMeasured": 0,
-      "worstMax": null,
-      "worstTask": null
+      "medianOfMax": 9.36,
+      "tasksAbove10Pct": 28,
+      "tasksAbove5Pct": 35,
+      "tasksMeasured": 59,
+      "worstMax": 142.6,
+      "worstTask": {
+        "suite": "file-ingest.json",
+        "task": "adaptive: observer-join"
+      }
     },
     "mean_ms": {
-      "medianOfMax": null,
-      "tasksAbove10Pct": 0,
-      "tasksAbove5Pct": 0,
-      "tasksMeasured": 0,
-      "worstMax": null,
-      "worstTask": null
+      "medianOfMax": 9.31,
+      "tasksAbove10Pct": 28,
+      "tasksAbove5Pct": 35,
+      "tasksMeasured": 59,
+      "worstMax": 142.6,
+      "worstTask": {
+        "suite": "file-ingest.json",
+        "task": "adaptive: observer-join"
+      }
     }
   },
   "headlineStatistic": "max |Δ%| observed across all unordered run pairs (never the p95: see the header comment)",
-  "note": "PLACEHOLDER. No A/A measurement has been committed yet: `tasks` is empty, so every tasks[<suite file>][<task name>] lookup misses and every A/B delta must read as UNKNOWN. Nothing here may be used to call a delta noise. Replace this file wholesale with the output of `node scripts/bench/noise-floor.mjs <results-dir> --emit-baseline scripts/bench/noise-floor-baseline.json`, run against a completed artifact from .github/workflows/benchmark-noise-floor.yml. That emitter refuses untrustworthy, partial and provenance-less measurements, so a file with status \"measured\" and a filled-in provenance block is one that passed those checks. Once measured, compare an A/B |Δ%| against `mean_ms` or `hz` on the matching entry; a null floor stays UNKNOWN and is never read as 0.",
+  "note": "Per-task A/A noise floor: the largest |Δ%| that IDENTICAL code produced between two runs. Look an entry up as tasks[<suite file>][<task name>] and compare the A/B |Δ%| against `mean_ms` or `hz` on it. A null floor means no floor was measured for that metric (see `unusable`) and MUST be treated as unknown, never as 0 -- in particular `no-variation-resolved` means the runs agreed to the source's own rounding step, which is not the same as a benchmark that cannot move.",
   "provenance": {
-    "distinctRuns": 0,
+    "distinctRuns": 4,
     "generator": "scripts/bench/noise-floor.mjs --emit-baseline",
-    "measuredAt": null,
-    "measuredAtSource": null,
-    "minRuns": null,
-    "pairsPerTask": 0,
-    "ref": null,
-    "repeatsRequested": null,
-    "runUrl": null,
-    "runs": 0,
-    "selectedSuites": [],
-    "sha": null,
-    "sourceReportSchema": null,
-    "suitesCollected": 0,
+    "measuredAt": "2026-08-15T15:57:51.406Z",
+    "measuredAtSource": "metadata.json mtime (the run that wrote it recorded no measured_at field)",
+    "minRuns": 4,
+    "pairsPerTask": 6,
+    "ref": "master",
+    "repeatsRequested": 4,
+    "runUrl": "https://github.com/dao-xyz/peerbit/actions/runs/31890449831",
+    "runs": 4,
+    "selectedSuites": [
+      "shared-log",
+      "transport",
+      "document"
+    ],
+    "sha": "b776198cd8dd20bd896a3c7b6b49d819e3142fd9",
+    "sourceReportSchema": "peerbit-bench-noise-floor/2",
+    "suitesCollected": 7,
     "suitesKnown": 7,
-    "tasksPublished": 0
+    "tasksPublished": 62
   },
   "rounding": "floors are rounded to 2 decimals AWAY from zero, so a published floor is never below the floor that was measured",
   "schema": "peerbit-bench-noise-floor-baseline/1",
-  "status": "not-yet-measured",
-  "tasks": {}
+  "status": "measured",
+  "tasks": {
+    "chunk-transfer.json": {
+      "ack: receiver-after-sender": {
+        "hz": null,
+        "mean_ms": null,
+        "n": 4,
+        "unusable": {
+          "hz": "never-measurable",
+          "mean_ms": "never-measurable"
+        }
+      },
+      "ack: receiver-complete": {
+        "hz": 7.3,
+        "mean_ms": 7.3,
+        "n": 4
+      },
+      "ack: sender-after-receiver": {
+        "hz": 20.01,
+        "mean_ms": 20.01,
+        "n": 4
+      },
+      "ack: sender-complete": {
+        "hz": 7.35,
+        "mean_ms": 7.35,
+        "n": 4
+      },
+      "silent: receiver-after-sender": {
+        "hz": 3.62,
+        "mean_ms": 3.62,
+        "n": 4
+      },
+      "silent: receiver-complete": {
+        "hz": 3.69,
+        "mean_ms": 3.69,
+        "n": 4
+      },
+      "silent: sender-after-receiver": {
+        "hz": null,
+        "mean_ms": null,
+        "n": 4,
+        "unusable": {
+          "hz": "never-measurable",
+          "mean_ms": "never-measurable"
+        }
+      },
+      "silent: sender-complete": {
+        "hz": 8.45,
+        "mean_ms": 8.45,
+        "n": 4
+      }
+    },
+    "document-put.json": {
+      "compat-path": {
+        "hz": 1.43,
+        "mean_ms": 1.43,
+        "n": 4
+      },
+      "hybrid-anystore": {
+        "hz": 13.06,
+        "mean_ms": 13.03,
+        "n": 4
+      },
+      "native-block-store": {
+        "hz": 14.74,
+        "mean_ms": 14.71,
+        "n": 4
+      },
+      "native-graph": {
+        "hz": 13.76,
+        "mean_ms": 13.84,
+        "n": 4
+      },
+      "rust-peerbit": {
+        "hz": 5.98,
+        "mean_ms": 6.02,
+        "n": 4
+      },
+      "rust-peerbit-transient-index": {
+        "hz": 6.88,
+        "mean_ms": 6.87,
+        "n": 4
+      },
+      "simple-index": {
+        "hz": 18.98,
+        "mean_ms": 18.91,
+        "n": 4
+      },
+      "sqlite-index": {
+        "hz": 9.37,
+        "mean_ms": 9.31,
+        "n": 4
+      }
+    },
+    "file-ingest.json": {
+      "adaptive: observer-chunk-entries-known": {
+        "hz": 35.86,
+        "mean_ms": 35.86,
+        "n": 4
+      },
+      "adaptive: observer-chunk-entries-known-tail": {
+        "hz": 42.13,
+        "mean_ms": 42.13,
+        "n": 4
+      },
+      "adaptive: observer-chunk-search": {
+        "hz": 77.5,
+        "mean_ms": 77.5,
+        "n": 4
+      },
+      "adaptive: observer-chunks-ready": {
+        "hz": 35.86,
+        "mean_ms": 35.86,
+        "n": 4
+      },
+      "adaptive: observer-chunks-tail": {
+        "hz": 42.13,
+        "mean_ms": 42.13,
+        "n": 4
+      },
+      "adaptive: observer-final-manifest-entry-known": {
+        "hz": 35.86,
+        "mean_ms": 35.86,
+        "n": 4
+      },
+      "adaptive: observer-final-manifest-entry-known-tail": {
+        "hz": 42.13,
+        "mean_ms": 42.13,
+        "n": 4
+      },
+      "adaptive: observer-join": {
+        "hz": 142.6,
+        "mean_ms": 142.6,
+        "n": 4
+      },
+      "adaptive: observer-manifest-ready": {
+        "hz": 49.78,
+        "mean_ms": 49.78,
+        "n": 4
+      },
+      "adaptive: observer-manifest-search": {
+        "hz": 26.8,
+        "mean_ms": 26.8,
+        "n": 4
+      },
+      "adaptive: observer-manifest-tail": {
+        "hz": 85.89,
+        "mean_ms": 85.89,
+        "n": 4
+      },
+      "adaptive: writer-complete": {
+        "hz": 9.36,
+        "mean_ms": 9.36,
+        "n": 4
+      },
+      "fixed1: observer-chunk-entries-known": {
+        "hz": 20.31,
+        "mean_ms": 20.31,
+        "n": 4
+      },
+      "fixed1: observer-chunk-entries-known-tail": {
+        "hz": 23.76,
+        "mean_ms": 23.76,
+        "n": 4
+      },
+      "fixed1: observer-chunk-search": {
+        "hz": 19.24,
+        "mean_ms": 19.24,
+        "n": 4
+      },
+      "fixed1: observer-chunks-ready": {
+        "hz": 20.31,
+        "mean_ms": 20.31,
+        "n": 4
+      },
+      "fixed1: observer-chunks-tail": {
+        "hz": 23.76,
+        "mean_ms": 23.76,
+        "n": 4
+      },
+      "fixed1: observer-final-manifest-entry-known": {
+        "hz": 20.31,
+        "mean_ms": 20.31,
+        "n": 4
+      },
+      "fixed1: observer-final-manifest-entry-known-tail": {
+        "hz": 23.76,
+        "mean_ms": 23.76,
+        "n": 4
+      },
+      "fixed1: observer-join": {
+        "hz": 81.27,
+        "mean_ms": 81.27,
+        "n": 4
+      },
+      "fixed1: observer-manifest-ready": {
+        "hz": 44.93,
+        "mean_ms": 44.93,
+        "n": 4
+      },
+      "fixed1: observer-manifest-search": {
+        "hz": 60.65,
+        "mean_ms": 60.65,
+        "n": 4
+      },
+      "fixed1: observer-manifest-tail": {
+        "hz": 67.12,
+        "mean_ms": 67.12,
+        "n": 4
+      },
+      "fixed1: writer-complete": {
+        "hz": 1.63,
+        "mean_ms": 1.63,
+        "n": 4
+      }
+    },
+    "pid-convergence.json": {
+      "even (peers=2)": {
+        "hz": 2.39,
+        "mean_ms": 2.63,
+        "n": 4
+      },
+      "even (peers=3)": {
+        "hz": 0.95,
+        "mean_ms": 0.6,
+        "n": 4
+      },
+      "even (peers=5)": {
+        "hz": 3.43,
+        "mean_ms": 3.34,
+        "n": 4
+      },
+      "memory-limited (2 peers, 25% cap)": {
+        "hz": null,
+        "mean_ms": null,
+        "n": 4,
+        "unusable": {
+          "hz": "never-measurable",
+          "mean_ms": "never-measurable"
+        }
+      }
+    },
+    "rateless-iblt-sender-startsync.json": {
+      "onMaybeMissingEntries (rateless IBLT, n=1000)": {
+        "hz": 1.25,
+        "mean_ms": 1.29,
+        "n": 4
+      },
+      "onMaybeMissingEntries (rateless IBLT, n=10000)": {
+        "hz": 1.63,
+        "mean_ms": 1.63,
+        "n": 4
+      },
+      "onMaybeMissingEntries (rateless IBLT, n=50000)": {
+        "hz": 2.48,
+        "mean_ms": 2.56,
+        "n": 4
+      }
+    },
+    "rateless-iblt-startsync-cache.json": {
+      "StartSync local decoder (after invalidation, n=1000)": {
+        "hz": 1.04,
+        "mean_ms": 0.95,
+        "n": 4
+      },
+      "StartSync local decoder (after invalidation, n=10000)": {
+        "hz": 0.72,
+        "mean_ms": 1,
+        "n": 4
+      },
+      "StartSync local decoder (after invalidation, n=50000)": {
+        "hz": 4.19,
+        "mean_ms": 4.11,
+        "n": 4
+      },
+      "StartSync local decoder (cold, n=1000)": {
+        "hz": 2.64,
+        "mean_ms": 3.09,
+        "n": 4
+      },
+      "StartSync local decoder (cold, n=10000)": {
+        "hz": 1.78,
+        "mean_ms": 1.81,
+        "n": 4
+      },
+      "StartSync local decoder (cold, n=50000)": {
+        "hz": 3.4,
+        "mean_ms": 3.29,
+        "n": 4
+      },
+      "StartSync local decoder (warm, n=1000)": {
+        "hz": 0.72,
+        "mean_ms": 1.18,
+        "n": 4
+      },
+      "StartSync local decoder (warm, n=10000)": {
+        "hz": 12.58,
+        "mean_ms": 12.25,
+        "n": 4
+      },
+      "StartSync local decoder (warm, n=50000)": {
+        "hz": 1.22,
+        "mean_ms": 1.23,
+        "n": 4
+      }
+    },
+    "sync-batch-sweep.json": {
+      "repairSweepTargetBufferSize=1024": {
+        "hz": 1.32,
+        "mean_ms": 1.32,
+        "n": 4
+      },
+      "repairSweepTargetBufferSize=16384": {
+        "hz": 2.09,
+        "mean_ms": 2.09,
+        "n": 4
+      },
+      "repairSweepTargetBufferSize=256": {
+        "hz": 3.74,
+        "mean_ms": 3.74,
+        "n": 4
+      },
+      "repairSweepTargetBufferSize=4096": {
+        "hz": 3.37,
+        "mean_ms": 3.37,
+        "n": 4
+      },
+      "repairSweepTargetBufferSize=512": {
+        "hz": 3.34,
+        "mean_ms": 3.34,
+        "n": 4
+      },
+      "repairSweepTargetBufferSize=65536": {
+        "hz": 2.54,
+        "mean_ms": 2.54,
+        "n": 4
+      }
+    }
+  }
 }

--- a/scripts/bench/noise-floor.spec.mjs
+++ b/scripts/bench/noise-floor.spec.mjs
@@ -1860,35 +1860,85 @@ test("refuses a baseline when metadata.json is absent, malformed or not ours", (
 	});
 });
 
-test("the committed placeholder has the emitted shape and answers unknown everywhere", () => {
+test("the committed baseline has the emitted shape and answers the consumer correctly", () => {
 	const bytes = fs.readFileSync(COMMITTED_BASELINE, "utf8");
 	const placeholder = JSON.parse(bytes);
 
-	// It is a placeholder, loudly: nothing in it may be read as a measurement.
-	assert.equal(placeholder.status, "not-yet-measured");
-	assert.deepEqual(placeholder.tasks, {});
-	assert.equal(placeholder.provenance.ref, null);
-	assert.equal(placeholder.provenance.sha, null);
-	assert.equal(placeholder.provenance.runUrl, null);
-	assert.equal(placeholder.provenance.measuredAt, null);
-	assert.equal(placeholder.provenance.runs, 0);
-	assert.equal(placeholder.provenance.tasksPublished, 0);
-	for (const metric of ["mean_ms", "hz"]) {
-		assert.equal(placeholder.headline[metric].tasksMeasured, 0);
-		assert.equal(placeholder.headline[metric].worstMax, null);
+	// The committed file is legitimately either state: the not-yet-measured
+	// placeholder before a floor has been distilled, or a real measurement after.
+	// Both must satisfy every shape and consumer property below; only the
+	// measurement-specific assertions differ, and each state is pinned so the
+	// other cannot drift in unnoticed.
+	assert.ok(
+		placeholder.status === "not-yet-measured" ||
+			placeholder.status === "measured",
+		`unexpected committed baseline status ${placeholder.status}`,
+	);
+	const measured = placeholder.status === "measured";
+
+	if (measured) {
+		// A measurement must be traceable: without provenance it cannot be
+		// re-measured or aged out, and a floor nobody can date is a floor nobody
+		// should trust.
+		assert.equal(typeof placeholder.provenance.ref, "string");
+		assert.match(placeholder.provenance.sha, /^[0-9a-f]{40}$/);
+		assert.match(placeholder.provenance.runUrl, /\/actions\/runs\/\d+$/);
+		assert.equal(typeof placeholder.provenance.measuredAt, "string");
+		assert.ok(placeholder.provenance.runs >= 3);
+		// Directories are not measurements; the emitter refuses when these
+		// disagree below the minimum, and the committed file records both.
+		assert.equal(
+			placeholder.provenance.distinctRuns,
+			placeholder.provenance.runs,
+		);
+		assert.ok(placeholder.provenance.tasksPublished > 0);
+		assert.ok(Object.keys(placeholder.tasks).length > 0);
+	} else {
+		// It is a placeholder, loudly: nothing in it may be read as a measurement.
+		assert.deepEqual(placeholder.tasks, {});
+		assert.equal(placeholder.provenance.ref, null);
+		assert.equal(placeholder.provenance.sha, null);
+		assert.equal(placeholder.provenance.runUrl, null);
+		assert.equal(placeholder.provenance.measuredAt, null);
+		assert.equal(placeholder.provenance.runs, 0);
+		assert.equal(placeholder.provenance.tasksPublished, 0);
+		for (const metric of ["mean_ms", "hz"]) {
+			assert.equal(placeholder.headline[metric].tasksMeasured, 0);
+			assert.equal(placeholder.headline[metric].worstMax, null);
+		}
 	}
 
 	// The consumer's "unknown" branch, exercised against the real committed file:
 	// `tasks` must be a plain OBJECT (an array reads to benchmarks.yml as a
 	// broken baseline, which is a louder and less accurate story than "nothing
-	// measured yet"), and every lookup through it must come back null.
+	// measured yet"), and a task nobody measured must come back null in EITHER
+	// state - that is the row benchmarks.yml renders as UNKNOWN.
 	assert.equal(Array.isArray(placeholder.tasks), false);
 	assert.equal(typeof placeholder.tasks, "object");
 	assert.notEqual(placeholder.tasks, null);
 	assert.equal(
-		consumerFloor(placeholder, "pid-convergence.json", "anything", "mean_ms"),
+		consumerFloor(
+			placeholder,
+			"pid-convergence.json",
+			"a task no run ever produced",
+			"mean_ms",
+		),
 		null,
 	);
+	if (measured) {
+		// ...and a task that WAS measured must resolve to a usable number, or the
+		// annotation silently degrades to UNKNOWN for everything.
+		const [suiteFile, tasks] = Object.entries(placeholder.tasks).find(
+			([, entries]) =>
+				Object.values(entries).some((entry) => entry.mean_ms !== null),
+		);
+		const taskName = Object.keys(tasks).find(
+			(name) => tasks[name].mean_ms !== null,
+		);
+		const floor = consumerFloor(placeholder, suiteFile, taskName, "mean_ms");
+		assert.equal(typeof floor, "number");
+		assert.ok(floor > 0);
+	}
 	// Committed in the emitter's own serialisation, so a hand-edit that breaks
 	// key order or indentation is caught here rather than in a review diff.
 	assert.equal(stringifyBaseline(placeholder), bytes);
@@ -1920,7 +1970,11 @@ test("the committed placeholder has the emitted shape and answers unknown everyw
 	assert.equal(placeholder.rounding, emitted.rounding);
 	assert.equal(placeholder.provenance.generator, emitted.provenance.generator);
 	assert.equal(placeholder.provenance.suitesKnown, emitted.provenance.suitesKnown);
-	assert.notEqual(placeholder.status, emitted.status);
+	// The fixture is a healthy 3-run measurement, so a successful emit is always
+	// "measured". (This used to assert the committed file DIFFERED from a fresh
+	// emission, which only held while the committed file was the placeholder; the
+	// committed status is checked against both valid states at the top instead.)
+	assert.equal(emitted.status, "measured");
 });
 
 test("buildBaseline is callable without the CLI and refuses the same things", () => {


### PR DESCRIPTION
Distilled from [run 31890449831](https://github.com/dao-xyz/peerbit/actions/runs/31890449831) on master `b776198cd`: **4 runs of one commit, all 7 suites, TRUSTWORTHY**, 62 task entries.

| | |
|---|---|
| median max \|Δ\| | **9.31%** |
| worst | **142.59%** — `file-ingest › adaptive: observer-join` |
| above 5% | 35 of 59 measured |
| above 10% | 28 |

## The document suite ran

This is the first floor run to include it. `file-ingest` previously crashed mid-run with `NotStartedError` and aborted the job; it completed all four repeats here. The close-race fix in `@peerbit/document@15.0.6` ([#1278](https://github.com/dao-xyz/peerbit/pull/1278)) did what it claimed.

## It closes the loop on the number that started this

A byte-identical refactor once showed **+155.9%** on `file-ingest › adaptive: observer-join` and read as a catastrophic regression. That task's own A/A floor — identical code, four runs — is **142.59%**.

It was never a regression. The task cannot measure anything smaller than itself. [#1280](https://github.com/dao-xyz/peerbit/pull/1280) will now say so on the row instead of leaving the reader to guess.

## On the wider median

9.31% here vs 2.73% over the five suites measured before is **not** a degradation. `file-ingest` contributes 24 tasks and most are noisy, so including it moves the middle. Per-suite the picture is unchanged: `rateless-iblt-sender-startsync` and `pid-convergence` still sit near 2%, and those are where a real perf change will show.

## The spec is now state-aware

It asserted the committed file **was** the placeholder — true only until this commit. It now pins shape and consumer behaviour for both states, and additionally requires a measurement to be traceable (40-hex sha, an actions run URL, `runs >= 3`, `distinctRuns == runs`) and to resolve a measured task to a positive floor.

Verified green in **both** states — 34/34 with the measurement committed, 34/34 with the placeholder restored — so neither can drift in unnoticed. `prettier --check` clean.

No changeset: `scripts/**` and `.github/**` are tool-config paths.