### PR TITLE
perf: avoid full replication scan on native append

### DIFF
--- a/.changeset/native-append-candidates.md
+++ b/.changeset/native-append-candidates.md
@@ -1,0 +1,8 @@
+---
+"@peerbit/shared-log-rust": patch
+"@peerbit/native-backbone": patch
+"@peerbit/shared-log": patch
+---
+
+Avoid scanning every replication range during native append when the exact
+resident owner count proves full-replica delivery cannot apply.

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -310,6 +310,11 @@ type NativeRangePlannerHandle = {
 type NativeSharedLogStateHandle = {
 	len: () => number;
 	clear: () => void;
+	/** @internal */
+	full_replica_candidates_for: (
+		minReplicas: number,
+		selfHash: string,
+	) => string[];
 	put: NativeRangePlannerHandle["put"];
 	delete: NativeRangePlannerHandle["delete"];
 	put_entry_coordinates: (
@@ -1060,6 +1065,11 @@ export class SharedLogNativeState {
 
 	clear(): void {
 		this.native.clear();
+	}
+
+	/** @internal */
+	fullReplicaCandidatesFor(minReplicas: number, selfHash: string): string[] {
+		return this.native.full_replica_candidates_for(minReplicas, selfHash);
 	}
 
 	put(range: NativeReplicationRange): void {

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -334,6 +334,26 @@ impl RangePlanner {
         }
     }
 
+    /// Materialize owners only when full-replica expansion can actually apply;
+    /// otherwise return no rows so the caller avoids an owner-sized transfer.
+    fn full_replica_candidates_for(&self, min_replicas: usize, self_hash: &str) -> Vec<String> {
+        let candidate_count =
+            self.peer_ranges.len() + usize::from(!self.peer_ranges.contains_key(self_hash));
+        if min_replicas < candidate_count {
+            return Vec::new();
+        }
+
+        let mut candidates = Vec::with_capacity(candidate_count);
+        candidates.push(self_hash.to_string());
+        candidates.extend(
+            self.peer_ranges
+                .keys()
+                .filter(|hash| hash.as_str() != self_hash)
+                .cloned(),
+        );
+        candidates
+    }
+
     /// Sample order is a native contract the TypeScript implementation cannot
     /// offer: cursors are visited in input order, intersecting matches surface
     /// in range-put order (containment buckets keep insertion order across
@@ -2277,6 +2297,14 @@ impl NativeSharedLogState {
 
     pub fn clear(&mut self) {
         self.inner.clear_all();
+    }
+
+    pub fn full_replica_candidates_for(&self, min_replicas: usize, self_hash: String) -> Array {
+        strings_to_array(
+            self.inner
+                .range_planner
+                .full_replica_candidates_for(min_replicas, &self_hash),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4283,6 +4311,81 @@ mod tests {
 
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].hash, "peer-b");
+    }
+
+    #[test]
+    fn skips_full_replica_candidate_materialization_when_not_all_peers_are_requested() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new("a", "peer-a", 0, 0, 10, 0, 10, 10, 0));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 10, 20, 10, 20, 10, 0,
+        ));
+
+        assert!(planner
+            .full_replica_candidates_for(2, "peer-self")
+            .is_empty());
+    }
+
+    #[test]
+    fn lists_each_full_replica_candidate_once_with_self_first() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "self",
+            "peer-self",
+            0,
+            0,
+            10,
+            0,
+            10,
+            10,
+            0,
+        ));
+        planner.put(ReplicationRange::new(
+            "a-1", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "a-2", "peer-a", 0, 20, 30, 20, 30, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 30, 30, 30, 30, 0, 1,
+        ));
+
+        assert_eq!(
+            planner.full_replica_candidates_for(3, "peer-self"),
+            vec!["peer-self", "peer-a", "peer-b"]
+        );
+    }
+
+    #[test]
+    fn tracks_owner_replacement_and_last_range_deletion() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "a-1", "peer-a", 0, 0, 10, 0, 10, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "a-2", "peer-a", 0, 10, 20, 10, 20, 10, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "b", "peer-b", 0, 20, 30, 20, 30, 10, 0,
+        ));
+
+        assert!(planner.delete("a-1"));
+        assert!(planner
+            .full_replica_candidates_for(2, "peer-self")
+            .is_empty());
+        assert!(planner.delete("a-2"));
+        assert_eq!(
+            planner.full_replica_candidates_for(2, "peer-self"),
+            vec!["peer-self", "peer-b"]
+        );
+
+        planner.put(ReplicationRange::new(
+            "b", "peer-c", 0, 20, 30, 20, 30, 10, 0,
+        ));
+        assert_eq!(
+            planner.full_replica_candidates_for(2, "peer-self"),
+            vec!["peer-self", "peer-c"]
+        );
     }
 
     #[test]

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -412,6 +412,29 @@ describe("native shared-log range planner", () => {
 		);
 	});
 
