### PR TITLE
fix: preserve native receiver for coordinate batches

### DIFF
--- a/.changeset/calm-batches-bind.md
+++ b/.changeset/calm-batches-bind.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log-rust": patch
+---
+
+Preserve the native receiver when committing entry coordinate batches.

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -1247,7 +1247,8 @@ export class SharedLogNativeState {
 			}
 			return;
 		}
-		nativeCommitBatch(
+		nativeCommitBatch.call(
+			this.native,
 			rows.map((row) => row.hash),
 			rows.map((row) => row.gid),
 			rows.map((row) => row.hashNumber),

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -450,6 +450,39 @@ describe("native shared-log range planner", () => {
 		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
 	});
 
+	it("commits entry coordinate batches with the native receiver", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("old-head", "old-gid", [1, 2]);
+
+		state.commitEntryCoordinatesBatch([
+			{
+				hash: "new-head",
+				gid: "new-gid",
+				coordinates: [3, 4],
+				nextHashes: ["old-head"],
+				assignedToRangeBoundary: true,
+				requestedReplicas: 2,
+				hashNumber: 42,
+			},
+			{
+				hash: "independent-head",
+				gid: "independent-gid",
+				coordinates: [5],
+				nextHashes: [],
+				requestedReplicas: 1,
+				hashNumber: 7,
+			},
+		]);
+
+		expect(state.getEntryCoordinates("new-head")).to.deep.equal([3, 4]);
+		expect(state.getEntryCoordinates("independent-head")).to.deep.equal([5]);
+		expect(state.getEntryCoordinates("old-head")).to.equal(undefined);
+		expect([...state.getEntryHashesForHashNumbers([42, 7])]).to.deep.equal([
+			[42n, ["new-head"]],
+			[7n, ["independent-head"]],
+		]);
+	});
+
 	it("lists resident entry coordinate hashes", async () => {
 		const state = await createSharedLogState("u32");
 		state.putEntryCoordinates("head-a", "gid-a", [1]);


### PR DESCRIPTION
## Summary

- preserve the wasm-bindgen receiver for native coordinate batch commits
- cover batch insertion, predecessor deletion, and hash-number lookup
- add a patch changeset for `@peerbit/shared-log-rust`

## Why

`commit_entry_coordinates_batch` was copied to a local variable and then invoked as a detached method. wasm-bindgen methods read `this.__wbg_ptr`, so the batch path threw before applying any mutation. Calling it with `this.native` as the receiver preserves the native pointer without changing the API or protocol.

## Validation

- `pnpm --dir packages/programs/data/shared-log/rust exec aegir test -t node` (121 passing)
- focused regression test passes
- mutation check: restoring the detached call makes the new test fail with `Cannot read properties of undefined (reading __wbg_ptr)`
- `pnpm exec eslint packages/programs/data/shared-log/rust/src/index.ts packages/programs/data/shared-log/rust/test/index.spec.ts`
- `pnpm run build`
