### PR TITLE
ci: use stable transport for shared-log profiling

### DIFF
--- a/.github/workflows/shared-log-recensus.yml
+++ b/.github/workflows/shared-log-recensus.yml
@@ -79,6 +79,11 @@ jobs:
         env:
           BENCH_JSON: "1"
           NODE_OPTIONS: --no-warnings
+          # TestSession's "mock" mode selects loopback TCP and disables relay; it
+          # does not mock shared-log, crypto, storage, or indexer behavior. The
+          # default WebSocket listener was unavailable after the long offline
+          # preload in both attempts of run 31897535074.
+          PEERBIT_TEST_SESSION: mock
           PROFILE: ${{ matrix.profile }}
           RECEIVE_PRUNE_COUNTS: "100,1000,5000"
           RECEIVE_PRUNE_RUNS: "1"


### PR DESCRIPTION
## Summary

- run shared-log re-census profiles on the same loopback-TCP `TestSession` transport used by normal CI
- keep shared-log, crypto, storage, indexer, and sync behavior real; `PEERBIT_TEST_SESSION=mock` only selects `transportsFast()`/`listenFast()` and disables relay

## Why

The first master re-census run completed receive/prune but failed sync-phase twice after its long offline preload:

- [run 31897535074 attempt 1](https://github.com/dao-xyz/peerbit/actions/runs/31897535074/attempts/1): `ConnectionFailedError` dialing `ws://127.0.0.1:34167`
- [run 31897535074 attempt 2](https://github.com/dao-xyz/peerbit/actions/runs/31897535074/attempts/2): the same error at `ws://127.0.0.1:43913`

Both failures happened before the measured catch-up could start. This profiler measures shared-log application phases, not localhost WebSocket listener reliability.

## Validation

The exact 20,000-new/10,000-seeded Node 22 profile completed locally with both transports:

- default WebSocket: 44,675.89 ms catch-up
- CI loopback TCP: 44,657.17 ms catch-up

The 0.04% difference confirms the transport selection does not materially change the measured top-level result while avoiding the refused CI listener.

Also run:

- `node --test scripts/ci/check-workflow-shell-safety.test.mjs`
- `node scripts/ci/check-workflow-shell-safety.mjs`
- `pnpm exec prettier --check .github/workflows/shared-log-recensus.yml`
- `git diff --check`

## CI re-census

[Run 31898757958](https://github.com/dao-xyz/peerbit/actions/runs/31898757958) completed both profiles successfully against master at `e0fb330ea20d4cb5f70db0224995882f3f1fe8d3`:

- sync-phase uploaded a nonempty 28 KB artifact and measured 51,258.10 ms catch-up
- receive-prune uploaded a nonempty 582 KB artifact across all 51 scenario/count rows
- the post-preload TCP dial completed; the WebSocket `ConnectionFailedError` did not recur