+	it("short-circuits and tracks exact full-replica candidates", async () => {
+		const state = await createSharedLogState("u32");
+		state.put(range({ id: "self", hash: "peer-self", start1: 0, end1: 10 }));
+		state.put(range({ id: "a-1", hash: "peer-a", start1: 10, end1: 20 }));
+		state.put(range({ id: "a-2", hash: "peer-a", start1: 20, end1: 30 }));
+		state.put(range({ id: "b", hash: "peer-b", start1: 30, end1: 30 }));
+
+		expect(state.fullReplicaCandidatesFor(2, "peer-self")).to.deep.equal([]);
+		expect(state.fullReplicaCandidatesFor(3, "peer-self")).to.deep.equal([
+			"peer-self",
+			"peer-a",
+			"peer-b",
+		]);
+
+		expect(state.delete("a-1")).equal(true);
+		expect(state.fullReplicaCandidatesFor(2, "peer-self")).to.deep.equal([]);
+		expect(state.delete("a-2")).equal(true);
+		expect(state.fullReplicaCandidatesFor(2, "peer-self")).to.deep.equal([
+			"peer-self",
+			"peer-b",
+		]);
+	});
+
 	it("plans entry assignment metadata from resident shared-log state", async () => {
 		const planner = await createRangePlanner("u32");
 		const state = await createSharedLogState("u32");

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -915,6 +915,13 @@ type NativeAppendEntryPlan<R extends "u32" | "u64"> = {
 	committedNativeCoordinateDeletes?: boolean;
 };
 
+type NativeFullReplicaCandidateSource = {
+	fullReplicaCandidatesFor?: (
+		minReplicas: number,
+		selfHash: string,
+	) => string[];
+};
+
 type EntryLeaderBatchItem<R extends "u32" | "u64"> = {
 	entry: ShallowOrFullEntry<any> | EntryReplicated<R>;
 	replicas: number;
@@ -8050,6 +8057,21 @@ export class SharedLog<
 		return candidates;
 	}
 
+	private async getNativeFullReplicaDeliveryCandidates(
+		minReplicas: number,
+		selfHash: string,
+	): Promise<Set<string>> {
+		const source = (this._nativeBackbone ?? this._nativeSharedLogState) as
+			| NativeFullReplicaCandidateSource
+			| undefined;
+		if (typeof source?.fullReplicaCandidatesFor === "function") {
+			return new Set(source.fullReplicaCandidatesFor(minReplicas, selfHash));
+		}
+		return this.getFullReplicaRepairCandidates(undefined, {
+			includeSubscribers: false,
+		});
+	}
+
 	private removeRepairFrontierTarget(
 		target: string,
 		options?: { expectedWarmupSession?: WarmupSession | null },
@@ -13566,9 +13588,10 @@ export class SharedLog<
 			ownershipLifecycleController,
 		);
 		const fullReplicaDeliveryCandidates =
-			await this.getFullReplicaRepairCandidates(undefined, {
-				includeSubscribers: false,
-			});
+			await this.getNativeFullReplicaDeliveryCandidates(
+				replicas,
+				context.selfHash,
+			);
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			ownershipLifecycleController,
 		);
@@ -13712,9 +13735,10 @@ export class SharedLog<
 			ownershipLifecycleController,
 		);
 		const fullReplicaDeliveryCandidates =
-			await this.getFullReplicaRepairCandidates(undefined, {
-				includeSubscribers: false,
-			});
+			await this.getNativeFullReplicaDeliveryCandidates(
+				replicas,
+				context.selfHash,
+			);
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			ownershipLifecycleController,
 		);
@@ -13924,9 +13948,10 @@ export class SharedLog<
 			ownershipLifecycleController,
 		);
 		const fullReplicaDeliveryCandidates =
-			await this.getFullReplicaRepairCandidates(undefined, {
-				includeSubscribers: false,
-			});
+			await this.getNativeFullReplicaDeliveryCandidates(
+				replicas,
+				context.selfHash,
+			);
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			ownershipLifecycleController,
 		);

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -3028,6 +3028,69 @@ describe("events", () => {
 		}
 	});
 
