### PR TITLE
bench: add shared-log resident and persistent scale census

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |
           pnpm run build
+      - name: Validate scale-census persistence round trip
+        if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
+        run: node --test scripts/bench/shared-log-scale-census.integration.mjs
       - name: Verify retired server artifacts cannot be packaged
         if: steps.workspace_dist_cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/shared-log-recensus.yml
+++ b/.github/workflows/shared-log-recensus.yml
@@ -25,6 +25,7 @@ jobs:
         profile:
           - sync-phase
           - receive-prune
+          - resident-scale
     concurrency:
       group: shared-log-recensus-${{ inputs.ref }}-${{ matrix.profile }}
       cancel-in-progress: false
@@ -103,6 +104,12 @@ jobs:
             receive-prune)
               node --loader ts-node/esm ./benchmark/receive-prune.ts > "$destination"
               ;;
+            resident-scale)
+              node "$GITHUB_WORKSPACE/scripts/bench/shared-log-scale-census.mjs" \
+                --counts 100000,1000000 \
+                --runs 1 \
+                --json > "$destination"
+              ;;
             *)
               echo "::error::Unknown profile '$PROFILE'."
               exit 1
@@ -114,14 +121,19 @@ jobs:
 
             const file = process.env.PROFILE_RESULT;
             const result = JSON.parse(readFileSync(file, "utf8"));
-            const expectedName =
-              process.env.PROFILE === "sync-phase"
-                ? "shared-log-sync-phase-profile"
-                : "shared-log-receive-prune";
+            const expectedNames = {
+              "sync-phase": "shared-log-sync-phase-profile",
+              "receive-prune": "shared-log-receive-prune",
+              "resident-scale": "shared-log-resident-scale-census",
+            };
+            const expectedName = expectedNames[process.env.PROFILE];
+            if (!expectedName) {
+              throw new Error(`Unknown profile '${process.env.PROFILE}'`);
+            }
             if (result.name !== expectedName) {
               throw new Error(`${file} has profile name '${result.name}', expected '${expectedName}'`);
             }
-            const rows = result.runs ?? result.aggregateRows;
+            const rows = result.runs ?? result.aggregateRows ?? result.rows;
             if (!Array.isArray(rows) || rows.length === 0) {
               throw new Error(`${file} carries no measured profile rows`);
             }

--- a/.github/workflows/shared-log-recensus.yml
+++ b/.github/workflows/shared-log-recensus.yml
@@ -7,6 +7,19 @@ on:
         required: false
         default: master
         type: string
+      profile:
+        description: Profile to run
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - sync-phase
+          - receive-prune
+          - scale-resident
+          - scale-persistent-chain
+          - scale-persistent-roots
+          - scale-persistent-coordinate
 
 permissions: {}
 
@@ -22,13 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile:
-          - sync-phase
-          - receive-prune
-          - scale-resident
-          - scale-persistent-chain
-          - scale-persistent-roots
-          - scale-persistent-coordinate
+        profile: ${{ fromJSON(inputs.profile == 'all' && '["sync-phase","receive-prune","scale-resident","scale-persistent-chain","scale-persistent-roots","scale-persistent-coordinate"]' || format('["{0}"]', inputs.profile)) }}
     concurrency:
       group: shared-log-recensus-${{ inputs.ref }}-${{ matrix.profile }}
       cancel-in-progress: false

--- a/.github/workflows/shared-log-recensus.yml
+++ b/.github/workflows/shared-log-recensus.yml
@@ -25,7 +25,10 @@ jobs:
         profile:
           - sync-phase
           - receive-prune
-          - scale-census
+          - scale-resident
+          - scale-persistent-chain
+          - scale-persistent-roots
+          - scale-persistent-coordinate
     concurrency:
       group: shared-log-recensus-${{ inputs.ref }}-${{ matrix.profile }}
       cancel-in-progress: false
@@ -104,11 +107,31 @@ jobs:
             receive-prune)
               node --loader ts-node/esm ./benchmark/receive-prune.ts > "$destination"
               ;;
-            scale-census)
+            scale-*)
+              case "$PROFILE" in
+                scale-resident)
+                  scenarios="native-graph-chain,native-graph-roots,coordinate-frontier"
+                  ;;
+                scale-persistent-chain)
+                  scenarios="persistent-head-index-graph-chain"
+                  ;;
+                scale-persistent-roots)
+                  scenarios="persistent-head-index-graph-roots"
+                  ;;
+                scale-persistent-coordinate)
+                  scenarios="persistent-coordinate-index"
+                  ;;
+                *)
+                  echo "::error::Unknown scale profile '$PROFILE'."
+                  exit 1
+                  ;;
+              esac
               node "$GITHUB_WORKSPACE/scripts/bench/shared-log-scale-census.mjs" \
                 --counts 100000,1000000 \
+                --scenarios "$scenarios" \
                 --runs 1 \
-                --json > "$destination"
+                --output "$destination" \
+                --json > /dev/null
               ;;
             *)
               echo "::error::Unknown profile '$PROFILE'."
@@ -124,9 +147,10 @@ jobs:
             const expectedNames = {
               "sync-phase": "shared-log-sync-phase-profile",
               "receive-prune": "shared-log-receive-prune",
-              "scale-census": "shared-log-scale-census",
             };
-            const expectedName = expectedNames[process.env.PROFILE];
+            const expectedName = process.env.PROFILE.startsWith("scale-")
+              ? "shared-log-scale-census"
+              : expectedNames[process.env.PROFILE];
             if (!expectedName) {
               throw new Error(`Unknown profile '${process.env.PROFILE}'`);
             }
@@ -136,6 +160,9 @@ jobs:
             const rows = result.runs ?? result.aggregateRows ?? result.rows;
             if (!Array.isArray(rows) || rows.length === 0) {
               throw new Error(`${file} carries no measured profile rows`);
+            }
+            if (expectedName === "shared-log-scale-census" && result.progress?.complete !== true) {
+              throw new Error(`${file} is an incomplete scale-census checkpoint`);
             }
           NODE
 

--- a/.github/workflows/shared-log-recensus.yml
+++ b/.github/workflows/shared-log-recensus.yml
@@ -25,7 +25,7 @@ jobs:
         profile:
           - sync-phase
           - receive-prune
-          - resident-scale
+          - scale-census
     concurrency:
       group: shared-log-recensus-${{ inputs.ref }}-${{ matrix.profile }}
       cancel-in-progress: false
@@ -104,7 +104,7 @@ jobs:
             receive-prune)
               node --loader ts-node/esm ./benchmark/receive-prune.ts > "$destination"
               ;;
-            resident-scale)
+            scale-census)
               node "$GITHUB_WORKSPACE/scripts/bench/shared-log-scale-census.mjs" \
                 --counts 100000,1000000 \
                 --runs 1 \