+	it("rehydrates native append candidates from persisted owner ranges", async () => {
+		const { db, log, replicationIndex } = await openDisconnectedLog(3);
+		const owners = session.peers
+			.slice(1)
+			.map((peer) => peer.identity.publicKey);
+		for (const [index, owner] of owners.entries()) {
+			await log.addReplicationRange(
+				[
+					makeReplicationRange(log, {
+						id: new Uint8Array([index + 1]),
+						ownerHash: owner.hashcode(),
+						offset: 0.1 + index * 0.4,
+					}),
+				],
+				owner,
+				{ checkDuplicates: false, rebalance: false },
+			);
+		}
+		for (const owner of owners) {
+			expect(
+				await replicationIndex.count({ query: { hash: owner.hashcode() } }),
+			).to.equal(1);
+		}
+
+		const originalNative = log._nativeBackbone ?? log._nativeSharedLogState;
+		expect(originalNative).to.exist;
+		await db.close();
+		const reopened = await session.peers[0].open(db, {
+			args: { replicate: false, timeUntilRoleMaturity: 0 },
+		});
+		const reopenedLog = reopened.log as any;
+		const nativePlanner =
+			reopenedLog._nativeBackbone ?? reopenedLog._nativeSharedLogState;
+		expect(nativePlanner).to.exist.and.not.equal(originalNative);
+		const selfHash = session.peers[0].identity.publicKey.hashcode();
+		const hydratedCandidates = nativePlanner.fullReplicaCandidatesFor(
+			owners.length + 1,
+			selfHash,
+		);
+		expect(hydratedCandidates[0]).to.equal(selfHash);
+		expect(hydratedCandidates).to.have.members([
+			selfHash,
+			...owners.map((owner) => owner.hashcode()),
+		]);
+
+		const nativeCandidates = sinon.spy(
+			nativePlanner,
+			"fullReplicaCandidatesFor",
+		);
+		const indexCandidates = sinon
+			.stub(reopenedLog, "getFullReplicaRepairCandidates")
+			.rejects(new Error("replication index scan should not run after reopen"));
+		try {
+			const { entry } = await reopened.add("native-append-hydrated-candidates");
+			expect(entry).to.exist;
+			expect(nativeCandidates.calledOnceWithExactly(2, selfHash)).to.be.true;
+			expect(indexCandidates.notCalled).to.be.true;
+		} finally {
+			nativeCandidates.restore();
+			indexCandidates.restore();
+		}
+	});
+
 	it("fences native append planning across its second await and reopen", async () => {
 		const { db, log } = await openDisconnectedLog(1);
 		const { entry } = await db.add("native-append-planner-generation");

--- a/packages/programs/data/shared-log/test/events.spec.ts
+++ b/packages/programs/data/shared-log/test/events.spec.ts
@@ -3001,6 +3001,33 @@ describe("events", () => {
 		}
 	});
 
+	it("uses resident native owners for append full-replica candidates", async () => {
+		const { db, log } = await openDisconnectedLog(1);
+		const nativePlanner = log._nativeBackbone ?? log._nativeSharedLogState;
+		expect(nativePlanner).to.exist;
+		const nativeCandidates = sinon
+			.stub(nativePlanner, "fullReplicaCandidatesFor")
+			.returns([]);
+		const indexCandidates = sinon
+			.stub(log, "getFullReplicaRepairCandidates")
+			.rejects(new Error("replication index scan should not run"));
+
+		try {
+			const { entry } = await db.add("native-append-resident-candidates");
+			expect(entry).to.exist;
+			expect(
+				nativeCandidates.calledOnceWithExactly(
+					2,
+					session.peers[0].identity.publicKey.hashcode(),
+				),
+			).to.be.true;
+			expect(indexCandidates.notCalled).to.be.true;
+		} finally {
+			nativeCandidates.restore();
+			indexCandidates.restore();
+		}
+	});
+
 	it("fences native append planning across its second await and reopen", async () => {
 		const { db, log } = await openDisconnectedLog(1);
 		const { entry } = await db.add("native-append-planner-generation");

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -599,6 +599,11 @@ type NativePeerbitBackboneHandle = {
 	clear: () => void;
 	clear_shared_log: () => void;
 	clear_entry_coordinates: () => void;
+	/** @internal */
+	full_replica_candidates_for: (
+		minReplicas: number,
+		selfHash: string,
+	) => string[];
 	put_range: (
 		id: string,
 		hash: string,
@@ -6825,6 +6830,11 @@ export class NativePeerbitBackbone {
 
 	clearSharedLog(): void {
 		this.native.clear_shared_log();
+	}
+
+	/** @internal */
+	fullReplicaCandidatesFor(minReplicas: number, selfHash: string): string[] {
+		return this.native.full_replica_candidates_for(minReplicas, selfHash);
 	}
 
 	clearEntryCoordinates(): void {

--- a/packages/utils/native-backbone/src/shared_log_plan.rs
+++ b/packages/utils/native-backbone/src/shared_log_plan.rs
@@ -362,6 +362,11 @@ impl NativePeerbitBackbone {
         self.clear_coordinate_core();
     }
 
+    pub fn full_replica_candidates_for(&self, min_replicas: usize, self_hash: String) -> Array {
+        self.shared_log
+            .full_replica_candidates_for(min_replicas, self_hash)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn put_range(
         &mut self,

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -355,6 +355,39 @@ describe("native peerbit backbone", () => {
 		);
 	});
 
+	it("bridges exact full-replica candidate discovery", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+			resolution: "u32",
+		});
+		for (const [id, hash, start, end, mode] of [
+			["a-1", "peer-a", 0, 10, 0],
+			["a-2", "peer-a", 10, 20, 0],
+			["b", "peer-b", 20, 20, 1],
+		] as const) {
+			backbone.putRange({
+				id,
+				hash,
+				timestamp: 0,
+				start1: start,
+				end1: end,
+				start2: start,
+				end2: end,
+				width: end - start,
+				mode,
+			});
+		}
+
+		expect(backbone.fullReplicaCandidatesFor(2, "peer-self")).to.deep.equal([]);
+		expect(backbone.fullReplicaCandidatesFor(3, "peer-self")).to.deep.equal([
+			"peer-self",
+			"peer-a",
+			"peer-b",
+		]);
+	});
+
 	it("defaults buffered coordinate WAL to bounded pending bytes", () => {
 		const persistence = new NativeBackboneCoordinatePersistence(
 			new NativeBackboneMemoryCoordinatePersistenceStore(),


### PR DESCRIPTION
## Problem

Native append planning still called `getReplicators()` before every append. That
materialized every row in the SQLite replication index even though full-replica
delivery only applies when the requested replica count covers every known owner.

A local scan benchmark measured the existing owner scan at:

| Distinct owners | Median scan |
| ---: | ---: |
| 1,000 | 2.687 ms |
| 10,000 | 22.532 ms |
| 50,000 | 122.482 ms |
| 100,000 | 261.657 ms |

## Change

- Track no new state: reuse the native range planner's exact resident owner map,
  which is already maintained across put, replacement, delete, clear, and index
  hydration.
- Count self exactly once. When `minReplicas` cannot cover every candidate,
  return an empty candidate list so the existing append expansion remains a
  no-op without scanning or materializing owners.
- Materialize the exact self-first owner list only when full-replica delivery can
  apply.
- Preserve the existing index-scan fallback when the optional native capability
  is unavailable.

At 100,000 owners, the common `minReplicas = 2` native check measured below
0.001 ms per call locally. The uncommon full-replica case still deliberately
materializes every recipient; that took 32.8 ms for 100,001 candidates in the
same run.

This does not change public package declarations or the network protocol.

## Validation

- `cargo test --manifest-path packages/programs/data/shared-log/rust/Cargo.toml`
  (26 passed)
- `cargo test --manifest-path packages/utils/native-backbone/Cargo.toml`
  (58 passed)
- Focused shared-log-rust WASM candidate test
- Focused native-backbone bridge test
- Real shared-log `db.add()` test proving the native append path does not scan
  the replication index
- Persisted multi-owner close/reopen test proving native hydration restores the
  exact candidate set before the first post-reopen append
- Existing reopen/lifecycle fallback test
- Builds for `@peerbit/shared-log-rust`, `@peerbit/native-backbone`, and
  `@peerbit/shared-log`
- Package lint for both native packages and root ESLint for the changed
  shared-log files
- Changeset status and generated public declaration audit

Mutation checks also confirmed that the exact candidate test fails when the Rust
method is forced empty, and the public append test fails when its native path is
forced back to the index scan. The persisted reopen test also fails when native
range hydration is disabled, observing only self instead of the persisted owners.