@@ -124,7 +124,7 @@ jobs:
             const expectedNames = {
               "sync-phase": "shared-log-sync-phase-profile",
               "receive-prune": "shared-log-receive-prune",
-              "resident-scale": "shared-log-resident-scale-census",
+              "scale-census": "shared-log-scale-census",
             };
             const expectedName = expectedNames[process.env.PROFILE];
             if (!expectedName) {

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
 		"bench:file-ingest": "TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/programs/data/document/document/benchmark/file-ingest.ts",
 		"bench:chunk-transfer": "pnpm --filter @peerbit/stream run bench:chunk-transfer",
 		"bench:payload-path": "TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./packages/log/benchmark/payload-path.ts",
+		"bench:shared-log-scale-census": "node ./scripts/bench/shared-log-scale-census.mjs",
 		"bench:file-share:prepare": "node ./scripts/file-share/prepare-peerbit-examples.mjs",
 		"bench:file-share:local": "node ./scripts/file-share/run-file-share-benchmark.mjs",
 		"bench:file-share:matrix": "node ./scripts/file-share/run-file-share-benchmark-matrix.mjs",

--- a/packages/programs/data/shared-log/benchmark/sync-phase-profile.ts
+++ b/packages/programs/data/shared-log/benchmark/sync-phase-profile.ts
@@ -233,6 +233,8 @@ const setup = {
 	name: "u64-iblt",
 };
 
+const SEEDED_JOIN_BATCH_SIZE = 1_024;
+
 const runCatchup = async (properties: {
 	batchSize: number;
 	entryCount: number;
@@ -263,6 +265,19 @@ const runCatchup = async (properties: {
 			},
 		});
 
+		// Keep the source as the only active replica during offline preload. Opening
+		// both programs first can leave delivery/maintenance work competing with the
+		// first Noise handshake on slower runners.
+		const seededEntries: Parameters<typeof db1.log.join>[0] = [];
+		for (let i = 0; i < properties.seededEntries; i++) {
+			const out = await db1.add(`seed-${i}`, { meta: { next: [] } });
+			seededEntries.push(out.entry);
+		}
+
+		for (let i = 0; i < properties.entryCount; i++) {
+			await db1.add(`entry-${i}`, { meta: { next: [] } });
+		}
+
 		db2 = await session.peers[1].open(store.clone(), {
 			args: {
 				replicate: { factor: 2 },
@@ -274,13 +289,14 @@ const runCatchup = async (properties: {
 			},
 		});
 
-		for (let i = 0; i < properties.seededEntries; i++) {
-			const out = await db1.add(`seed-${i}`, { meta: { next: [] } });
-			await db2.log.join([out.entry]);
-		}
-
-		for (let i = 0; i < properties.entryCount; i++) {
-			await db1.add(`entry-${i}`, { meta: { next: [] } });
+		for (
+			let offset = 0;
+			offset < seededEntries.length;
+			offset += SEEDED_JOIN_BATCH_SIZE
+		) {
+			await db2.log.join(
+				seededEntries.slice(offset, offset + SEEDED_JOIN_BATCH_SIZE),
+			);
 		}
 
 		const expectedLength = properties.seededEntries + properties.entryCount;

--- a/scripts/bench/SHARED_LOG_BOUNDED_STATE_CONTRACT.md
+++ b/scripts/bench/SHARED_LOG_BOUNDED_STATE_CONTRACT.md
@@ -119,7 +119,9 @@ Before claiming the 100-million-entry target:
    buckets if the workload cannot bound one component.
 6. Progress through distributed 10M and 100M global-entry soaks.
 
-The rebalancing implementation handoff should begin after step 1 records the
-persistent 100k/1M results. At that point the planner has measured local-state
-budgets and this lifecycle contract, rather than an unconstrained global-entry
-goal.
+The rebalancing implementation handoff can begin after step 1 records complete
+100k results and a measured or censored 1M boundary. A timeout with preserved
+progress is valid boundary evidence; complete 1M metric rows remain measurement
+work, not a prerequisite for bounded planner design. At that point the planner
+has local-state budgets and this lifecycle contract, rather than an
+unconstrained global-entry goal.

--- a/scripts/bench/SHARED_LOG_BOUNDED_STATE_CONTRACT.md
+++ b/scripts/bench/SHARED_LOG_BOUNDED_STATE_CONTRACT.md
@@ -1,0 +1,125 @@
+# Shared-log bounded-state contract
+
+This document defines the architecture boundary for scaling a shared-log
+deployment to 100 million global entries. It is a design contract and work
+order, not a statement that the current implementation meets the target.
+
+The target is bounded local state. Global history may reach 100 million entries,
+but an ordinary storage peer must open, repair, rebalance, and prune work that is
+proportional to its assigned shards and active frontier, not global history.
+
+## State ledger
+
+Every locally retained entry can be represented in several stores. A move or
+prune is complete only when all stores have reached the same ownership outcome.
+
+| State                        | Current owner                                        | Durable                       | Release boundary                                    | Required bound                                 |
+| ---------------------------- | ---------------------------------------------------- | ----------------------------- | --------------------------------------------------- | ---------------------------------------------- |
+| Entry and payload blocks     | log block store                                      | yes                           | log prune, trim, clear, or drop                     | assigned local payload bytes                   |
+| Shallow log rows             | entry index (`heads` scope)                          | yes                           | entry-index delete, clear, or drop                  | assigned local entries                         |
+| Native log graph             | `LogGraphIndex`                                      | no; rebuilt from shallow rows | entry delete or graph clear                         | active frontier plus bounded hot history       |
+| Replication coordinates      | shared-log coordinate index or native backbone       | yes when configured           | coordinate delete or index drop                     | assigned local entries/frontier                |
+| Application query rows       | application index                                    | backend-dependent             | application deletion policy                         | paged working set, not all global rows in RAM  |
+| Replication ranges           | replication index and native range planner           | yes when configured           | ownership mutation or close                         | assigned ranges and active peers               |
+| Gid/peer suppression history | `_gidPeersHistory` and native mirrors                | no                            | prune, peer removal, explicit cache reset, or close | live local gids and a bounded retention window |
+| Entry/peer and repair memos  | sync, repair, leader, and recently-rebalanced caches | no                            | TTL, size cap, lifecycle rotation, or close         | explicit per-peer and per-session caps         |
+
+The current native graph and Rust query index reconstruct all locally retained
+rows on open. Pruning disk blocks alone therefore does not bound startup or RSS:
+the shallow row, graph node, coordinate row, and any application row must be
+released as part of the same logical ownership transition.
+
+## Ownership move protocol
+
+The planner chooses work; an executor performs durable transfer. Keeping those
+roles separate makes plans testable and prevents a controller tick from deleting
+data directly.
+
+1. Capture a membership and ownership epoch.
+2. Produce a bounded move from one source assignment to one or more destination
+   assignments. Include the replication policy, estimated entries and bytes,
+   and a resumable cursor.
+3. Transfer blocks and index metadata in capped batches with backpressure.
+4. Have each destination persist the batch before acknowledging its checkpoint.
+   Pubsub delivery or receipt alone is not proof of durable possession.
+5. Revalidate membership, epoch, role maturity, and required replica coverage.
+6. Commit the new assignment only after the required destinations have durable
+   checkpoints covering the move.
+7. Prune the source in capped, idempotent batches across every state-ledger row.
+8. Persist progress so restart resumes transfer or prune without replaying an
+   unrelated shard or losing an acknowledged batch.
+
+Writes racing a move require one explicit policy: dual-write to old and new
+owners, or record and replay a source journal after the transfer checkpoint. A
+plan is not complete until the chosen policy has crossed its commit boundary.
+
+## Safety invariants
+
+- Never prune based only on a planned leader set. Required replicas must have
+  acknowledged durable possession under the current ownership epoch.
+- Stale acknowledgements, timers, and repair work from an older lifecycle cannot
+  authorize a commit or delete.
+- Transfer, commit, and prune operations are idempotent after process failure.
+- No operation materializes an unbounded iterator with `all()` or builds an
+  unbounded range/entry array. Every scan has a cursor, batch cap, cancellation,
+  and backpressure.
+- The planner budgets bytes, entries, frontier width, and hot-write rate. Entry
+  count alone is not a capacity signal for media workloads.
+- Current placement treats a gid/component as indivisible. The planner must
+  preserve that rule until a separately versioned sharding semantic exists.
+- Cache eviction may cause redundant repair traffic, but cannot authorize prune
+  or weaken replica coverage.
+
+## Planner contract
+
+A planner invocation consumes an immutable snapshot:
+
+- ownership and membership epoch;
+- mature, eligible storage peers and their advertised capacities;
+- current ranges and replica policy;
+- per-shard estimates for entries, bytes, frontier width, and write rate;
+- transfer concurrency, churn, memory, disk, CPU, and network budgets; and
+- restart, catch-up, and availability SLOs.
+
+It returns a deterministic plan with a stable plan id, ordered moves, source and
+destination assignments, expected cost, dependencies, and maximum concurrency.
+It does not send messages, mutate ranges, or prune data. The executor reports
+durable checkpoints and terminal outcomes keyed by plan id and epoch.
+
+The plan must be bounded by the number of peers, ranges, and selected moves. It
+must not enumerate global entries. Entry enumeration belongs to the resumable
+executor for one selected shard.
+
+## Validation gates
+
+Before claiming the 100-million-entry target:
+
+- declare p50/p95/p99 local entries, bytes, ranges, gids, and frontier rows;
+- gate fresh-process RSS and reopen time at those local percentiles;
+- verify transfer and prune resume after source, destination, and coordinator
+  restarts at every checkpoint;
+- verify replica coverage during concurrent writes, owner churn, delayed or
+  dropped messages, and partial transfer;
+- demonstrate that planner memory and time depend on peers/ranges, not history;
+- run 10M and 100M global soaks on dedicated infrastructure with machine-readable
+  coverage and resource artifacts; and
+- separate non-storage viewers from storage peers in 10k-100k-user simulations.
+
+## Work order
+
+1. Land the reproducible resident and persistent census and establish local
+   entry/RSS/reopen budgets.
+2. Add a state-ledger invariant test that proves prune releases every local
+   representation and survives restart between stages.
+3. Extract a pure, bounded ownership planner behind the contract above while
+   retaining current placement semantics.
+4. Add the resumable transfer/prune executor and epoch-fenced durable
+   acknowledgements.
+5. Introduce versioned shardable gid semantics for hot video channels or time
+   buckets if the workload cannot bound one component.
+6. Progress through distributed 10M and 100M global-entry soaks.
+
+The rebalancing implementation handoff should begin after step 1 records the
+persistent 100k/1M results. At that point the planner has measured local-state
+budgets and this lifecycle contract, rather than an unconstrained global-entry
+goal.

--- a/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
+++ b/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
@@ -82,10 +82,25 @@ Machine-readable output uses a versioned JSON envelope:
 BENCH_JSON=1 pnpm run bench:shared-log-scale-census > scale-census.json
 ```
 
+For long runs, use `--output` instead of relying only on stdout:
+
+```bash
+pnpm run bench:shared-log-scale-census -- \
+  --output scale-census.json \
+  --json > /dev/null
+```
+
+The output file is replaced atomically before a row starts and after it
+finishes. Schema version 3 includes `progress.expectedRows`, `completedRows`,
+`activeRow`, and `complete`, so a timeout preserves completed rows and identifies
+the censored row.
+
 The `Shared log re-census` manual workflow runs canonical 100k and 1M sizes and
-uploads the JSON result. Ordinary pull-request CI runs the
-argument/report tests and tiny persistent round trips; it does not allocate
-million-entry states.
+uploads the JSON result. Resident, persistent chain, persistent roots, and
+persistent coordinate workloads use independent jobs, giving each slow reopen
+its own timeout and artifact. Ordinary pull-request CI runs the argument/report
+tests and tiny persistent round trips; it does not allocate million-entry
+states.
 
 ## Development-machine observation
 
@@ -104,6 +119,15 @@ real `Log.open()` path had not completed at a 30-minute local censor point. It
 was still CPU-bound at roughly 4.3 GiB RSS. That RSS is partial, not a final
 peak, and endpoint validation had not yet run. The result rules out treating one
 million locally materialized rows as a healthy ordinary-peer startup target.
+
+Manual workflow
+[run 31939388160](https://github.com/dao-xyz/peerbit/actions/runs/31939388160)
+provided a second censor point on an Ubuntu runner. The persistent chain 1M row
+advanced to the next scenario after about 1 hour 59 minutes. The roots 1M row
+was still running 56 minutes later when the combined job reached its three-hour
+limit; the persistent coordinate row was never reached. These are wall-clock
+boundaries from progress logs, not complete metric rows. They motivated the
+independent workflow jobs and checkpointed report format above.
 
 ## Interpretation
 

--- a/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
+++ b/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
@@ -1,0 +1,61 @@
+# Shared-log resident scale census
+
+This benchmark measures the resident reconstruction costs that currently grow
+with locally retained shared-log state. It is an input to the 100-million-entry
+work tracked in [#1286](https://github.com/dao-xyz/peerbit/issues/1286), not a
+claim that the complete stack already supports that deployment.
+
+## Scenarios
+
+- `native-graph-chain`: locally retained history in one DAG and one logical
+  head. This exercises the native graph state rebuilt when a log opens.
+- `native-graph-roots`: independent roots with distinct gids. Every entry is a
+  head, modeling the high-frontier shape that stresses graph and sync state.
+- `coordinate-frontier`: independent resident coordinate rows with distinct
+  gids, modeling shared-log coordinate hydration and frontier-wide planning.
+
+Every `(scenario, count, run)` executes in a fresh Node process. The worker
+loads the real WASM package, creates an empty native state, forces garbage
+collection, inserts deterministic CID-length hashes, then forces collection
+again. `rssDeltaBytes` therefore measures state added after the fixed runtime,
+WASM module, and empty index are loaded. `fixedRuntimeRssBytes` reports that
+excluded fixed portion separately.
+
+## Running
+
+Build the native shared-log dependency closure first:
+
+```bash
+pnpm --filter @peerbit/shared-log... run build
+pnpm run bench:shared-log-scale-census -- --counts 100000,1000000 --runs 1
+```
+
+Machine-readable output uses a versioned JSON envelope:
+
+```bash
+BENCH_JSON=1 pnpm run bench:shared-log-scale-census > scale-census.json
+```
+
+The `Shared log re-census` workflow runs the canonical 100k and 1M sizes on a
+dedicated runner and uploads the JSON result. Ordinary pull-request CI only
+tests the argument/report contract; it does not allocate million-entry states.
+
+## Interpretation
+
+Compare results only on the same Node major version, architecture, and machine
+class. RSS is process-level and allocator/WASM growth is chunky, so a single
+small run is directional rather than a regression gate. Use repeated isolated
+runs before making a performance claim.
+
+This first census deliberately excludes block payloads, disk reads, query-index
+reopen, network catch-up, replication skew, and churn. Those require separate
+rows before a deployment can claim 100M global entries:
+
+1. persistent log and query-index close/reopen time, RSS, and disk bytes;
+2. range-scoped catch-up and ownership-transfer throughput;
+3. gid skew and hot-component partitioning;
+4. distributed 10M and 100M soak runs with replica-coverage checks.
+
+Large media bytes must be budgeted separately from graph metadata. The target
+is bounded local state in a globally sharded deployment, not one ordinary peer
+materializing all 100M entries in memory.

--- a/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
+++ b/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
@@ -98,9 +98,9 @@ the censored row.
 The `Shared log re-census` manual workflow runs canonical 100k and 1M sizes and
 uploads the JSON result. Resident, persistent chain, persistent roots, and
 persistent coordinate workloads use independent jobs, giving each slow reopen
-its own timeout and artifact. Ordinary pull-request CI runs the argument/report
-tests and tiny persistent round trips; it does not allocate million-entry
-states.
+its own timeout and artifact. Its `profile` input can select one workload for a
+focused rerun. Ordinary pull-request CI runs the argument/report tests and tiny
+persistent round trips; it does not allocate million-entry states.
 
 ## Development-machine observation
 

--- a/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
+++ b/scripts/bench/SHARED_LOG_SCALE_CENSUS.md
@@ -1,33 +1,79 @@
-# Shared-log resident scale census
+# Shared-log scale census
 
-This benchmark measures the resident reconstruction costs that currently grow
-with locally retained shared-log state. It is an input to the 100-million-entry
-work tracked in [#1286](https://github.com/dao-xyz/peerbit/issues/1286), not a
-claim that the complete stack already supports that deployment.
+This benchmark measures memory, disk, close, and fresh-process reconstruction
+costs that grow with locally retained shared-log state. It is evidence for the
+100-million-global-entry work tracked in
+[#1286](https://github.com/dao-xyz/peerbit/issues/1286), not a claim that the
+complete stack already supports that deployment.
 
 ## Scenarios
 
-- `native-graph-chain`: locally retained history in one DAG and one logical
-  head. This exercises the native graph state rebuilt when a log opens.
-- `native-graph-roots`: independent roots with distinct gids. Every entry is a
-  head, modeling the high-frontier shape that stresses graph and sync state.
-- `coordinate-frontier`: independent resident coordinate rows with distinct
-  gids, modeling shared-log coordinate hydration and frontier-wide planning.
+Resident rows load the real WASM implementation in one fresh process, establish
+an empty-state baseline, populate deterministic CID-length metadata, force
+garbage collection, and report the added memory:
 
-Every `(scenario, count, run)` executes in a fresh Node process. The worker
-loads the real WASM package, creates an empty native state, forces garbage
-collection, inserts deterministic CID-length hashes, then forces collection
-again. `rssDeltaBytes` therefore measures state added after the fixed runtime,
-WASM module, and empty index are loaded. `fixedRuntimeRssBytes` reports that
-excluded fixed portion separately.
+- `native-graph-chain`: one DAG and one logical head;
+- `native-graph-roots`: independent roots with distinct gids, where every entry
+  is a head; and
+- `coordinate-frontier`: independent native coordinate rows with distinct gids.
+
+Persistent rows use two fresh processes and a temporary directory:
+
+- `persistent-head-index-graph-chain`: a compacted Rust shallow-entry index,
+  reopened through the real `Log.open()` native-graph reconstruction path;
+- `persistent-head-index-graph-roots`: the same path for a high-frontier shape;
+  and
+- `persistent-coordinate-index`: a compacted Rust `EntryReplicatedU32` index,
+  reopened through the real indexer initialization path.
+
+The first process creates the exact authoritative `index.bin` format by calling
+the indexer's own `SnapshotFile.compact()` implementation. This fixture step is
+reported as `seed.snapshotMs`; it is not append-throughput evidence. The second
+process loads an empty Rust/WASM state, records a baseline, opens the compacted
+index, validates its size and endpoints, records memory, and closes it normally.
+The report also verifies that close did not change the logical file footprint.
+
+This split avoids contaminating reopen RSS with fixture allocations. It also
+keeps the census focused on post-close disk and startup behavior; journal append
+and crash-recovery throughput require separate workloads.
+
+## Metrics
+
+For resident rows, `rssDeltaBytes` and the heap/external/ArrayBuffer equivalents
+measure state added after the fixed runtime, WASM module, and empty index are
+loaded. `fixedRuntimeRssBytes` reports that excluded portion.
+
+For persistent rows:
+
+- `seed.buildMs` and `seed.snapshotMs` describe deterministic fixture creation;
+- `seed.maxRssBytes` captures fixture peak memory;
+- `reopen.openMs` and `reopen.openEntriesPerSecond` describe fresh startup;
+- `reopen.rssDeltaBytes` and related fields describe reconstructed state;
+- `reopen.openMaxRssBytes` captures peak RSS through open, while
+  `reopen.maxRssBytes` also includes close compaction;
+- `reopen.closeMs` measures a normal full close/compaction; and
+- `disk.logicalBytes`, allocated bytes, per-entry costs, and individual files
+  describe the compacted index footprint.
+
+The shallow-entry fixtures contain graph/index metadata, not entry blocks or
+media payloads. The coordinate fixtures use real schemas with deterministic
+synthetic metadata. Application document indexes are not included.
 
 ## Running
 
-Build the native shared-log dependency closure first:
+Build the shared-log dependency closure first:
 
 ```bash
 pnpm --filter @peerbit/shared-log... run build
 pnpm run bench:shared-log-scale-census -- --counts 100000,1000000 --runs 1
+```
+
+Select a subset while investigating one path:
+
+```bash
+pnpm run bench:shared-log-scale-census -- \
+  --counts 100000 \
+  --scenarios persistent-head-index-graph-chain,persistent-coordinate-index
 ```
 
 Machine-readable output uses a versioned JSON envelope:
@@ -36,26 +82,44 @@ Machine-readable output uses a versioned JSON envelope:
 BENCH_JSON=1 pnpm run bench:shared-log-scale-census > scale-census.json
 ```
 
-The `Shared log re-census` workflow runs the canonical 100k and 1M sizes on a
-dedicated runner and uploads the JSON result. Ordinary pull-request CI only
-tests the argument/report contract; it does not allocate million-entry states.
+The `Shared log re-census` manual workflow runs canonical 100k and 1M sizes and
+uploads the JSON result. Ordinary pull-request CI runs the
+argument/report tests and tiny persistent round trips; it does not allocate
+million-entry states.
+
+## Development-machine observation
+
+One Node v22.23.2 run on an Apple M3 Pro produced these 100k persistent results.
+They validate the harness and reveal the growth shape; they are not portable
+thresholds or a substitute for the workflow artifact.
+
+| Scenario                 | Reopen | Reopened RSS | RSS/row |     Disk | Disk/row |
+| ------------------------ | -----: | -----------: | ------: | -------: | -------: |
+| head index + chain graph | 8.67 s |    649.2 MiB | 6,808 B | 23.0 MiB |    241 B |
+| head index + root graphs | 7.37 s |    563.8 MiB | 5,912 B | 17.0 MiB |    178 B |
+| coordinate index         | 4.91 s |    631.1 MiB | 6,617 B | 24.6 MiB |    258 B |
+
+The same machine created a valid 1M chain snapshot of 240,999,957 bytes, but the
+real `Log.open()` path had not completed at a 30-minute local censor point. It
+was still CPU-bound at roughly 4.3 GiB RSS. That RSS is partial, not a final
+peak, and endpoint validation had not yet run. The result rules out treating one
+million locally materialized rows as a healthy ordinary-peer startup target.
 
 ## Interpretation
 
 Compare results only on the same Node major version, architecture, and machine
-class. RSS is process-level and allocator/WASM growth is chunky, so a single
-small run is directional rather than a regression gate. Use repeated isolated
+class. RSS is process-level and allocator/WASM growth is chunky, so one small
+run is directional rather than a regression threshold. Use repeated isolated
 runs before making a performance claim.
 
-This first census deliberately excludes block payloads, disk reads, query-index
-reopen, network catch-up, replication skew, and churn. Those require separate
-rows before a deployment can claim 100M global entries:
+The target is bounded local state in a globally sharded deployment, not one
+ordinary peer materializing all 100 million entries. Persistent files can be
+compact while reopen remains expensive because the current Rust query index
+deserializes all local rows and the native graph is rebuilt from every retained
+shallow row.
 
-1. persistent log and query-index close/reopen time, RSS, and disk bytes;
-2. range-scoped catch-up and ownership-transfer throughput;
-3. gid skew and hot-component partitioning;
-4. distributed 10M and 100M soak runs with replica-coverage checks.
-
-Large media bytes must be budgeted separately from graph metadata. The target
-is bounded local state in a globally sharded deployment, not one ordinary peer
-materializing all 100M entries in memory.
+Before claiming the global target, add range-scoped ownership-transfer and prune
+profiles, gid-skew/hot-component workloads, application-index reopen rows, and
+distributed 10M/100M soaks with replica-coverage checks. The lifecycle and
+planner requirements are recorded in
+[`SHARED_LOG_BOUNDED_STATE_CONTRACT.md`](./SHARED_LOG_BOUNDED_STATE_CONTRACT.md).

--- a/scripts/bench/shared-log-scale-census-lib.mjs
+++ b/scripts/bench/shared-log-scale-census-lib.mjs
@@ -1,0 +1,151 @@
+import { parseArgs } from "node:util";
+
+export const SCALE_CENSUS_NAME = "shared-log-resident-scale-census";
+
+export const SCALE_CENSUS_SCENARIOS = Object.freeze([
+	"native-graph-chain",
+	"native-graph-roots",
+	"coordinate-frontier",
+]);
+
+const parsePositiveInteger = (value, label) => {
+	const normalized = String(value).replaceAll("_", "");
+	if (!/^[1-9][0-9]*$/.test(normalized)) {
+		throw new Error(`${label} must be a positive integer, got '${value}'`);
+	}
+	const parsed = Number(normalized);
+	if (!Number.isSafeInteger(parsed)) {
+		throw new Error(`${label} exceeds JavaScript's safe integer range`);
+	}
+	return parsed;
+};
+
+const parseUniqueList = (value, label, parseValue) => {
+	const values = String(value)
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.map(parseValue);
+	if (values.length === 0) {
+		throw new Error(`${label} must contain at least one value`);
+	}
+	if (new Set(values).size !== values.length) {
+		throw new Error(`${label} must not contain duplicate values`);
+	}
+	return values;
+};
+
+const parseCounts = (value) =>
+	parseUniqueList(value, "counts", (part) =>
+		parsePositiveInteger(part, "count"),
+	);
+
+const parseScenarios = (value) =>
+	parseUniqueList(value, "scenarios", (scenario) => {
+		if (!SCALE_CENSUS_SCENARIOS.includes(scenario)) {
+			throw new Error(`Unknown scale-census scenario '${scenario}'`);
+		}
+		return scenario;
+	});
+
+export const parseScaleCensusArgs = (args, env = {}) => {
+	const normalizedArgs = args[0] === "--" ? args.slice(1) : args;
+	const { values } = parseArgs({
+		args: normalizedArgs,
+		strict: true,
+		allowPositionals: false,
+		options: {
+			counts: { type: "string" },
+			scenarios: { type: "string" },
+			runs: { type: "string" },
+			json: { type: "boolean" },
+			help: { type: "boolean" },
+			worker: { type: "boolean" },
+			scenario: { type: "string" },
+			count: { type: "string" },
+			run: { type: "string" },
+		},
+	});
+
+	if (values.help) {
+		return { mode: "help" };
+	}
+
+	if (values.worker) {
+		if (!values.scenario || !values.count || !values.run) {
+			throw new Error("worker mode requires --scenario, --count, and --run");
+		}
+		const [scenario] = parseScenarios(values.scenario);
+		if (values.scenario.includes(",")) {
+			throw new Error("worker mode accepts exactly one scenario");
+		}
+		return {
+			mode: "worker",
+			scenario,
+			count: parsePositiveInteger(values.count, "count"),
+			run: parsePositiveInteger(values.run, "run"),
+		};
+	}
+
+	if (values.scenario || values.count || values.run) {
+		throw new Error("--scenario, --count, and --run are worker-only options");
+	}
+
+	return {
+		mode: "parent",
+		counts: parseCounts(
+			values.counts ?? env.SHARED_LOG_SCALE_COUNTS ?? "100000,1000000",
+		),
+		scenarios: parseScenarios(
+			values.scenarios ??
+				env.SHARED_LOG_SCALE_SCENARIOS ??
+				SCALE_CENSUS_SCENARIOS.join(","),
+		),
+		runs: parsePositiveInteger(
+			values.runs ?? env.SHARED_LOG_SCALE_RUNS ?? "1",
+			"runs",
+		),
+		json: values.json === true || env.BENCH_JSON === "1",
+	};
+};
+
+const MEMORY_FIELDS = [
+	"rss",
+	"heapTotal",
+	"heapUsed",
+	"external",
+	"arrayBuffers",
+];
+
+export const memoryDeltas = (before, after, count) => {
+	const result = {};
+	for (const field of MEMORY_FIELDS) {
+		const delta = after[field] - before[field];
+		result[`${field}BeforeBytes`] = before[field];
+		result[`${field}AfterBytes`] = after[field];
+		result[`${field}DeltaBytes`] = delta;
+		result[`${field}BytesPerEntry`] = Math.round(delta / count);
+	}
+	return result;
+};
+
+export const buildScaleCensusReport = ({
+	counts,
+	scenarios,
+	runs,
+	rows,
+	host,
+}) => ({
+	name: SCALE_CENSUS_NAME,
+	schemaVersion: 1,
+	meta: {
+		counts,
+		scenarios,
+		runs,
+		isolation: "one fresh process per row",
+		measurement:
+			"resident state added after WASM and an empty index are loaded",
+		...host,
+	},
+	rows,
+});

--- a/scripts/bench/shared-log-scale-census-lib.mjs
+++ b/scripts/bench/shared-log-scale-census-lib.mjs
@@ -1,12 +1,40 @@
 import { parseArgs } from "node:util";
 
-export const SCALE_CENSUS_NAME = "shared-log-resident-scale-census";
+export const SCALE_CENSUS_NAME = "shared-log-scale-census";
 
-export const SCALE_CENSUS_SCENARIOS = Object.freeze([
+export const SCALE_CENSUS_RESIDENT_SCENARIOS = Object.freeze([
 	"native-graph-chain",
 	"native-graph-roots",
 	"coordinate-frontier",
 ]);
+
+export const SCALE_CENSUS_PERSISTENT_SCENARIOS = Object.freeze([
+	"persistent-head-index-graph-chain",
+	"persistent-head-index-graph-roots",
+	"persistent-coordinate-index",
+]);
+
+export const SCALE_CENSUS_SCENARIOS = Object.freeze([
+	...SCALE_CENSUS_RESIDENT_SCENARIOS,
+	...SCALE_CENSUS_PERSISTENT_SCENARIOS,
+]);
+
+export const isPersistentScaleCensusScenario = (scenario) =>
+	SCALE_CENSUS_PERSISTENT_SCENARIOS.includes(scenario);
+
+export const SCALE_CENSUS_HASH_CHARACTERS = 59;
+export const SCALE_CENSUS_GID_CHARACTERS = 44;
+
+const HASH_PREFIX = "bafybeigdyrzt";
+const HASH_SUFFIX_LENGTH = SCALE_CENSUS_HASH_CHARACTERS - HASH_PREFIX.length;
+const GID_PREFIX = "gid-";
+const GID_SUFFIX_LENGTH = SCALE_CENSUS_GID_CHARACTERS - GID_PREFIX.length;
+
+export const makeScaleCensusHash = (index) =>
+	`${HASH_PREFIX}${index.toString(36).padStart(HASH_SUFFIX_LENGTH, "0")}`;
+
+export const makeScaleCensusGid = (index) =>
+	`${GID_PREFIX}${index.toString(36).padStart(GID_SUFFIX_LENGTH, "0")}`;
 
 const parsePositiveInteger = (value, label) => {
 	const normalized = String(value).replaceAll("_", "");
@@ -64,6 +92,8 @@ export const parseScaleCensusArgs = (args, env = {}) => {
 			scenario: { type: "string" },
 			count: { type: "string" },
 			run: { type: "string" },
+			phase: { type: "string" },
+			directory: { type: "string" },
 		},
 	});
 
@@ -79,16 +109,42 @@ export const parseScaleCensusArgs = (args, env = {}) => {
 		if (values.scenario.includes(",")) {
 			throw new Error("worker mode accepts exactly one scenario");
 		}
+		const persistent = isPersistentScaleCensusScenario(scenario);
+		const phase = values.phase ?? (persistent ? undefined : "measure");
+		if (persistent && phase !== "seed" && phase !== "reopen") {
+			throw new Error(
+				"persistent worker mode requires --phase seed or --phase reopen",
+			);
+		}
+		if (!persistent && phase !== "measure") {
+			throw new Error("resident worker mode only accepts --phase measure");
+		}
+		if (persistent && !values.directory) {
+			throw new Error("persistent worker mode requires --directory");
+		}
+		if (!persistent && values.directory) {
+			throw new Error("resident worker mode does not accept --directory");
+		}
 		return {
 			mode: "worker",
 			scenario,
 			count: parsePositiveInteger(values.count, "count"),
 			run: parsePositiveInteger(values.run, "run"),
+			phase,
+			...(values.directory ? { directory: values.directory } : {}),
 		};
 	}
 
-	if (values.scenario || values.count || values.run) {
-		throw new Error("--scenario, --count, and --run are worker-only options");
+	if (
+		values.scenario ||
+		values.count ||
+		values.run ||
+		values.phase ||
+		values.directory
+	) {
+		throw new Error(
+			"--scenario, --count, --run, --phase, and --directory are worker-only options",
+		);
 	}
 
 	return {
@@ -137,14 +193,15 @@ export const buildScaleCensusReport = ({
 	host,
 }) => ({
 	name: SCALE_CENSUS_NAME,
-	schemaVersion: 1,
+	schemaVersion: 2,
 	meta: {
 		counts,
 		scenarios,
 		runs,
-		isolation: "one fresh process per row",
+		isolation:
+			"resident rows use one fresh process; persistent rows use separate seed and reopen processes",
 		measurement:
-			"resident state added after WASM and an empty index are loaded",
+			"resident growth plus persistent index disk, close, and fresh-process reopen costs",
 		...host,
 	},
 	rows,

--- a/scripts/bench/shared-log-scale-census-lib.mjs
+++ b/scripts/bench/shared-log-scale-census-lib.mjs
@@ -86,6 +86,7 @@ export const parseScaleCensusArgs = (args, env = {}) => {
 			counts: { type: "string" },
 			scenarios: { type: "string" },
 			runs: { type: "string" },
+			output: { type: "string" },
 			json: { type: "boolean" },
 			help: { type: "boolean" },
 			worker: { type: "boolean" },
@@ -102,6 +103,9 @@ export const parseScaleCensusArgs = (args, env = {}) => {
 	}
 
 	if (values.worker) {
+		if (values.output) {
+			throw new Error("worker mode does not accept --output");
+		}
 		if (!values.scenario || !values.count || !values.run) {
 			throw new Error("worker mode requires --scenario, --count, and --run");
 		}
@@ -161,6 +165,9 @@ export const parseScaleCensusArgs = (args, env = {}) => {
 			values.runs ?? env.SHARED_LOG_SCALE_RUNS ?? "1",
 			"runs",
 		),
+		...((values.output ?? env.SHARED_LOG_SCALE_OUTPUT)
+			? { output: values.output ?? env.SHARED_LOG_SCALE_OUTPUT }
+			: {}),
 		json: values.json === true || env.BENCH_JSON === "1",
 	};
 };
@@ -191,9 +198,11 @@ export const buildScaleCensusReport = ({
 	runs,
 	rows,
 	host,
+	activeRow = null,
+	failure = null,
 }) => ({
 	name: SCALE_CENSUS_NAME,
-	schemaVersion: 2,
+	schemaVersion: 3,
 	meta: {
 		counts,
 		scenarios,
@@ -203,6 +212,16 @@ export const buildScaleCensusReport = ({
 		measurement:
 			"resident growth plus persistent index disk, close, and fresh-process reopen costs",
 		...host,
+	},
+	progress: {
+		expectedRows: counts.length * scenarios.length * runs,
+		completedRows: rows.length,
+		complete:
+			rows.length === counts.length * scenarios.length * runs &&
+			activeRow === null &&
+			failure === null,
+		activeRow,
+		...(failure ? { failure } : {}),
 	},
 	rows,
 });

--- a/scripts/bench/shared-log-scale-census.integration.mjs
+++ b/scripts/bench/shared-log-scale-census.integration.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -11,31 +14,46 @@ const SCALE_CENSUS_SCRIPT = fileURLToPath(
 	new URL("./shared-log-scale-census.mjs", import.meta.url),
 );
 
-test("round-trips compact snapshots through fresh persistent workers", () => {
-	const child = spawnSync(
-		process.execPath,
-		[
-			SCALE_CENSUS_SCRIPT,
-			"--counts",
-			"3",
-			"--scenarios",
-			SCALE_CENSUS_PERSISTENT_SCENARIOS.join(","),
-			"--runs",
-			"1",
-			"--json",
-		],
-		{ encoding: "utf8", env: process.env, maxBuffer: 1024 * 1024 },
-	);
-	assert.equal(child.status, 0, child.stderr || child.stdout);
-	const report = JSON.parse(child.stdout);
-	assert.equal(report.name, SCALE_CENSUS_NAME);
-	assert.equal(report.rows.length, SCALE_CENSUS_PERSISTENT_SCENARIOS.length);
-	for (const row of report.rows) {
-		assert.equal(row.kind, "persistent-reopen");
-		assert.equal(row.count, 3);
-		assert.equal(row.validation.seededEntries, 3);
-		assert.equal(row.validation.reopenedEntries, 3);
-		assert.equal(row.validation.logicalFootprintStable, true);
-		assert.equal(row.seed.fixture, "indexer-snapshot-file-compact");
+test("checkpoints and round-trips compact snapshots", async () => {
+	const directory = await mkdtemp(join(os.tmpdir(), "scale-census-test-"));
+	try {
+		const output = join(directory, "report.json");
+		const child = spawnSync(
+			process.execPath,
+			[
+				SCALE_CENSUS_SCRIPT,
+				"--counts",
+				"3",
+				"--scenarios",
+				SCALE_CENSUS_PERSISTENT_SCENARIOS.join(","),
+				"--runs",
+				"1",
+				"--output",
+				output,
+				"--json",
+			],
+			{ encoding: "utf8", env: process.env, maxBuffer: 1024 * 1024 },
+		);
+		assert.equal(child.status, 0, child.stderr || child.stdout);
+		const report = JSON.parse(child.stdout);
+		assert.deepEqual(JSON.parse(await readFile(output, "utf8")), report);
+		assert.equal(report.name, SCALE_CENSUS_NAME);
+		assert.deepEqual(report.progress, {
+			expectedRows: SCALE_CENSUS_PERSISTENT_SCENARIOS.length,
+			completedRows: SCALE_CENSUS_PERSISTENT_SCENARIOS.length,
+			complete: true,
+			activeRow: null,
+		});
+		assert.equal(report.rows.length, SCALE_CENSUS_PERSISTENT_SCENARIOS.length);
+		for (const row of report.rows) {
+			assert.equal(row.kind, "persistent-reopen");
+			assert.equal(row.count, 3);
+			assert.equal(row.validation.seededEntries, 3);
+			assert.equal(row.validation.reopenedEntries, 3);
+			assert.equal(row.validation.logicalFootprintStable, true);
+			assert.equal(row.seed.fixture, "indexer-snapshot-file-compact");
+		}
+	} finally {
+		await rm(directory, { recursive: true, force: true });
 	}
 });

--- a/scripts/bench/shared-log-scale-census.integration.mjs
+++ b/scripts/bench/shared-log-scale-census.integration.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	SCALE_CENSUS_NAME,
+	SCALE_CENSUS_PERSISTENT_SCENARIOS,
+} from "./shared-log-scale-census-lib.mjs";
+
+const SCALE_CENSUS_SCRIPT = fileURLToPath(
+	new URL("./shared-log-scale-census.mjs", import.meta.url),
+);
+
+test("round-trips compact snapshots through fresh persistent workers", () => {
+	const child = spawnSync(
+		process.execPath,
+		[
+			SCALE_CENSUS_SCRIPT,
+			"--counts",
+			"3",
+			"--scenarios",
+			SCALE_CENSUS_PERSISTENT_SCENARIOS.join(","),
+			"--runs",
+			"1",
+			"--json",
+		],
+		{ encoding: "utf8", env: process.env, maxBuffer: 1024 * 1024 },
+	);
+	assert.equal(child.status, 0, child.stderr || child.stdout);
+	const report = JSON.parse(child.stdout);
+	assert.equal(report.name, SCALE_CENSUS_NAME);
+	assert.equal(report.rows.length, SCALE_CENSUS_PERSISTENT_SCENARIOS.length);
+	for (const row of report.rows) {
+		assert.equal(row.kind, "persistent-reopen");
+		assert.equal(row.count, 3);
+		assert.equal(row.validation.seededEntries, 3);
+		assert.equal(row.validation.reopenedEntries, 3);
+		assert.equal(row.validation.logicalFootprintStable, true);
+		assert.equal(row.seed.fixture, "indexer-snapshot-file-compact");
+	}
+});

--- a/scripts/bench/shared-log-scale-census.mjs
+++ b/scripts/bench/shared-log-scale-census.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+	SCALE_CENSUS_NAME,
+	SCALE_CENSUS_SCENARIOS,
+	buildScaleCensusReport,
+	memoryDeltas,
+	parseScaleCensusArgs,
+} from "./shared-log-scale-census-lib.mjs";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const LOG_RUST_URL = new URL(
+	"../../packages/log/rust/dist/src/index.js",
+	import.meta.url,
+);
+const SHARED_LOG_RUST_URL = new URL(
+	"../../packages/programs/data/shared-log/rust/dist/src/index.js",
+	import.meta.url,
+);
+
+const HASH_PREFIX = "bafybeigdyrzt";
+const HASH_SUFFIX_LENGTH = 59 - HASH_PREFIX.length;
+const GID_PREFIX = "gid-";
+const GID_SUFFIX_LENGTH = 44 - GID_PREFIX.length;
+
+const makeHash = (index) =>
+	`${HASH_PREFIX}${index.toString(36).padStart(HASH_SUFFIX_LENGTH, "0")}`;
+
+const makeGid = (index) =>
+	`${GID_PREFIX}${index.toString(36).padStart(GID_SUFFIX_LENGTH, "0")}`;
+
+const chainGid = makeGid(0);
+
+const collectGarbage = () => {
+	if (typeof globalThis.gc !== "function") {
+		throw new Error("scale-census workers require Node.js --expose-gc");
+	}
+	globalThis.gc();
+	globalThis.gc();
+};
+
+const memorySnapshot = () => {
+	const usage = process.memoryUsage();
+	return {
+		rss: usage.rss,
+		heapTotal: usage.heapTotal,
+		heapUsed: usage.heapUsed,
+		external: usage.external,
+		arrayBuffers: usage.arrayBuffers,
+	};
+};
+
+const graphEntry = (index, topology) => ({
+	hash: makeHash(index),
+	gid: topology === "chain" ? chainGid : makeGid(index),
+	next: topology === "chain" && index > 0 ? [makeHash(index - 1)] : [],
+	type: 0,
+	head: true,
+	payloadSize: 1,
+	clock: { timestamp: { wallTime: BigInt(index + 1), logical: 0 } },
+});
+
+const measureNativeGraph = async (scenario, count) => {
+	const { createLogGraphIndex } = await import(LOG_RUST_URL);
+	const graph = await createLogGraphIndex();
+	collectGarbage();
+	const empty = memorySnapshot();
+	const topology = scenario === "native-graph-chain" ? "chain" : "roots";
+	const started = performance.now();
+	for (let index = 0; index < count; index++) {
+		graph.put(graphEntry(index, topology));
+	}
+	const elapsedMs = performance.now() - started;
+	if (graph.length !== count) {
+		throw new Error(
+			`native graph retained ${graph.length} of ${count} entries`,
+		);
+	}
+	if (!graph.has(makeHash(0)) || !graph.has(makeHash(count - 1))) {
+		throw new Error("native graph failed endpoint membership validation");
+	}
+	collectGarbage();
+	return {
+		empty,
+		populated: memorySnapshot(),
+		elapsedMs,
+		validation: {
+			retainedEntries: graph.length,
+			endpointHashesPresent: true,
+		},
+	};
+};
+
+const measureCoordinateFrontier = async (count) => {
+	const { createSharedLogState } = await import(SHARED_LOG_RUST_URL);
+	const state = await createSharedLogState("u32");
+	collectGarbage();
+	const empty = memorySnapshot();
+	const started = performance.now();
+	for (let index = 0; index < count; index++) {
+		state.putEntryCoordinates(
+			makeHash(index),
+			makeGid(index),
+			[index],
+			false,
+			1,
+			index,
+		);
+	}
+	const elapsedMs = performance.now() - started;
+	const first = state.getEntryCoordinates(makeHash(0));
+	const last = state.getEntryCoordinates(makeHash(count - 1));
+	if (first?.[0] !== 0 || last?.[0] !== count - 1) {
+		throw new Error("coordinate frontier failed endpoint validation");
+	}
+	collectGarbage();
+	return {
+		empty,
+		populated: memorySnapshot(),
+		elapsedMs,
+		validation: {
+			attemptedRows: count,
+			endpointCoordinates: [first[0], last[0]],
+		},
+	};
+};
+
+const runWorker = async ({ scenario, count, run }) => {
+	collectGarbage();
+	const processStart = memorySnapshot();
+	const measured =
+		scenario === "coordinate-frontier"
+			? await measureCoordinateFrontier(count)
+			: await measureNativeGraph(scenario, count);
+	const elapsedMs = Math.round(measured.elapsedMs * 1000) / 1000;
+	return {
+		scenario,
+		count,
+		run,
+		elapsedMs,
+		opsPerSecond: Math.round((count / measured.elapsedMs) * 1000),
+		fixedRuntimeRssBytes: measured.empty.rss - processStart.rss,
+		maxRssBytes: process.resourceUsage().maxRSS * 1024,
+		...memoryDeltas(measured.empty, measured.populated, count),
+		validation: measured.validation,
+	};
+};
+
+const runIsolatedRow = ({ scenario, count, run }) => {
+	const child = spawnSync(
+		process.execPath,
+		[
+			"--expose-gc",
+			SCRIPT_PATH,
+			"--worker",
+			"--scenario",
+			scenario,
+			"--count",
+			String(count),
+			"--run",
+			String(run),
+		],
+		{
+			encoding: "utf8",
+			env: process.env,
+			maxBuffer: 1024 * 1024,
+		},
+	);
+	if (child.status !== 0) {
+		throw new Error(
+			`scale-census worker failed (${scenario}, count=${count}, run=${run})\n${child.stderr || child.stdout}`,
+		);
+	}
+	const output = child.stdout.trim();
+	if (!output) {
+		throw new Error("scale-census worker produced no result");
+	}
+	let row;
+	try {
+		row = JSON.parse(output);
+	} catch (error) {
+		throw new Error(`scale-census worker produced invalid JSON: ${output}`, {
+			cause: error,
+		});
+	}
+	if (row?.scenario !== scenario || row?.count !== count || row?.run !== run) {
+		throw new Error(
+			`scale-census worker returned the wrong row for ${scenario}, count=${count}, run=${run}`,
+		);
+	}
+	return row;
+};
+
+const hostMetadata = () => ({
+	node: process.version,
+	v8: process.versions.v8,
+	platform: process.platform,
+	arch: process.arch,
+	cpu: os.cpus()[0]?.model ?? "unknown",
+	logicalCpus: os.cpus().length,
+	totalMemoryBytes: os.totalmem(),
+	hashCharacters: 59,
+	gidCharacters: 44,
+	payloadSizeMetadataBytes: 1,
+});
+
+const renderHuman = (report) => {
+	console.log(`${SCALE_CENSUS_NAME} (${report.meta.node}, ${report.meta.cpu})`);
+	console.table(
+		report.rows.map((row) => ({
+			scenario: row.scenario,
+			entries: row.count,
+			run: row.run,
+			elapsedMs: row.elapsedMs,
+			opsPerSecond: row.opsPerSecond,
+			rssDeltaMiB: Math.round((row.rssDeltaBytes / 1024 / 1024) * 10) / 10,
+			rssBytesPerEntry: row.rssBytesPerEntry,
+		})),
+	);
+};
+
+const usage = () => `Usage:
+  node scripts/bench/shared-log-scale-census.mjs [options]
+
+Options:
+  --counts <csv>       Entry counts (default: 100000,1000000)
+  --scenarios <csv>    ${SCALE_CENSUS_SCENARIOS.join(",")}
+  --runs <n>           Isolated runs per scenario/count (default: 1)
+  --json               Emit the versioned JSON report
+  --help               Show this help
+`;
+
+const main = async () => {
+	const options = parseScaleCensusArgs(process.argv.slice(2), process.env);
+	if (options.mode === "help") {
+		console.log(usage());
+		return;
+	}
+	if (options.mode === "worker") {
+		console.log(JSON.stringify(await runWorker(options)));
+		return;
+	}
+
+	const rows = [];
+	for (const scenario of options.scenarios) {
+		for (const count of options.counts) {
+			for (let run = 1; run <= options.runs; run++) {
+				console.error(
+					`[scale-census] scenario=${scenario} count=${count} run=${run}/${options.runs}`,
+				);
+				rows.push(runIsolatedRow({ scenario, count, run }));
+			}
+		}
+	}
+	const report = buildScaleCensusReport({
+		counts: options.counts,
+		scenarios: options.scenarios,
+		runs: options.runs,
+		rows,
+		host: hostMetadata(),
+	});
+	if (options.json) {
+		console.log(JSON.stringify(report, null, 2));
+	} else {
+		renderHuman(report);
+	}
+};
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.stack : error);
+	process.exitCode = 1;
+});

--- a/scripts/bench/shared-log-scale-census.mjs
+++ b/scripts/bench/shared-log-scale-census.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -318,6 +318,14 @@ const renderHuman = (report) => {
 	);
 };
 
+const writeReport = async (path, report) => {
+	const destination = resolve(path);
+	await mkdir(dirname(destination), { recursive: true });
+	const temporary = `${destination}.${process.pid}.tmp`;
+	await writeFile(temporary, `${JSON.stringify(report, null, 2)}\n`);
+	await rename(temporary, destination);
+};
+
 const usage = () => `Usage:
   node scripts/bench/shared-log-scale-census.mjs [options]
 
@@ -325,6 +333,7 @@ Options:
   --counts <csv>       Entry counts (default: 100000,1000000)
   --scenarios <csv>    ${SCALE_CENSUS_SCENARIOS.join(",")}
   --runs <n>           Isolated runs per scenario/count (default: 1)
+  --output <path>      Atomically checkpoint the JSON report after each row
   --json               Emit the versioned JSON report
   --help               Show this help
 `;
@@ -353,27 +362,56 @@ const main = async () => {
 	}
 
 	const rows = [];
+	const host = hostMetadata();
+	let activeRow = null;
+	let failure = null;
+	const report = () =>
+		buildScaleCensusReport({
+			counts: options.counts,
+			scenarios: options.scenarios,
+			runs: options.runs,
+			rows,
+			host,
+			activeRow,
+			failure,
+		});
+	const checkpoint = async () => {
+		if (options.output) {
+			await writeReport(options.output, report());
+		}
+	};
+	await checkpoint();
 	for (const scenario of options.scenarios) {
 		for (const count of options.counts) {
 			for (let run = 1; run <= options.runs; run++) {
+				activeRow = { scenario, count, run };
+				await checkpoint();
 				console.error(
 					`[scale-census] scenario=${scenario} count=${count} run=${run}/${options.runs}`,
 				);
-				rows.push(await runIsolatedRow({ scenario, count, run }));
+				let row;
+				try {
+					row = await runIsolatedRow({ scenario, count, run });
+				} catch (error) {
+					failure = {
+						...activeRow,
+						message: error instanceof Error ? error.message : String(error),
+					};
+					activeRow = null;
+					await checkpoint();
+					throw error;
+				}
+				rows.push(row);
+				activeRow = null;
+				await checkpoint();
 			}
 		}
 	}
-	const report = buildScaleCensusReport({
-		counts: options.counts,
-		scenarios: options.scenarios,
-		runs: options.runs,
-		rows,
-		host: hostMetadata(),
-	});
+	const completedReport = report();
 	if (options.json) {
-		console.log(JSON.stringify(report, null, 2));
+		console.log(JSON.stringify(completedReport, null, 2));
 	} else {
-		renderHuman(report);
+		renderHuman(completedReport);
 	}
 };
 

--- a/scripts/bench/shared-log-scale-census.mjs
+++ b/scripts/bench/shared-log-scale-census.mjs
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
+import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import {
+	SCALE_CENSUS_GID_CHARACTERS,
+	SCALE_CENSUS_HASH_CHARACTERS,
 	SCALE_CENSUS_NAME,
 	SCALE_CENSUS_SCENARIOS,
 	buildScaleCensusReport,
+	isPersistentScaleCensusScenario,
+	makeScaleCensusGid,
+	makeScaleCensusHash,
 	memoryDeltas,
 	parseScaleCensusArgs,
 } from "./shared-log-scale-census-lib.mjs";
@@ -23,18 +30,7 @@ const SHARED_LOG_RUST_URL = new URL(
 	import.meta.url,
 );
 
-const HASH_PREFIX = "bafybeigdyrzt";
-const HASH_SUFFIX_LENGTH = 59 - HASH_PREFIX.length;
-const GID_PREFIX = "gid-";
-const GID_SUFFIX_LENGTH = 44 - GID_PREFIX.length;
-
-const makeHash = (index) =>
-	`${HASH_PREFIX}${index.toString(36).padStart(HASH_SUFFIX_LENGTH, "0")}`;
-
-const makeGid = (index) =>
-	`${GID_PREFIX}${index.toString(36).padStart(GID_SUFFIX_LENGTH, "0")}`;
-
-const chainGid = makeGid(0);
+const chainGid = makeScaleCensusGid(0);
 
 const collectGarbage = () => {
 	if (typeof globalThis.gc !== "function") {
@@ -56,9 +52,10 @@ const memorySnapshot = () => {
 };
 
 const graphEntry = (index, topology) => ({
-	hash: makeHash(index),
-	gid: topology === "chain" ? chainGid : makeGid(index),
-	next: topology === "chain" && index > 0 ? [makeHash(index - 1)] : [],
+	hash: makeScaleCensusHash(index),
+	gid: topology === "chain" ? chainGid : makeScaleCensusGid(index),
+	next:
+		topology === "chain" && index > 0 ? [makeScaleCensusHash(index - 1)] : [],
 	type: 0,
 	head: true,
 	payloadSize: 1,
@@ -81,7 +78,10 @@ const measureNativeGraph = async (scenario, count) => {
 			`native graph retained ${graph.length} of ${count} entries`,
 		);
 	}
-	if (!graph.has(makeHash(0)) || !graph.has(makeHash(count - 1))) {
+	if (
+		!graph.has(makeScaleCensusHash(0)) ||
+		!graph.has(makeScaleCensusHash(count - 1))
+	) {
 		throw new Error("native graph failed endpoint membership validation");
 	}
 	collectGarbage();
@@ -104,8 +104,8 @@ const measureCoordinateFrontier = async (count) => {
 	const started = performance.now();
 	for (let index = 0; index < count; index++) {
 		state.putEntryCoordinates(
-			makeHash(index),
-			makeGid(index),
+			makeScaleCensusHash(index),
+			makeScaleCensusGid(index),
 			[index],
 			false,
 			1,
@@ -113,8 +113,8 @@ const measureCoordinateFrontier = async (count) => {
 		);
 	}
 	const elapsedMs = performance.now() - started;
-	const first = state.getEntryCoordinates(makeHash(0));
-	const last = state.getEntryCoordinates(makeHash(count - 1));
+	const first = state.getEntryCoordinates(makeScaleCensusHash(0));
+	const last = state.getEntryCoordinates(makeScaleCensusHash(count - 1));
 	if (first?.[0] !== 0 || last?.[0] !== count - 1) {
 		throw new Error("coordinate frontier failed endpoint validation");
 	}
@@ -146,34 +146,37 @@ const runWorker = async ({ scenario, count, run }) => {
 		opsPerSecond: Math.round((count / measured.elapsedMs) * 1000),
 		fixedRuntimeRssBytes: measured.empty.rss - processStart.rss,
 		maxRssBytes: process.resourceUsage().maxRSS * 1024,
+		phase: "measure",
 		...memoryDeltas(measured.empty, measured.populated, count),
 		validation: measured.validation,
 	};
 };
 
-const runIsolatedRow = ({ scenario, count, run }) => {
-	const child = spawnSync(
-		process.execPath,
-		[
-			"--expose-gc",
-			SCRIPT_PATH,
-			"--worker",
-			"--scenario",
-			scenario,
-			"--count",
-			String(count),
-			"--run",
-			String(run),
-		],
-		{
-			encoding: "utf8",
-			env: process.env,
-			maxBuffer: 1024 * 1024,
-		},
-	);
+const runWorkerProcess = ({ scenario, count, run, phase, directory }) => {
+	const workerArguments = [
+		"--expose-gc",
+		SCRIPT_PATH,
+		"--worker",
+		"--scenario",
+		scenario,
+		"--count",
+		String(count),
+		"--run",
+		String(run),
+		"--phase",
+		phase,
+	];
+	if (directory) {
+		workerArguments.push("--directory", directory);
+	}
+	const child = spawnSync(process.execPath, workerArguments, {
+		encoding: "utf8",
+		env: process.env,
+		maxBuffer: 1024 * 1024,
+	});
 	if (child.status !== 0) {
 		throw new Error(
-			`scale-census worker failed (${scenario}, count=${count}, run=${run})\n${child.stderr || child.stdout}`,
+			`scale-census worker failed (${scenario}, count=${count}, run=${run}, phase=${phase})\n${child.stderr || child.stdout}`,
 		);
 	}
 	const output = child.stdout.trim();
@@ -188,12 +191,83 @@ const runIsolatedRow = ({ scenario, count, run }) => {
 			cause: error,
 		});
 	}
-	if (row?.scenario !== scenario || row?.count !== count || row?.run !== run) {
+	if (
+		row?.scenario !== scenario ||
+		row?.count !== count ||
+		row?.run !== run ||
+		row?.phase !== phase
+	) {
 		throw new Error(
-			`scale-census worker returned the wrong row for ${scenario}, count=${count}, run=${run}`,
+			`scale-census worker returned the wrong row for ${scenario}, count=${count}, run=${run}, phase=${phase}`,
 		);
 	}
 	return row;
+};
+
+const withoutWorkerIdentity = (workerRow) => {
+	const metrics = { ...workerRow };
+	for (const key of ["scenario", "count", "run", "phase"]) {
+		delete metrics[key];
+	}
+	return metrics;
+};
+
+const sameLogicalFootprint = (before, after) =>
+	before.logicalBytes === after.logicalBytes &&
+	before.files.length === after.files.length &&
+	before.files.every(
+		(file, index) =>
+			file.path === after.files[index].path &&
+			file.logicalBytes === after.files[index].logicalBytes,
+	);
+
+const runIsolatedRow = async ({ scenario, count, run }) => {
+	if (!isPersistentScaleCensusScenario(scenario)) {
+		return {
+			kind: "resident",
+			...withoutWorkerIdentity(
+				runWorkerProcess({ scenario, count, run, phase: "measure" }),
+			),
+			scenario,
+			count,
+			run,
+		};
+	}
+
+	const directory = await mkdtemp(
+		join(os.tmpdir(), "peerbit-shared-log-scale-census-"),
+	);
+	try {
+		const seed = runWorkerProcess({
+			scenario,
+			count,
+			run,
+			phase: "seed",
+			directory,
+		});
+		const reopen = runWorkerProcess({
+			scenario,
+			count,
+			run,
+			phase: "reopen",
+			directory,
+		});
+		return {
+			scenario,
+			count,
+			run,
+			kind: "persistent-reopen",
+			seed: withoutWorkerIdentity(seed),
+			reopen: withoutWorkerIdentity(reopen),
+			validation: {
+				seededEntries: seed.validation.retainedEntriesInSnapshot,
+				reopenedEntries: reopen.validation.retainedEntries,
+				logicalFootprintStable: sameLogicalFootprint(seed.disk, reopen.disk),
+			},
+		};
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
 };
 
 const hostMetadata = () => ({
@@ -204,23 +278,43 @@ const hostMetadata = () => ({
 	cpu: os.cpus()[0]?.model ?? "unknown",
 	logicalCpus: os.cpus().length,
 	totalMemoryBytes: os.totalmem(),
-	hashCharacters: 59,
-	gidCharacters: 44,
+	hashCharacters: SCALE_CENSUS_HASH_CHARACTERS,
+	gidCharacters: SCALE_CENSUS_GID_CHARACTERS,
 	payloadSizeMetadataBytes: 1,
 });
 
 const renderHuman = (report) => {
 	console.log(`${SCALE_CENSUS_NAME} (${report.meta.node}, ${report.meta.cpu})`);
 	console.table(
-		report.rows.map((row) => ({
-			scenario: row.scenario,
-			entries: row.count,
-			run: row.run,
-			elapsedMs: row.elapsedMs,
-			opsPerSecond: row.opsPerSecond,
-			rssDeltaMiB: Math.round((row.rssDeltaBytes / 1024 / 1024) * 10) / 10,
-			rssBytesPerEntry: row.rssBytesPerEntry,
-		})),
+		report.rows.map((row) =>
+			row.kind === "resident"
+				? {
+						scenario: row.scenario,
+						entries: row.count,
+						run: row.run,
+						operationMs: row.elapsedMs,
+						opsPerSecond: row.opsPerSecond,
+						rssDeltaMiB:
+							Math.round((row.rssDeltaBytes / 1024 / 1024) * 10) / 10,
+						rssBytesPerEntry: row.rssBytesPerEntry,
+					}
+				: {
+						scenario: row.scenario,
+						entries: row.count,
+						run: row.run,
+						operationMs: row.reopen.openMs,
+						opsPerSecond: row.reopen.openEntriesPerSecond,
+						rssDeltaMiB:
+							Math.round((row.reopen.rssDeltaBytes / 1024 / 1024) * 10) / 10,
+						rssBytesPerEntry: row.reopen.rssBytesPerEntry,
+						diskMiB:
+							Math.round((row.reopen.disk.logicalBytes / 1024 / 1024) * 10) /
+							10,
+						diskBytesPerEntry: row.reopen.disk.logicalBytesPerEntry,
+						snapshotMs: row.seed.snapshotMs,
+						reopenCloseMs: row.reopen.closeMs,
+					},
+		),
 	);
 };
 
@@ -242,6 +336,18 @@ const main = async () => {
 		return;
 	}
 	if (options.mode === "worker") {
+		if (isPersistentScaleCensusScenario(options.scenario)) {
+			const { reopenPersistentScaleScenario, seedPersistentScaleScenario } =
+				await import("./shared-log-scale-persistence.mjs");
+			console.log(
+				JSON.stringify(
+					options.phase === "seed"
+						? await seedPersistentScaleScenario(options)
+						: await reopenPersistentScaleScenario(options),
+				),
+			);
+			return;
+		}
 		console.log(JSON.stringify(await runWorker(options)));
 		return;
 	}
@@ -253,7 +359,7 @@ const main = async () => {
 				console.error(
 					`[scale-census] scenario=${scenario} count=${count} run=${run}/${options.runs}`,
 				);
-				rows.push(runIsolatedRow({ scenario, count, run }));
+				rows.push(await runIsolatedRow({ scenario, count, run }));
 			}
 		}
 	}

--- a/scripts/bench/shared-log-scale-census.spec.mjs
+++ b/scripts/bench/shared-log-scale-census.spec.mjs
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
+	SCALE_CENSUS_GID_CHARACTERS,
+	SCALE_CENSUS_HASH_CHARACTERS,
 	SCALE_CENSUS_NAME,
+	SCALE_CENSUS_PERSISTENT_SCENARIOS,
 	SCALE_CENSUS_SCENARIOS,
 	buildScaleCensusReport,
+	isPersistentScaleCensusScenario,
+	makeScaleCensusGid,
+	makeScaleCensusHash,
 	memoryDeltas,
 	parseScaleCensusArgs,
 } from "./shared-log-scale-census-lib.mjs";
+
+const SCALE_CENSUS_SCRIPT = fileURLToPath(
+	new URL("./shared-log-scale-census.mjs", import.meta.url),
+);
 
 test("parses the canonical scale census", () => {
 	assert.deepEqual(parseScaleCensusArgs([], {}), {
@@ -70,8 +82,40 @@ test("parses one isolated worker row", () => {
 			scenario: "native-graph-roots",
 			count: 1_000,
 			run: 2,
+			phase: "measure",
 		},
 	);
+});
+
+test("parses persistent seed and reopen workers", () => {
+	for (const phase of ["seed", "reopen"]) {
+		assert.deepEqual(
+			parseScaleCensusArgs(
+				[
+					"--worker",
+					"--scenario",
+					"persistent-coordinate-index",
+					"--count",
+					"1000",
+					"--run",
+					"1",
+					"--phase",
+					phase,
+					"--directory",
+					"/tmp/census",
+				],
+				{},
+			),
+			{
+				mode: "worker",
+				scenario: "persistent-coordinate-index",
+				count: 1_000,
+				run: 1,
+				phase,
+				directory: "/tmp/census",
+			},
+		);
+	}
 });
 
 test("rejects ambiguous or invalid workloads", () => {
@@ -99,6 +143,75 @@ test("rejects ambiguous or invalid workloads", () => {
 			),
 		/requires --scenario, --count, and --run/,
 	);
+	assert.throws(
+		() =>
+			parseScaleCensusArgs(
+				[
+					"--worker",
+					"--scenario",
+					"persistent-coordinate-index",
+					"--count",
+					"100",
+					"--run",
+					"1",
+				],
+				{},
+			),
+		/requires --phase seed or --phase reopen/,
+	);
+	assert.throws(
+		() =>
+			parseScaleCensusArgs(
+				[
+					"--worker",
+					"--scenario",
+					"persistent-coordinate-index",
+					"--count",
+					"100",
+					"--run",
+					"1",
+					"--phase",
+					"seed",
+				],
+				{},
+			),
+		/requires --directory/,
+	);
+	assert.throws(
+		() =>
+			parseScaleCensusArgs(
+				[
+					"--worker",
+					"--scenario",
+					"native-graph-chain",
+					"--count",
+					"100",
+					"--run",
+					"1",
+					"--directory",
+					"/tmp/census",
+				],
+				{},
+			),
+		/does not accept --directory/,
+	);
+	assert.throws(
+		() => parseScaleCensusArgs(["--phase", "seed"], {}),
+		/worker-only/,
+	);
+});
+
+test("builds fixed-width unique synthetic identifiers", () => {
+	assert.equal(makeScaleCensusHash(0).length, SCALE_CENSUS_HASH_CHARACTERS);
+	assert.equal(makeScaleCensusHash(1).length, SCALE_CENSUS_HASH_CHARACTERS);
+	assert.notEqual(makeScaleCensusHash(0), makeScaleCensusHash(1));
+	assert.equal(makeScaleCensusGid(0).length, SCALE_CENSUS_GID_CHARACTERS);
+	assert.equal(makeScaleCensusGid(1).length, SCALE_CENSUS_GID_CHARACTERS);
+	assert.notEqual(makeScaleCensusGid(0), makeScaleCensusGid(1));
+	assert.ok(
+		SCALE_CENSUS_PERSISTENT_SCENARIOS.every(isPersistentScaleCensusScenario),
+	);
+	assert.equal(isPersistentScaleCensusScenario("native-graph-chain"), false);
 });
 
 test("reports memory deltas and per-entry costs", () => {
@@ -156,18 +269,48 @@ test("builds a versioned machine-readable report", () => {
 		}),
 		{
 			name: SCALE_CENSUS_NAME,
-			schemaVersion: 1,
+			schemaVersion: 2,
 			meta: {
 				counts: [100],
 				scenarios: ["native-graph-chain"],
 				runs: 1,
-				isolation: "one fresh process per row",
+				isolation:
+					"resident rows use one fresh process; persistent rows use separate seed and reopen processes",
 				measurement:
-					"resident state added after WASM and an empty index are loaded",
+					"resident growth plus persistent index disk, close, and fresh-process reopen costs",
 				node: "v22.0.0",
 				platform: "linux",
 			},
 			rows: [{ scenario: "native-graph-chain", count: 100 }],
 		},
 	);
+});
+
+test("round-trips compact snapshots through fresh persistent workers", () => {
+	const child = spawnSync(
+		process.execPath,
+		[
+			SCALE_CENSUS_SCRIPT,
+			"--counts",
+			"3",
+			"--scenarios",
+			SCALE_CENSUS_PERSISTENT_SCENARIOS.join(","),
+			"--runs",
+			"1",
+			"--json",
+		],
+		{ encoding: "utf8", env: process.env, maxBuffer: 1024 * 1024 },
+	);
+	assert.equal(child.status, 0, child.stderr || child.stdout);
+	const report = JSON.parse(child.stdout);
+	assert.equal(report.name, SCALE_CENSUS_NAME);
+	assert.equal(report.rows.length, SCALE_CENSUS_PERSISTENT_SCENARIOS.length);
+	for (const row of report.rows) {
+		assert.equal(row.kind, "persistent-reopen");
+		assert.equal(row.count, 3);
+		assert.equal(row.validation.seededEntries, 3);
+		assert.equal(row.validation.reopenedEntries, 3);
+		assert.equal(row.validation.logicalFootprintStable, true);
+		assert.equal(row.seed.fixture, "indexer-snapshot-file-compact");
+	}
 });

--- a/scripts/bench/shared-log-scale-census.spec.mjs
+++ b/scripts/bench/shared-log-scale-census.spec.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	SCALE_CENSUS_NAME,
+	SCALE_CENSUS_SCENARIOS,
+	buildScaleCensusReport,
+	memoryDeltas,
+	parseScaleCensusArgs,
+} from "./shared-log-scale-census-lib.mjs";
+
+test("parses the canonical scale census", () => {
+	assert.deepEqual(parseScaleCensusArgs([], {}), {
+		mode: "parent",
+		counts: [100_000, 1_000_000],
+		scenarios: [...SCALE_CENSUS_SCENARIOS],
+		runs: 1,
+		json: false,
+	});
+});
+
+test("accepts explicit and environment scale census options", () => {
+	assert.deepEqual(
+		parseScaleCensusArgs(
+			[
+				"--counts",
+				"1_000,20_000",
+				"--scenarios",
+				"native-graph-chain,coordinate-frontier",
+				"--runs",
+				"3",
+				"--json",
+			],
+			{},
+		),
+		{
+			mode: "parent",
+			counts: [1_000, 20_000],
+			scenarios: ["native-graph-chain", "coordinate-frontier"],
+			runs: 3,
+			json: true,
+		},
+	);
+
+	assert.equal(parseScaleCensusArgs([], { BENCH_JSON: "1" }).json, true);
+	assert.deepEqual(parseScaleCensusArgs(["--", "--counts", "1000"], {}), {
+		mode: "parent",
+		counts: [1_000],
+		scenarios: [...SCALE_CENSUS_SCENARIOS],
+		runs: 1,
+		json: false,
+	});
+});
+
+test("parses one isolated worker row", () => {
+	assert.deepEqual(
+		parseScaleCensusArgs(
+			[
+				"--worker",
+				"--scenario",
+				"native-graph-roots",
+				"--count",
+				"1000",
+				"--run",
+				"2",
+			],
+			{},
+		),
+		{
+			mode: "worker",
+			scenario: "native-graph-roots",
+			count: 1_000,
+			run: 2,
+		},
+	);
+});
+
+test("rejects ambiguous or invalid workloads", () => {
+	assert.throws(
+		() => parseScaleCensusArgs(["--counts", "0"], {}),
+		/count must be a positive integer/,
+	);
+	assert.throws(
+		() => parseScaleCensusArgs(["--counts", "100,100"], {}),
+		/counts must not contain duplicate values/,
+	);
+	assert.throws(
+		() => parseScaleCensusArgs(["--scenarios", "unknown"], {}),
+		/Unknown scale-census scenario/,
+	);
+	assert.throws(
+		() => parseScaleCensusArgs(["--count", "100"], {}),
+		/worker-only/,
+	);
+	assert.throws(
+		() =>
+			parseScaleCensusArgs(
+				["--worker", "--scenario", "native-graph-chain"],
+				{},
+			),
+		/requires --scenario, --count, and --run/,
+	);
+});
+
+test("reports memory deltas and per-entry costs", () => {
+	assert.deepEqual(
+		memoryDeltas(
+			{
+				rss: 100,
+				heapTotal: 200,
+				heapUsed: 50,
+				external: 20,
+				arrayBuffers: 10,
+			},
+			{
+				rss: 500,
+				heapTotal: 300,
+				heapUsed: 70,
+				external: 60,
+				arrayBuffers: 20,
+			},
+			10,
+		),
+		{
+			rssBeforeBytes: 100,
+			rssAfterBytes: 500,
+			rssDeltaBytes: 400,
+			rssBytesPerEntry: 40,
+			heapTotalBeforeBytes: 200,
+			heapTotalAfterBytes: 300,
+			heapTotalDeltaBytes: 100,
+			heapTotalBytesPerEntry: 10,
+			heapUsedBeforeBytes: 50,
+			heapUsedAfterBytes: 70,
+			heapUsedDeltaBytes: 20,
+			heapUsedBytesPerEntry: 2,
+			externalBeforeBytes: 20,
+			externalAfterBytes: 60,
+			externalDeltaBytes: 40,
+			externalBytesPerEntry: 4,
+			arrayBuffersBeforeBytes: 10,
+			arrayBuffersAfterBytes: 20,
+			arrayBuffersDeltaBytes: 10,
+			arrayBuffersBytesPerEntry: 1,
+		},
+	);
+});
+
+test("builds a versioned machine-readable report", () => {
+	assert.deepEqual(
+		buildScaleCensusReport({
+			counts: [100],
+			scenarios: ["native-graph-chain"],
+			runs: 1,
+			rows: [{ scenario: "native-graph-chain", count: 100 }],
+			host: { node: "v22.0.0", platform: "linux" },
+		}),
+		{
+			name: SCALE_CENSUS_NAME,
+			schemaVersion: 1,
+			meta: {
+				counts: [100],
+				scenarios: ["native-graph-chain"],
+				runs: 1,
+				isolation: "one fresh process per row",
+				measurement:
+					"resident state added after WASM and an empty index are loaded",
+				node: "v22.0.0",
+				platform: "linux",
+			},
+			rows: [{ scenario: "native-graph-chain", count: 100 }],
+		},
+	);
+});

--- a/scripts/bench/shared-log-scale-census.spec.mjs
+++ b/scripts/bench/shared-log-scale-census.spec.mjs
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
 import {
 	SCALE_CENSUS_GID_CHARACTERS,
 	SCALE_CENSUS_HASH_CHARACTERS,
@@ -15,10 +13,6 @@ import {
 	memoryDeltas,
 	parseScaleCensusArgs,
 } from "./shared-log-scale-census-lib.mjs";
-
-const SCALE_CENSUS_SCRIPT = fileURLToPath(
-	new URL("./shared-log-scale-census.mjs", import.meta.url),
-);
 
 test("parses the canonical scale census", () => {
 	assert.deepEqual(parseScaleCensusArgs([], {}), {
@@ -284,33 +278,4 @@ test("builds a versioned machine-readable report", () => {
 			rows: [{ scenario: "native-graph-chain", count: 100 }],
 		},
 	);
-});
-
-test("round-trips compact snapshots through fresh persistent workers", () => {
-	const child = spawnSync(
-		process.execPath,
-		[
-			SCALE_CENSUS_SCRIPT,
-			"--counts",
-			"3",
-			"--scenarios",
-			SCALE_CENSUS_PERSISTENT_SCENARIOS.join(","),
-			"--runs",
-			"1",
-			"--json",
-		],
-		{ encoding: "utf8", env: process.env, maxBuffer: 1024 * 1024 },
-	);
-	assert.equal(child.status, 0, child.stderr || child.stdout);
-	const report = JSON.parse(child.stdout);
-	assert.equal(report.name, SCALE_CENSUS_NAME);
-	assert.equal(report.rows.length, SCALE_CENSUS_PERSISTENT_SCENARIOS.length);
-	for (const row of report.rows) {
-		assert.equal(row.kind, "persistent-reopen");
-		assert.equal(row.count, 3);
-		assert.equal(row.validation.seededEntries, 3);
-		assert.equal(row.validation.reopenedEntries, 3);
-		assert.equal(row.validation.logicalFootprintStable, true);
-		assert.equal(row.seed.fixture, "indexer-snapshot-file-compact");
-	}
 });

--- a/scripts/bench/shared-log-scale-census.spec.mjs
+++ b/scripts/bench/shared-log-scale-census.spec.mjs
@@ -48,6 +48,18 @@ test("accepts explicit and environment scale census options", () => {
 	);
 
 	assert.equal(parseScaleCensusArgs([], { BENCH_JSON: "1" }).json, true);
+	assert.equal(
+		parseScaleCensusArgs([], {
+			SHARED_LOG_SCALE_OUTPUT: "/tmp/scale-census.json",
+		}).output,
+		"/tmp/scale-census.json",
+	);
+	assert.equal(
+		parseScaleCensusArgs(["--output", "/tmp/explicit-scale-census.json"], {
+			SHARED_LOG_SCALE_OUTPUT: "/tmp/environment-scale-census.json",
+		}).output,
+		"/tmp/explicit-scale-census.json",
+	);
 	assert.deepEqual(parseScaleCensusArgs(["--", "--counts", "1000"], {}), {
 		mode: "parent",
 		counts: [1_000],
@@ -193,6 +205,24 @@ test("rejects ambiguous or invalid workloads", () => {
 		() => parseScaleCensusArgs(["--phase", "seed"], {}),
 		/worker-only/,
 	);
+	assert.throws(
+		() =>
+			parseScaleCensusArgs(
+				[
+					"--worker",
+					"--scenario",
+					"native-graph-chain",
+					"--count",
+					"100",
+					"--run",
+					"1",
+					"--output",
+					"/tmp/result.json",
+				],
+				{},
+			),
+		/worker mode does not accept --output/,
+	);
 });
 
 test("builds fixed-width unique synthetic identifiers", () => {
@@ -263,7 +293,7 @@ test("builds a versioned machine-readable report", () => {
 		}),
 		{
 			name: SCALE_CENSUS_NAME,
-			schemaVersion: 2,
+			schemaVersion: 3,
 			meta: {
 				counts: [100],
 				scenarios: ["native-graph-chain"],
@@ -275,7 +305,64 @@ test("builds a versioned machine-readable report", () => {
 				node: "v22.0.0",
 				platform: "linux",
 			},
+			progress: {
+				expectedRows: 1,
+				completedRows: 1,
+				complete: true,
+				activeRow: null,
+			},
 			rows: [{ scenario: "native-graph-chain", count: 100 }],
+		},
+	);
+});
+
+test("reports checkpoint progress and a terminal row failure", () => {
+	assert.deepEqual(
+		buildScaleCensusReport({
+			counts: [100, 1_000],
+			scenarios: ["native-graph-chain"],
+			runs: 1,
+			rows: [{ scenario: "native-graph-chain", count: 100, run: 1 }],
+			host: { node: "v22.0.0" },
+			activeRow: {
+				scenario: "native-graph-chain",
+				count: 1_000,
+				run: 1,
+			},
+		}).progress,
+		{
+			expectedRows: 2,
+			completedRows: 1,
+			complete: false,
+			activeRow: {
+				scenario: "native-graph-chain",
+				count: 1_000,
+				run: 1,
+			},
+		},
+	);
+
+	const failure = {
+		scenario: "native-graph-chain",
+		count: 1_000,
+		run: 1,
+		message: "worker failed",
+	};
+	assert.deepEqual(
+		buildScaleCensusReport({
+			counts: [100, 1_000],
+			scenarios: ["native-graph-chain"],
+			runs: 1,
+			rows: [{ scenario: "native-graph-chain", count: 100, run: 1 }],
+			host: { node: "v22.0.0" },
+			failure,
+		}).progress,
+		{
+			expectedRows: 2,
+			completedRows: 1,
+			complete: false,
+			activeRow: null,
+			failure,
 		},
 	);
 });

--- a/scripts/bench/shared-log-scale-persistence.mjs
+++ b/scripts/bench/shared-log-scale-persistence.mjs
@@ -1,0 +1,423 @@
+import { readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import {
+	makeScaleCensusGid,
+	makeScaleCensusHash,
+	memoryDeltas,
+} from "./shared-log-scale-census-lib.mjs";
+
+const INDEXER_RUST_URL = new URL(
+	"../../packages/utils/indexer/rust/dist/src/index.js",
+	import.meta.url,
+);
+const INDEXER_INTERFACE_URL = new URL(
+	"../../packages/utils/indexer/interface/dist/src/index.js",
+	import.meta.url,
+);
+const INDEXER_PERSISTENCE_URL = new URL(
+	"../../packages/utils/indexer/rust/dist/src/persistence.js",
+	import.meta.url,
+);
+const LOG_URL = new URL(
+	"../../packages/log/dist/src/index.js",
+	import.meta.url,
+);
+const LOG_RUST_URL = new URL(
+	"../../packages/log/rust/dist/src/index.js",
+	import.meta.url,
+);
+const SHARED_LOG_URL = new URL(
+	"../../packages/programs/data/shared-log/dist/src/index.js",
+	import.meta.url,
+);
+const BLOCKS_URL = new URL(
+	"../../packages/transport/blocks/dist/src/index.js",
+	import.meta.url,
+);
+const CRYPTO_URL = new URL(
+	"../../packages/utils/crypto/dist/src/index.js",
+	import.meta.url,
+);
+
+const CLOCK_ID = new Uint8Array(32).fill(7);
+const LOG_ID = new Uint8Array(32).fill(11);
+
+const isHeadGraphScenario = (scenario) =>
+	scenario === "persistent-head-index-graph-chain" ||
+	scenario === "persistent-head-index-graph-roots";
+
+const collectGarbage = () => {
+	if (typeof globalThis.gc !== "function") {
+		throw new Error("scale-census workers require Node.js --expose-gc");
+	}
+	globalThis.gc();
+	globalThis.gc();
+};
+
+const memorySnapshot = () => {
+	const usage = process.memoryUsage();
+	return {
+		rss: usage.rss,
+		heapTotal: usage.heapTotal,
+		heapUsed: usage.heapUsed,
+		external: usage.external,
+		arrayBuffers: usage.arrayBuffers,
+	};
+};
+
+const roundedMilliseconds = (value) => Math.round(value * 1_000) / 1_000;
+
+const directoryFootprint = async (directory, count) => {
+	const files = [];
+	const visit = async (current) => {
+		for (const entry of await readdir(current, { withFileTypes: true })) {
+			const path = join(current, entry.name);
+			if (entry.isDirectory()) {
+				await visit(path);
+				continue;
+			}
+			if (!entry.isFile()) {
+				continue;
+			}
+			const file = await stat(path);
+			files.push({
+				path: relative(directory, path).split("\\").join("/"),
+				logicalBytes: file.size,
+				allocatedBytes:
+					typeof file.blocks === "number" ? file.blocks * 512 : null,
+			});
+		}
+	};
+	await visit(directory);
+	files.sort((left, right) => left.path.localeCompare(right.path));
+	const logicalBytes = files.reduce((sum, file) => sum + file.logicalBytes, 0);
+	const allocatedValues = files.map((file) => file.allocatedBytes);
+	const allocatedBytes = allocatedValues.every((value) => value != null)
+		? allocatedValues.reduce((sum, value) => sum + value, 0)
+		: null;
+	return {
+		logicalBytes,
+		logicalBytesPerEntry: Math.round(logicalBytes / count),
+		allocatedBytes,
+		allocatedBytesPerEntry:
+			allocatedBytes == null ? null : Math.round(allocatedBytes / count),
+		fileCount: files.length,
+		files,
+	};
+};
+
+const buildHeadRows = ({
+	start,
+	end,
+	count,
+	topology,
+	ShallowEntry,
+	ShallowMeta,
+	LamportClock,
+	Timestamp,
+}) => {
+	const rows = new Array(end - start);
+	for (let index = start; index < end; index++) {
+		const gid =
+			topology === "chain" ? makeScaleCensusGid(0) : makeScaleCensusGid(index);
+		rows[index - start] = new ShallowEntry({
+			hash: makeScaleCensusHash(index),
+			meta: new ShallowMeta({
+				gid,
+				clock: new LamportClock({
+					id: CLOCK_ID,
+					timestamp: new Timestamp({ wallTime: BigInt(index + 1) }),
+				}),
+				type: 0,
+				next:
+					topology === "chain" && index > 0
+						? [makeScaleCensusHash(index - 1)]
+						: [],
+			}),
+			payloadSize: 1,
+			head: topology === "roots" || index === count - 1,
+		});
+	}
+	return rows;
+};
+
+const createCoordinateMetaBytes = ({
+	EntryReplicatedU32,
+	ShallowMeta,
+	LamportClock,
+	Timestamp,
+}) =>
+	new EntryReplicatedU32({
+		hash: makeScaleCensusHash(0),
+		hashNumber: 0,
+		coordinates: [0],
+		assignedToRangeBoundary: false,
+		meta: new ShallowMeta({
+			gid: makeScaleCensusGid(0),
+			clock: new LamportClock({
+				id: CLOCK_ID,
+				timestamp: new Timestamp({ wallTime: 1n }),
+			}),
+			type: 0,
+			next: [],
+		}),
+	}).getMetaBytes();
+
+const buildCoordinateRows = ({ start, end, metaBytes, EntryReplicatedU32 }) => {
+	const rows = new Array(end - start);
+	for (let index = start; index < end; index++) {
+		rows[index - start] = new EntryReplicatedU32({
+			hash: makeScaleCensusHash(index),
+			hashNumber: index >>> 0,
+			gid: makeScaleCensusGid(index),
+			coordinates: [index >>> 0],
+			wallTime: BigInt(index + 1),
+			assignedToRangeBoundary: false,
+			metaBytes,
+		});
+	}
+	return rows;
+};
+
+export const seedPersistentScaleScenario = async ({
+	scenario,
+	count,
+	run,
+	directory,
+}) => {
+	const processStart = memorySnapshot();
+	const [{ createSnapshotFile }, logModule, sharedLogModule] =
+		await Promise.all([
+			import(INDEXER_PERSISTENCE_URL),
+			import(LOG_URL),
+			import(SHARED_LOG_URL),
+		]);
+	const { ShallowEntry, ShallowMeta, LamportClock, Timestamp } = logModule;
+	const { EntryReplicatedU32 } = sharedLogModule;
+	const schema = isHeadGraphScenario(scenario)
+		? ShallowEntry
+		: EntryReplicatedU32;
+	const snapshotFile = await createSnapshotFile(
+		directory,
+		isHeadGraphScenario(scenario) ? ["heads"] : [],
+		["hash"],
+	);
+	if (!snapshotFile) {
+		throw new Error("persistent snapshot fixture requires a directory");
+	}
+	const topology = scenario.endsWith("chain") ? "chain" : "roots";
+	const metaBytes = isHeadGraphScenario(scenario)
+		? undefined
+		: createCoordinateMetaBytes({
+				EntryReplicatedU32,
+				ShallowMeta,
+				LamportClock,
+				Timestamp,
+			});
+	collectGarbage();
+	const fixedRuntime = memorySnapshot();
+	const buildStarted = performance.now();
+	let rows = isHeadGraphScenario(scenario)
+		? buildHeadRows({
+				start: 0,
+				end: count,
+				count,
+				topology,
+				ShallowEntry,
+				ShallowMeta,
+				LamportClock,
+				Timestamp,
+			})
+		: buildCoordinateRows({
+				start: 0,
+				end: count,
+				metaBytes,
+				EntryReplicatedU32,
+			});
+	const buildMs = performance.now() - buildStarted;
+	const snapshotStarted = performance.now();
+	await snapshotFile.compact(rows, schema);
+	const snapshotMs = performance.now() - snapshotStarted;
+	const retainedEntries = rows.length;
+	rows = [];
+	collectGarbage();
+	return {
+		scenario,
+		count,
+		run,
+		phase: "seed",
+		fixture: "indexer-snapshot-file-compact",
+		buildMs: roundedMilliseconds(buildMs),
+		snapshotMs: roundedMilliseconds(snapshotMs),
+		snapshotRowsPerSecond: Math.round((count / snapshotMs) * 1_000),
+		fixedRuntimeRssBytes: fixedRuntime.rss - processStart.rss,
+		maxRssBytes: process.resourceUsage().maxRSS * 1_024,
+		disk: await directoryFootprint(directory, count),
+		validation: { retainedEntriesInSnapshot: retainedEntries },
+	};
+};
+
+const warmRustIndex = async (create, schema, scope) => {
+	const indices = create();
+	await indices.start();
+	const owner = scope ? await indices.scope(scope) : indices;
+	await owner.init({ schema });
+	await indices.drop();
+};
+
+const warmNativeGraph = async (createLogGraphIndex) => {
+	const graph = await createLogGraphIndex();
+	graph.clear();
+};
+
+const reopenCoordinateIndex = async ({ scenario, count, run, directory }) => {
+	const processStart = memorySnapshot();
+	const [{ create }, { toId }, { EntryReplicatedU32 }] = await Promise.all([
+		import(INDEXER_RUST_URL),
+		import(INDEXER_INTERFACE_URL),
+		import(SHARED_LOG_URL),
+	]);
+	await warmRustIndex(create, EntryReplicatedU32);
+	collectGarbage();
+	const empty = memorySnapshot();
+	const indices = create(directory);
+	const openStarted = performance.now();
+	await indices.start();
+	const index = await indices.init({ schema: EntryReplicatedU32 });
+	const openMs = performance.now() - openStarted;
+	if (index.getSize() !== count) {
+		throw new Error(
+			`coordinate reopen retained ${index.getSize()} of ${count} rows`,
+		);
+	}
+	const retainedEntries = index.getSize();
+	const [first, last] = await Promise.all([
+		index.get(toId(makeScaleCensusHash(0))),
+		index.get(toId(makeScaleCensusHash(count - 1))),
+	]);
+	if (
+		first?.value?.coordinates?.[0] !== 0 ||
+		last?.value?.coordinates?.[0] !== (count - 1) >>> 0
+	) {
+		throw new Error("coordinate reopen failed endpoint validation");
+	}
+	collectGarbage();
+	const opened = memorySnapshot();
+	const openMaxRssBytes = process.resourceUsage().maxRSS * 1_024;
+	const closeStarted = performance.now();
+	await indices.stop();
+	const closeMs = performance.now() - closeStarted;
+	return {
+		scenario,
+		count,
+		run,
+		phase: "reopen",
+		openMs: roundedMilliseconds(openMs),
+		openEntriesPerSecond: Math.round((count / openMs) * 1_000),
+		closeMs: roundedMilliseconds(closeMs),
+		fixedRuntimeRssBytes: empty.rss - processStart.rss,
+		openMaxRssBytes,
+		maxRssBytes: process.resourceUsage().maxRSS * 1_024,
+		...memoryDeltas(empty, opened, count),
+		disk: await directoryFootprint(directory, count),
+		validation: {
+			retainedEntries,
+			endpointCoordinates: [
+				first.value.coordinates[0],
+				last.value.coordinates[0],
+			],
+		},
+	};
+};
+
+const reopenHeadIndexAndGraph = async ({ scenario, count, run, directory }) => {
+	const processStart = memorySnapshot();
+	const [indexerModule, logModule, logRustModule, blocksModule, cryptoModule] =
+		await Promise.all([
+			import(INDEXER_RUST_URL),
+			import(LOG_URL),
+			import(LOG_RUST_URL),
+			import(BLOCKS_URL),
+			import(CRYPTO_URL),
+		]);
+	const { create } = indexerModule;
+	const { Log, ShallowEntry } = logModule;
+	const { createLogGraphIndex } = logRustModule;
+	const { AnyBlockStore } = blocksModule;
+	const { Ed25519Keypair } = cryptoModule;
+	await warmRustIndex(create, ShallowEntry, "heads");
+	await warmNativeGraph(createLogGraphIndex);
+	const store = new AnyBlockStore();
+	await store.start();
+	const key = await Ed25519Keypair.create();
+	collectGarbage();
+	const empty = memorySnapshot();
+	const indices = create(directory);
+	const log = new Log({ id: LOG_ID });
+	const openStarted = performance.now();
+	await log.open(store, key, {
+		indexer: indices,
+		nativeGraph: true,
+	});
+	const openMs = performance.now() - openStarted;
+	const graph = log.entryIndex.properties.nativeGraph?.graph;
+	if (!graph || graph.length !== count || log.length !== count) {
+		throw new Error(
+			`graph reopen retained ${graph?.length ?? 0} of ${count} entries`,
+		);
+	}
+	if (
+		!graph.has(makeScaleCensusHash(0)) ||
+		!graph.has(makeScaleCensusHash(count - 1))
+	) {
+		throw new Error("graph reopen failed endpoint membership validation");
+	}
+	const topology = scenario.endsWith("chain") ? "chain" : "roots";
+	const sampledGids =
+		topology === "chain" || count === 1
+			? [makeScaleCensusGid(0)]
+			: [makeScaleCensusGid(0), makeScaleCensusGid(count - 1)];
+	const headSamples = sampledGids.flatMap((gid) => graph.heads(gid));
+	if (
+		(topology === "chain" &&
+			(headSamples.length !== 1 ||
+				headSamples[0] !== makeScaleCensusHash(count - 1))) ||
+		(topology === "roots" && headSamples.length !== sampledGids.length)
+	) {
+		throw new Error("graph reopen failed head validation");
+	}
+	collectGarbage();
+	const opened = memorySnapshot();
+	const openMaxRssBytes = process.resourceUsage().maxRSS * 1_024;
+	const closeStarted = performance.now();
+	await log.close();
+	const closeMs = performance.now() - closeStarted;
+	await store.stop();
+	return {
+		scenario,
+		count,
+		run,
+		phase: "reopen",
+		openMs: roundedMilliseconds(openMs),
+		openEntriesPerSecond: Math.round((count / openMs) * 1_000),
+		closeMs: roundedMilliseconds(closeMs),
+		fixedRuntimeRssBytes: empty.rss - processStart.rss,
+		openMaxRssBytes,
+		maxRssBytes: process.resourceUsage().maxRSS * 1_024,
+		...memoryDeltas(empty, opened, count),
+		disk: await directoryFootprint(directory, count),
+		validation: {
+			retainedEntries: count,
+			endpointHashesPresent: true,
+			topology,
+			headSampleCount: headSamples.length,
+		},
+	};
+};
+
+export const reopenPersistentScaleScenario = async (options) =>
+	options.scenario === "persistent-coordinate-index"
+		? reopenCoordinateIndex(options)
+		: reopenHeadIndexAndGraph(options);


### PR DESCRIPTION
## Summary

- retain the isolated-process resident census for native graph chains, independent roots, and coordinate frontiers
- add compact Rust head-index and coordinate-index fixtures, then reopen them in separate fresh processes through the real indexer and `Log.open()` native-graph paths
- report versioned disk, startup, opened RSS, open/close peak RSS, close-compaction, and integrity results
- add tiny end-to-end snapshot/reopen coverage to ordinary CI and run 100k/1M profiles only through the manual re-census workflow
- document the state ledger, durable transfer/prune invariants, and pure planner/executor boundary needed for bounded local ownership

## Why

The 100M target in #1286 is a global-entry target, not permission for an ordinary peer to reconstruct all history. The prior census measured resident native state but excluded the persisted Rust indexes and fresh startup path. Those paths matter because the current indexer deserializes every locally retained row on open and the log then rebuilds the native graph from every shallow row.

Persistent fixtures call the indexer's own `SnapshotFile.compact()` implementation to create the exact post-close `index.bin` format. Fixture time is reported but is not append-throughput evidence. Reopen happens in a second process after loading an empty Rust/WASM baseline, and validates size, endpoints, topology, heads, and a stable logical disk footprint after normal close.

## Observations

[Re-census run 31914725666](https://github.com/dao-xyz/peerbit/actions/runs/31914725666) measured the resident-only parent commit with Node 22 on Linux/AMD EPYC:

| Resident scenario | 100k | 1M | 1M bytes/entry |
| --- | ---: | ---: | ---: |
| native graph chain | 85.4 MiB | 923.1 MiB | 968 |
| native graph roots | 54.5 MiB | 542.6 MiB | 569 |
| coordinate frontier | 60.5 MiB | 516.1 MiB | 541 |

A local Node v22.23.2 Apple M3 Pro validation of this commit produced:

| Persistent scenario (100k) | Reopen | Reopened RSS | RSS/row | Disk | Disk/row |
| --- | ---: | ---: | ---: | ---: | ---: |
| head index + chain graph | 8.67 s | 649.2 MiB | 6,808 B | 23.0 MiB | 241 B |
| head index + root graphs | 7.37 s | 563.8 MiB | 5,912 B | 17.0 MiB | 178 B |
| coordinate index | 4.91 s | 631.1 MiB | 6,617 B | 24.6 MiB | 258 B |

The same machine created a valid 1M chain snapshot of 240,999,957 bytes. The real `Log.open()` path did not complete by a 30-minute local censor point and was still CPU-bound at roughly 4.3 GiB RSS. That is a partial value, not a final peak, and endpoint validation had not yet run. This is direct evidence that one million locally materialized rows is not a healthy ordinary-peer startup target even though the disk snapshot is compact.

These are observations, not cross-machine thresholds. The manual workflow will produce the comparable Linux artifact for the new schema.

## Validation

- `node --test scripts/bench/*.spec.mjs` (42 passing pre-build contracts)
- `node --test scripts/bench/shared-log-scale-census.integration.mjs` (real three-schema post-build persistence round trip)
- Node 22 scale-census test file (9 passing)
- workflow shell-safety test and repository checker
- ESLint and Prettier on changed files
- `pnpm --filter @peerbit/shared-log... run build`
- all six 100k scenarios completed with integrity validation
- 1M chain snapshot completed; reopen was intentionally censored after 30 minutes
- no publishable runtime, protocol, or package API changed

Refs #1286