### PR TITLE
fix: bound shared-log sync range materialization

### DIFF
--- a/.changeset/bounded-rateless-ranges.md
+++ b/.changeset/bounded-rateless-ranges.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/shared-log-rust": patch
+"@peerbit/native-backbone": patch
+"@peerbit/shared-log": patch
+---
+
+Bound receive-side rateless range materialization in JavaScript and both native
+backends, fall back to simple sync on overflow, and page simple coordinate
+lookups without using `iterator.all()`.

--- a/.changeset/lazy-simple-index-pages.md
+++ b/.changeset/lazy-simple-index-pages.md
@@ -1,0 +1,8 @@
+---
+"@peerbit/indexer-simple": patch
+---
+
+Page unsorted in-memory index iteration from a bounded forward cursor instead
+of materializing every query match on the first `next()` call. Sorted iteration
+keeps its eager snapshot behavior; unsorted iteration has finite weak-snapshot
+semantics when rows mutate after consumption starts.

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -340,12 +340,14 @@ type NativeSharedLogStateHandle = {
 		end1: string,
 		start2: string,
 		end2: string,
+		limit?: number,
 	) => unknown[];
 	entry_hash_numbers_in_range_u64?: (
 		start1: string,
 		end1: string,
 		start2: string,
 		end2: string,
+		limit?: number,
 	) => BigUint64Array;
 	commit_entry_coordinates: (
 		hash: string,
@@ -1162,6 +1164,7 @@ export class SharedLogNativeState {
 		end1: bigint | number | string;
 		start2: bigint | number | string;
 		end2: bigint | number | string;
+		limit?: number;
 	}): bigint[] {
 		return rowsToNumbers(
 			"u64",
@@ -1170,6 +1173,7 @@ export class SharedLogNativeState {
 				asIntegerString(range.end1),
 				asIntegerString(range.start2),
 				asIntegerString(range.end2),
+				range.limit,
 			),
 		) as bigint[];
 	}
@@ -1179,6 +1183,7 @@ export class SharedLogNativeState {
 		end1: bigint | number | string;
 		start2: bigint | number | string;
 		end2: bigint | number | string;
+		limit?: number;
 	}): BigUint64Array | undefined {
 		if (
 			typeof BigUint64Array === "undefined" ||
@@ -1191,6 +1196,7 @@ export class SharedLogNativeState {
 			asIntegerString(range.end1),
 			asIntegerString(range.start2),
 			asIntegerString(range.end2),
+			range.limit,
 		);
 	}
 

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -2518,15 +2518,17 @@ impl NativeSharedLogState {
         end1: String,
         start2: String,
         end2: String,
+        limit: Option<u32>,
     ) -> Result<Array, JsValue> {
         let start1 = parse_u64(&start1)?;
         let end1 = parse_u64(&end1)?;
         let start2 = parse_u64(&start2)?;
         let end2 = parse_u64(&end2)?;
         let out = Array::new();
-        self.push_entry_hash_numbers_in_segment(&out, start1, end1);
-        if start2 != end2 {
-            self.push_entry_hash_numbers_in_segment(&out, start2, end2);
+        let mut remaining = limit.map(|value| value as usize).unwrap_or(usize::MAX);
+        remaining = self.push_entry_hash_numbers_in_segment(&out, start1, end1, remaining);
+        if remaining > 0 && start2 != end2 {
+            self.push_entry_hash_numbers_in_segment(&out, start2, end2, remaining);
         }
         Ok(out)
     }
@@ -2537,38 +2539,63 @@ impl NativeSharedLogState {
         end1: String,
         start2: String,
         end2: String,
+        limit: Option<u32>,
     ) -> Result<BigUint64Array, JsValue> {
         let start1 = parse_u64(&start1)?;
         let end1 = parse_u64(&end1)?;
         let start2 = parse_u64(&start2)?;
         let end2 = parse_u64(&end2)?;
         let mut out = Vec::new();
-        self.collect_entry_hash_numbers_in_segment(&mut out, start1, end1);
-        if start2 != end2 {
-            self.collect_entry_hash_numbers_in_segment(&mut out, start2, end2);
+        let mut remaining = limit.map(|value| value as usize).unwrap_or(usize::MAX);
+        remaining = self.collect_entry_hash_numbers_in_segment(&mut out, start1, end1, remaining);
+        if remaining > 0 && start2 != end2 {
+            self.collect_entry_hash_numbers_in_segment(&mut out, start2, end2, remaining);
         }
         Ok(BigUint64Array::from(out.as_slice()))
     }
 
-    fn push_entry_hash_numbers_in_segment(&self, out: &Array, start: u64, end: u64) {
-        if start >= end {
-            return;
+    fn push_entry_hash_numbers_in_segment(
+        &self,
+        out: &Array,
+        start: u64,
+        end: u64,
+        mut remaining: usize,
+    ) -> usize {
+        if start >= end || remaining == 0 {
+            return remaining;
         }
         for (hash_number, hashes) in self.inner.entry_hashes_by_hash_number.range(start..end) {
             let value = JsValue::from_str(&hash_number.to_string());
             for _ in hashes {
+                if remaining == 0 {
+                    return remaining;
+                }
                 out.push(&value);
+                remaining -= 1;
             }
         }
+        remaining
     }
 
-    fn collect_entry_hash_numbers_in_segment(&self, out: &mut Vec<u64>, start: u64, end: u64) {
-        if start >= end {
-            return;
+    fn collect_entry_hash_numbers_in_segment(
+        &self,
+        out: &mut Vec<u64>,
+        start: u64,
+        end: u64,
+        mut remaining: usize,
+    ) -> usize {
+        if start >= end || remaining == 0 {
+            return remaining;
         }
         for (hash_number, hashes) in self.inner.entry_hashes_by_hash_number.range(start..end) {
-            out.resize(out.len() + hashes.len(), *hash_number);
+            let take = hashes.len().min(remaining);
+            out.resize(out.len() + take, *hash_number);
+            remaining -= take;
+            if remaining == 0 {
+                return remaining;
+            }
         }
+        remaining
     }
 
     pub fn commit_entry_coordinates(

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -584,6 +584,29 @@ describe("native shared-log range planner", () => {
 			"90",
 			"90",
 		]);
+		expect(
+			state
+				.getEntryHashNumbersInRange({
+					start1: 0n,
+					end1: 10n,
+					start2: 80n,
+					end2: 100n,
+					limit: 3,
+				})
+				.map((value) => value.toString()),
+		).to.deep.equal(["5", "8", "90"]);
+		expect(
+			Array.from(
+				state.getEntryHashNumbersInRangeU64({
+					start1: 0n,
+					end1: 10n,
+					start2: 80n,
+					end2: 100n,
+					limit: 2,
+				})!,
+				(value) => value.toString(),
+			),
+		).to.deep.equal(["5", "8"]);
 
 		state.deleteEntryCoordinates("head-c");
 		expect(

--- a/packages/programs/data/shared-log/src/sync/factory.ts
+++ b/packages/programs/data/shared-log/src/sync/factory.ts
@@ -87,6 +87,7 @@ export function createSyncronizer<R extends "u32" | "u64">(
 		end1: bigint | number;
 		start2: bigint | number;
 		end2: bigint | number;
+		limit: number;
 	}) => {
 		const nativeState = props.getNativeState();
 		return (

--- a/packages/programs/data/shared-log/src/sync/index.ts
+++ b/packages/programs/data/shared-log/src/sync/index.ts
@@ -35,6 +35,14 @@ export type SyncOptions<R extends "u32" | "u64"> = {
 	maxSimpleEntries?: number;
 
 	/**
+	 * Maximum number of local entries materialized into the range encoder for
+	 * one incoming rateless sync. Ranges above this limit fall back to bounded
+	 * simple sync. Defaults to 16,384. This is a per-process entry cap, not an
+	 * aggregate byte budget across concurrent syncs.
+	 */
+	maxRatelessReceiveRangeEntries?: number;
+
+	/**
 	 * Maximum number of hash strings in one simple sync message.
 	 */
 	maxSimpleHashesPerMessage?: number;
@@ -151,6 +159,8 @@ export type HashSymbolRangeResolver = (range: {
 	end1: bigint | number;
 	start2: bigint | number;
 	end2: bigint | number;
+	/** Maximum values to return, including any overflow sentinel. */
+	limit: number;
 }) =>
 	| Iterable<bigint | number>
 	| undefined

--- a/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
+++ b/packages/programs/data/shared-log/src/sync/rateless-iblt.ts
@@ -91,6 +91,11 @@ const CODED_SYMBOL_WORDS = 3;
 const CODED_SYMBOL_WORD_BYTES = 8;
 const CODED_SYMBOL_BYTES = CODED_SYMBOL_WORDS * CODED_SYMBOL_WORD_BYTES;
 const MAX_CODED_SYMBOL_BATCH_SIZE = 1_024;
+const DEFAULT_MAX_RATELESS_RECEIVE_RANGE_ENTRIES = 16_384;
+const RATELESS_RANGE_QUERY_PAGE_SIZE = 1_024;
+// Native range resolvers accept a u32 limit. Keep one value available as the
+// overflow sentinel used to distinguish an exact fit from a larger range.
+const MAX_RATELESS_RANGE_ENTRIES = 0xffff_fffe;
 const BIG_UINT64_ARRAY_IS_LITTLE_ENDIAN =
 	typeof BigUint64Array !== "undefined" &&
 	new Uint8Array(new BigUint64Array([1n]).buffer)[0] === 1;
@@ -656,6 +661,7 @@ const buildEncoderOrDecoderFromRange = async <
 	},
 	entryIndex: Index<EntryReplicated<D>>,
 	type: T,
+	maxEntries: number,
 	profile?: SyncProfileFn,
 	resolveHashNumbersInRange?: HashSymbolRangeResolver,
 ): Promise<E | false> => {
@@ -665,6 +671,7 @@ const buildEncoderOrDecoderFromRange = async <
 	let transferred = false;
 	try {
 		const rangeQueryStartedAt = syncProfileStart(profile);
+		const queryLimit = maxEntries + 1;
 		let hashNumbers: Array<bigint | number> | BigUint64Array | undefined;
 		let source = "index";
 		const resolved = await resolveHashNumbersInRange?.({
@@ -672,45 +679,86 @@ const buildEncoderOrDecoderFromRange = async <
 			start1: ranges.start1,
 			end2: ranges.end2,
 			start2: ranges.start2,
+			limit: queryLimit,
 		});
 		if (resolved) {
 			source = "native";
-			hashNumbers =
+			if (
 				typeof BigUint64Array !== "undefined" &&
 				resolved instanceof BigUint64Array
-					? resolved
-					: [...resolved];
+			) {
+				hashNumbers = resolved;
+			} else {
+				hashNumbers = [];
+				const iterator = resolved[Symbol.iterator]();
+				let exhausted = false;
+				try {
+					while (hashNumbers.length < queryLimit) {
+						const next = iterator.next();
+						if (next.done) {
+							exhausted = true;
+							break;
+						}
+						hashNumbers.push(next.value);
+					}
+				} finally {
+					if (!exhausted) {
+						iterator.return?.();
+					}
+				}
+			}
 		} else {
-			const entries = await entryIndex
-				.iterate(
-					{
-						// Range sync for IBLT is done in hashNumber space.
-						query: matchEntriesByHashNumberInRangeQuery({
-							end1: ranges.end1,
-							start1: ranges.start1,
-							end2: ranges.end2,
-							start2: ranges.start2,
-						}),
+			const iterator = entryIndex.iterate(
+				{
+					// Range sync for IBLT is done in hashNumber space.
+					query: matchEntriesByHashNumberInRangeQuery({
+						end1: ranges.end1,
+						start1: ranges.start1,
+						end2: ranges.end2,
+						start2: ranges.start2,
+					}),
+				},
+				{
+					shape: {
+						hash: true,
+						hashNumber: true,
 					},
-					{
-						shape: {
-							hash: true,
-							hashNumber: true,
-						},
-					},
-				)
-				.all();
-			hashNumbers = entries.map((entry) => entry.value.hashNumber);
+				},
+			);
+			hashNumbers = [];
+			try {
+				while (hashNumbers.length < queryLimit) {
+					const remaining = queryLimit - hashNumbers.length;
+					const entries = await iterator.next(
+						Math.min(RATELESS_RANGE_QUERY_PAGE_SIZE, remaining),
+					);
+					if (entries.length === 0) {
+						break;
+					}
+					for (const entry of entries) {
+						if (hashNumbers.length >= queryLimit) {
+							break;
+						}
+						hashNumbers.push(entry.value.hashNumber);
+					}
+					if (iterator.done()) {
+						break;
+					}
+				}
+			} finally {
+				await iterator.close();
+			}
 		}
+		const overflow = hashNumbers.length > maxEntries;
 		if (profile) {
 			emitSyncProfileDuration(profile, rangeQueryStartedAt, {
 				name: "rateless.rangeQuery",
 				entries: hashNumbers.length,
-				details: { type, source },
+				details: { type, source, overflow, maxEntries },
 			});
 		}
 
-		if (hashNumbers.length === 0) {
+		if (hashNumbers.length === 0 || overflow) {
 			return false;
 		}
 
@@ -910,6 +958,13 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 		return value && Number.isFinite(value) && value > 0
 			? Math.max(1, Math.floor(value))
 			: DEFAULT_MAX_CONVERGENT_TRACKED_HASHES;
+	}
+
+	private get maxRatelessReceiveRangeEntries() {
+		const value = this.properties.sync?.maxRatelessReceiveRangeEntries;
+		return value && Number.isFinite(value) && value > 0
+			? Math.min(MAX_RATELESS_RANGE_ENTRIES, Math.max(1, Math.floor(value)))
+			: DEFAULT_MAX_RATELESS_RECEIVE_RANGE_ENTRIES;
 	}
 
 	private normalizeRetryIntervals(retryIntervalsMs?: number[]): number[] {
@@ -1342,6 +1397,7 @@ export class RatelessIBLTSynchronizer<D extends "u32" | "u64">
 			ranges,
 			this.properties.entryIndex,
 			"encoder",
+			this.maxRatelessReceiveRangeEntries,
 			profile,
 			this.properties.resolveHashNumbersInRange,
 		)) as EncoderWrapper | false;

--- a/packages/programs/data/shared-log/src/sync/simple.ts
+++ b/packages/programs/data/shared-log/src/sync/simple.ts
@@ -139,6 +139,8 @@ type KnownSyncKeys = {
 	checkedHashes: boolean;
 };
 
+const SIMPLE_COORDINATE_INDEX_PAGE_SIZE = 1_024;
+
 const getHashesFromSymbols = async (
 	symbols: bigint[],
 	entryIndex: Index<EntryReplicated<any>, any>,
@@ -151,6 +153,7 @@ const getHashesFromSymbols = async (
 	let batchSize = 128; // TODO arg
 	let results = new Set<string>();
 	let missingSymbols: bigint[] = [];
+	let remainingIndexCandidates = maxHashes;
 	const addHash = (hash: string) => {
 		if (results.has(hash)) {
 			return true;
@@ -171,22 +174,47 @@ const getHashesFromSymbols = async (
 	};
 	const handleBatch = async (end = false) => {
 		if (queries.length >= batchSize || (end && queries.length > 0)) {
-			const entries = await entryIndex
-				.iterate(
-					{ query: queries.length > 1 ? new Or(queries) : queries },
-					{ shape: { hash: true, hashNumber: true } },
-				)
-				.all();
+			const remainingHashes = maxHashes - results.size;
+			if (remainingHashes <= 0 || remainingIndexCandidates <= 0) {
+				queries = [];
+				return;
+			}
+			const iterator = entryIndex.iterate(
+				{ query: queries.length > 1 ? new Or(queries) : queries },
+				{ shape: { hash: true, hashNumber: true } },
+			);
 			queries = [];
-
-			for (const entry of entries) {
-				if (!addHash(entry.value.hash)) {
-					break;
+			try {
+				while (results.size < maxHashes && remainingIndexCandidates > 0) {
+					const entries = await iterator.next(
+						Math.min(
+							SIMPLE_COORDINATE_INDEX_PAGE_SIZE,
+							maxHashes - results.size,
+							remainingIndexCandidates,
+						),
+					);
+					if (entries.length === 0) {
+						break;
+					}
+					for (const entry of entries) {
+						if (remainingIndexCandidates <= 0) {
+							break;
+						}
+						remainingIndexCandidates -= 1;
+						if (!addHash(entry.value.hash)) {
+							break;
+						}
+						coordinateToHash.add(entry.value.hashNumber, entry.value.hash);
+						if (results.size >= maxHashes) {
+							break;
+						}
+					}
+					if (iterator.done()) {
+						break;
+					}
 				}
-				coordinateToHash.add(entry.value.hashNumber, entry.value.hash);
-				if (results.size >= maxHashes) {
-					break;
-				}
+			} finally {
+				await iterator.close();
 			}
 		}
 	};

--- a/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
+++ b/packages/programs/data/shared-log/test/rateless-iblt-cache.spec.ts
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import {
 	RatelessIBLTSynchronizer,
+	RequestAll,
 	StartSync,
 } from "../src/sync/rateless-iblt.js";
 
@@ -16,16 +17,18 @@ describe("rateless-iblt-syncronizer cache", () => {
 	});
 
 	it("reuses cached local range encoder across StartSync", async () => {
-		const iterate = sinon.stub().returns({
-			all: async () => [
-				{
-					value: {
-						hash: "h0",
-						hashNumber: 1n,
-					},
+		const next = sinon.stub().resolves([
+			{
+				value: {
+					hash: "h0",
+					hashNumber: 1n,
 				},
-			],
-		});
+			},
+		]);
+		const close = sinon.stub().resolves();
+		const all = sinon.stub().throws(new Error("all() must not be used"));
+		const done = sinon.stub().returns(true);
+		const iterate = sinon.stub().returns({ next, close, all, done });
 
 		const send = sinon.stub().resolves();
 		const sync = new RatelessIBLTSynchronizer<"u64">({
@@ -45,6 +48,9 @@ describe("rateless-iblt-syncronizer cache", () => {
 		expect(await sync.onMessage(createStartSync(), context)).to.equal(true);
 
 		expect(iterate.callCount).to.equal(1);
+		expect(next.calledOnceWithExactly(1_024)).to.equal(true);
+		expect(close.calledOnce).to.equal(true);
+		expect(all.called).to.equal(false);
 
 		await sync.close();
 	});
@@ -62,6 +68,7 @@ describe("rateless-iblt-syncronizer cache", () => {
 			coordinateToHash: new Cache<string>({ max: 10 }),
 			numbers: { maxValue: 2n ** 64n - 1n } as any,
 			resolveHashNumbersInRange,
+			sync: { maxRatelessReceiveRangeEntries: 2 },
 		});
 
 		expect(
@@ -77,9 +84,130 @@ describe("rateless-iblt-syncronizer cache", () => {
 			end1: 10n,
 			start2: 0n,
 			end2: 0n,
+			limit: 3,
 		});
 
 		await sync.close();
+	});
+
+	it("falls back to simple sync when the native range exceeds the cap", async () => {
+		const free = sinon.spy(EncoderWrapper.prototype, "free");
+		const send = sinon.stub().resolves();
+		const resolveHashNumbersInRange = sinon
+			.stub()
+			.returns(new BigUint64Array([1n, 2n, 3n]));
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {
+				iterate: sinon
+					.stub()
+					.throws(new Error("entry index should not be used")),
+			} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			resolveHashNumbersInRange,
+			sync: { maxRatelessReceiveRangeEntries: 2 },
+		});
+
+		try {
+			expect(
+				await sync.onMessage(
+					new StartSync({ from: 0n, to: 10n, symbols: [] }),
+					{ from: peer } as any,
+				),
+			).to.equal(true);
+
+			expect(resolveHashNumbersInRange.firstCall.args[0].limit).to.equal(3);
+			expect(free.calledOnce).to.equal(true);
+			expect(send.calledOnce).to.equal(true);
+			expect(send.firstCall.args[0]).to.be.instanceOf(RequestAll);
+			expect((sync as any).localRangeEncoderCache.size).to.equal(0);
+		} finally {
+			await sync.close();
+			free.restore();
+		}
+	});
+
+	it("bounds index iteration and falls back without calling all()", async () => {
+		const next = sinon.stub().resolves(
+			[1n, 2n, 3n].map((hashNumber) => ({
+				value: { hash: `h${hashNumber}`, hashNumber },
+			})),
+		);
+		const close = sinon.stub().resolves();
+		const all = sinon.stub().throws(new Error("all() must not be used"));
+		const done = sinon.stub().returns(true);
+		const send = sinon.stub().resolves();
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {
+				iterate: sinon.stub().returns({ next, close, all, done }),
+			} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			sync: { maxRatelessReceiveRangeEntries: 2 },
+		});
+
+		try {
+			await sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from: peer,
+			} as any);
+
+			expect(next.calledOnceWithExactly(3)).to.equal(true);
+			expect(close.calledOnce).to.equal(true);
+			expect(all.called).to.equal(false);
+			expect(send.calledOnce).to.equal(true);
+			expect(send.firstCall.args[0]).to.be.instanceOf(RequestAll);
+		} finally {
+			await sync.close();
+		}
+	});
+
+	it("continues through short index pages up to the overflow sentinel", async () => {
+		const next = sinon.stub();
+		next.onCall(0).resolves([{ value: { hash: "h1", hashNumber: 1n } }]);
+		next.onCall(1).resolves([{ value: { hash: "h2", hashNumber: 2n } }]);
+		next
+			.onCall(2)
+			.resolves([
+				{ value: { hash: "h3", hashNumber: 3n } },
+				{ value: { hash: "h4", hashNumber: 4n } },
+			]);
+		const close = sinon.stub().resolves();
+		const all = sinon.stub().throws(new Error("all() must not be used"));
+		const done = sinon.stub().returns(false);
+		const send = sinon.stub().resolves();
+		const sync = new RatelessIBLTSynchronizer<"u64">({
+			rpc: { send } as any,
+			rangeIndex: {} as any,
+			entryIndex: {
+				iterate: sinon.stub().returns({ next, close, all, done }),
+			} as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+			numbers: { maxValue: 2n ** 64n - 1n } as any,
+			sync: { maxRatelessReceiveRangeEntries: 3 },
+		});
+
+		try {
+			await sync.onMessage(new StartSync({ from: 0n, to: 10n, symbols: [] }), {
+				from: peer,
+			} as any);
+
+			expect(next.callCount).to.equal(3);
+			expect(next.getCall(0).args).to.deep.equal([4]);
+			expect(next.getCall(1).args).to.deep.equal([3]);
+			expect(next.getCall(2).args).to.deep.equal([2]);
+			expect(close.calledOnce).to.equal(true);
+			expect(all.called).to.equal(false);
+			expect(send.firstCall.args[0]).to.be.instanceOf(RequestAll);
+		} finally {
+			await sync.close();
+		}
 	});
 
 	it("frees an empty native range encoder before requesting all", async () => {
@@ -276,16 +404,22 @@ describe("rateless-iblt-syncronizer cache", () => {
 	});
 
 	it("invalidates cached range encoder on entry removal", async () => {
-		const iterate = sinon.stub().returns({
-			all: async () => [
-				{
-					value: {
-						hash: "h0",
-						hashNumber: 1n,
-					},
+		const all = sinon.stub().throws(new Error("all() must not be used"));
+		const close = sinon.stub().resolves();
+		const next = sinon.stub().resolves([
+			{
+				value: {
+					hash: "h0",
+					hashNumber: 1n,
 				},
-			],
-		});
+			},
+		]);
+		const iterate = sinon.stub().callsFake(() => ({
+			all,
+			close,
+			next,
+			done: sinon.stub().returns(true),
+		}));
 
 		const send = sinon.stub().resolves();
 		const sync = new RatelessIBLTSynchronizer<"u64">({
@@ -306,6 +440,9 @@ describe("rateless-iblt-syncronizer cache", () => {
 		await sync.onMessage(createStartSync(), context);
 
 		expect(iterate.callCount).to.equal(2);
+		expect(next.callCount).to.equal(2);
+		expect(close.callCount).to.equal(2);
+		expect(all.called).to.equal(false);
 
 		await sync.close();
 	});

--- a/packages/programs/data/shared-log/test/sync-chunking.spec.ts
+++ b/packages/programs/data/shared-log/test/sync-chunking.spec.ts
@@ -3105,6 +3105,46 @@ describe("sync-chunking", () => {
 		).to.deep.equal(["head-a"]);
 	});
 
+	it("bounds fallback coordinate index materialization", async () => {
+		const next = sinon.stub();
+		next
+			.onFirstCall()
+			.resolves([{ value: { hash: "head-a", hashNumber: 42n } }]);
+		next.onSecondCall().resolves([]);
+		const close = sinon.stub().resolves();
+		const all = sinon
+			.stub()
+			.throws(new Error("coordinate lookup must not materialize all matches"));
+		const done = sinon.stub().returns(false);
+		const iterate = sinon.stub().returns({ next, close, all, done });
+		const sync = new SimpleSyncronizer<"u64">({
+			rpc: { send: sinon.stub().resolves() } as any,
+			entryIndex: { iterate } as any,
+			log: {} as any,
+			coordinateToHash: new Cache<string>({ max: 10 }),
+		});
+		const ship = sinon.stub(sync as any, "shipExchangeHeads").resolves({
+			messages: 1,
+			fused: false,
+		});
+
+		try {
+			await sync.onMessage(
+				new RequestMaybeSyncCoordinate({ hashNumbers: [42n] }),
+				{ from: peerA } as any,
+			);
+
+			expect(next.callCount).to.equal(2);
+			expect(next.getCall(0).args).to.deep.equal([1_024]);
+			expect(next.getCall(1).args).to.deep.equal([1_024]);
+			expect(close.calledOnce).to.equal(true);
+			expect(all.called).to.equal(false);
+			expect(ship.firstCall.args[0]).to.deep.equal(["head-a"]);
+		} finally {
+			await sync.close();
+		}
+	});
+
 	it("uses native flat coordinate symbol resolver for response lookup", async () => {
 		const send = sinon.stub().resolves();
 		const iterate = sinon

--- a/packages/utils/indexer/simple/src/index.ts
+++ b/packages/utils/indexer/simple/src/index.ts
@@ -6,12 +6,22 @@ import { equals } from "uint8arrays";
 const logger = loggerFn("peerbit:indexer:simple");
 const warn = logger.newScope("warn");
 
+const normalizeIteratorAmount = (amount: number) => {
+	if (amount === Infinity) {
+		return amount;
+	}
+	return Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+};
+
 const getBatchFromResults = <T extends Record<string, any>>(
 	results: types.IndexedValue<T>[],
 	wantedSize: number,
 	/* properties: types.IteratorBatchProperties */
 ) => {
 	const batch: types.IndexedValue<T>[] = [];
+	if (wantedSize <= 0) {
+		return batch;
+	}
 	/* let size = 0; */
 	for (const result of results) {
 		batch.push(result);
@@ -229,6 +239,18 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 			| types.SumOptions,
 	): Promise<types.IndexedValue<T>[]> {
 		const queryCoerced = types.toQuery(query?.query);
+		const directResults = this.getDirectResults(queryCoerced);
+		if (directResults) {
+			return directResults;
+		}
+
+		// Handle query normally
+		return this._queryDocuments((doc) => this.matchesQuery(queryCoerced, doc));
+	}
+
+	private getDirectResults(
+		queryCoerced: types.Query[],
+	): types.IndexedValue<T>[] | undefined {
 		if (
 			queryCoerced.length === 1 &&
 			(queryCoerced[0] instanceof types.ByteMatchQuery ||
@@ -248,19 +270,19 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 				return doc ? [doc] : [];
 			}
 		}
+	}
 
-		// Handle query normally
-		const indexedDocuments = await this._queryDocuments(async (doc) => {
-			let innerHits = new Map();
-			for (const f of queryCoerced) {
-				if (!(await this.handleQueryObject(f, doc.value, innerHits))) {
-					return false;
-				}
+	private async matchesQuery(
+		queryCoerced: types.Query[],
+		doc: types.IndexedValue<T>,
+	): Promise<boolean> {
+		let innerHits = new Map();
+		for (const f of queryCoerced) {
+			if (!(await this.handleQueryObject(f, doc.value, innerHits))) {
+				return false;
 			}
-			return true;
-		});
-
-		return indexedDocuments;
+		}
+		return true;
 	}
 
 	iterate<S extends types.Shape | undefined>(
@@ -271,6 +293,21 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 			return this.closedIterator<S>();
 		}
 		this.assertOpen();
+		const sort = query?.sort
+			? Array.isArray(query.sort)
+				? query.sort
+				: [query.sort]
+			: [];
+		return sort.length > 0
+			? this.sortedIterator(query, properties, sort)
+			: this.unsortedIterator(query, properties);
+	}
+
+	private sortedIterator<S extends types.Shape | undefined>(
+		query: types.IterateOptions | undefined,
+		properties: { shape?: S; reference?: boolean } | undefined,
+		sort: types.Sort[],
+	): types.IndexIterator<T, S> {
 		let done: boolean | undefined = undefined;
 		let queue:
 			| {
@@ -290,19 +327,12 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 			if (!queue && !done) {
 				const indexedDocuments = await this.queryAll(query);
 				if (indexedDocuments.length > 1) {
-					// Sort
-					if (query?.sort) {
-						const sortArr = Array.isArray(query.sort)
-							? query.sort
-							: [query.sort];
-						sortArr.length > 0 &&
-							indexedDocuments.sort((a, b) =>
-								types.extractSortCompare(a.value, b.value, sortArr, undefined, {
-									a: a.id,
-									b: b.id,
-								}),
-							);
-					}
+					indexedDocuments.sort((a, b) =>
+						types.extractSortCompare(a.value, b.value, sort, undefined, {
+							a: a.id,
+							b: b.id,
+						}),
+					);
 				}
 
 				if (indexedDocuments.length > 0) {
@@ -323,11 +353,15 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 				return [];
 			}
 
+			const wantedSize = normalizeIteratorAmount(n);
 			const batch = getBatchFromResults<T>(
 				queue.arr,
-				n,
+				wantedSize,
 				/* this.properties.iterator.batch */
 			);
+			if (queue.arr.length === 0) {
+				done = true;
+			}
 
 			return (
 				queue.reference ? batch : cloneResults(batch, this.properties.schema)
@@ -365,6 +399,170 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 			close: () => {
 				done = true;
 				queue = undefined;
+			},
+		};
+	}
+
+	private unsortedIterator<S extends types.Shape | undefined>(
+		query: types.IterateOptions | undefined,
+		properties: { shape?: S; reference?: boolean } | undefined,
+	): types.IndexIterator<T, S> {
+		const queryCoerced = types.toQuery(query?.query);
+		let done: boolean | undefined;
+		let closed = false;
+		let cursor: Iterator<types.IndexedValue<T>> | undefined;
+		let remainingRaw: number | undefined;
+		let sourceExhausted = false;
+		const buffered: types.IndexedValue<T>[] = [];
+
+		const initialize = () => {
+			if (cursor) {
+				return;
+			}
+			const directResults = this.getDirectResults(queryCoerced);
+			const source = directResults ?? this._index.values();
+			cursor = source[Symbol.iterator]();
+			remainingRaw = directResults?.length ?? this._index.size;
+			done = false;
+		};
+
+		// A forward Map cursor is live under mutation. Cap raw reads at the size
+		// observed when iteration starts so appended rows cannot create an
+		// unbounded tail. Unvisited deletes can disappear and replacements can be
+		// observed; sorted iterators retain the eager snapshot behavior above.
+		const nextSourceMatch = async (): Promise<
+			types.IndexedValue<T> | undefined
+		> => {
+			while (!closed && !sourceExhausted && remainingRaw! > 0) {
+				const activeCursor = cursor;
+				if (!activeCursor) {
+					sourceExhausted = true;
+					remainingRaw = 0;
+					return;
+				}
+				const next = activeCursor.next();
+				if (next.done) {
+					sourceExhausted = true;
+					remainingRaw = 0;
+					return;
+				}
+				remainingRaw = remainingRaw! - 1;
+				const matches = await this.matchesQuery(queryCoerced, next.value);
+				if (closed) {
+					return;
+				}
+				if (matches) {
+					return next.value;
+				}
+			}
+			if (!closed) {
+				sourceExhausted = true;
+			}
+		};
+
+		const refreshDone = () => {
+			done = sourceExhausted && buffered.length === 0;
+		};
+
+		const fetch = async (
+			n: number,
+		): Promise<types.IndexedResults<types.ReturnTypeFromShape<T, S>>> => {
+			if (this.isClosing()) {
+				done = true;
+				closed = true;
+				sourceExhausted = true;
+				remainingRaw = 0;
+				cursor = undefined;
+				buffered.length = 0;
+				return [];
+			}
+			this.assertOpen();
+			if (closed || done) {
+				return [];
+			}
+
+			const wantedSize = normalizeIteratorAmount(n);
+			if (wantedSize === 0) {
+				return [];
+			}
+			initialize();
+
+			const batch = getBatchFromResults(buffered, wantedSize);
+			while (batch.length < wantedSize) {
+				const next = await nextSourceMatch();
+				if (closed) {
+					return [];
+				}
+				if (!next) {
+					break;
+				}
+				batch.push(next);
+			}
+			if (closed) {
+				return [];
+			}
+
+			if (wantedSize !== Infinity && batch.length === wantedSize) {
+				const next = await nextSourceMatch();
+				if (closed) {
+					return [];
+				}
+				if (next) {
+					buffered.push(next);
+				}
+			}
+			refreshDone();
+
+			return (
+				properties?.reference
+					? batch
+					: cloneResults(batch, this.properties.schema)
+			) as types.IndexedResults<types.ReturnTypeFromShape<T, S>>;
+		};
+
+		const pending = async () => {
+			if (this.isClosing()) {
+				done = true;
+				closed = true;
+				sourceExhausted = true;
+				remainingRaw = 0;
+				cursor = undefined;
+				buffered.length = 0;
+				return 0;
+			}
+			this.assertOpen();
+			if (closed || done) {
+				return 0;
+			}
+			initialize();
+			while (!sourceExhausted) {
+				const next = await nextSourceMatch();
+				if (closed) {
+					return 0;
+				}
+				if (next) {
+					buffered.push(next);
+				}
+			}
+			if (closed) {
+				return 0;
+			}
+			refreshDone();
+			return buffered.length;
+		};
+
+		return {
+			all: () => fetch(Infinity),
+			next: fetch,
+			done: () => (this.isClosing() ? true : done),
+			pending,
+			close: () => {
+				closed = true;
+				done = true;
+				sourceExhausted = true;
+				remainingRaw = 0;
+				cursor = undefined;
+				buffered.length = 0;
 			},
 		};
 	}
@@ -598,7 +796,7 @@ export class HashmapIndex<T extends Record<string, any>, NestedType = any>
 	}
 
 	private async _queryDocuments(
-		filter: (doc: types.IndexedValue) => Promise<boolean>,
+		filter: (doc: types.IndexedValue<T>) => Promise<boolean>,
 	): Promise<types.IndexedValue<T>[]> {
 		// Whether we return the full operation data or just the db value
 		const results: types.IndexedValue<T>[] = [];

--- a/packages/utils/indexer/simple/test/index.spec.ts
+++ b/packages/utils/indexer/simple/test/index.spec.ts
@@ -57,4 +57,141 @@ describe("all", () => {
 
 		await indices.drop();
 	});
+
+	it("lazily evaluates unsorted pages", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+		let tagReads = 0;
+
+		for (let i = 0; i < 64; i++) {
+			const value = new Proxy(new BatchDocument(String(i), "peerbit"), {
+				get: (target, property, receiver) => {
+					if (property === "tag") {
+						tagReads++;
+					}
+					return Reflect.get(target, property, receiver);
+				},
+			});
+			await index.put(value);
+		}
+
+		const iterator = index.iterate(
+			{
+				query: new StringMatch({
+					key: "tag",
+					value: "peerbit",
+					method: StringMatchMethod.exact,
+				}),
+			},
+			{ reference: true },
+		);
+		const first = await iterator.next(2);
+
+		expect(first.map((result) => result.value.id)).to.deep.equal(["0", "1"]);
+		// Two returned rows plus one lookahead are evaluated. The remaining 61
+		// rows stay behind the Map cursor instead of being materialized eagerly.
+		expect(tagReads).to.equal(3);
+		expect(iterator.done()).to.equal(false);
+
+		await iterator.close();
+		expect(tagReads).to.equal(3);
+		await indices.drop();
+	});
+
+	it("drains unsorted pending rows without losing the first result", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+		await index.putBatch?.([
+			new BatchDocument("a", "peerbit"),
+			new BatchDocument("b", "peerbit"),
+			new BatchDocument("c", "peerbit"),
+		]);
+
+		const iterator = index.iterate();
+		expect(await iterator.pending()).to.equal(3);
+		expect(
+			(await iterator.next(2)).map((result) => result.value.id),
+		).to.deep.equal(["a", "b"]);
+		expect(await iterator.pending()).to.equal(1);
+		expect(
+			(await iterator.all()).map((result) => result.value.id),
+		).to.deep.equal(["c"]);
+		expect(iterator.done()).to.equal(true);
+
+		await indices.drop();
+	});
+
+	it("does not chase rows appended after unsorted iteration starts", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+		await index.putBatch?.([
+			new BatchDocument("a", "peerbit"),
+			new BatchDocument("b", "peerbit"),
+		]);
+
+		const iterator = index.iterate();
+		expect(
+			(await iterator.next(1)).map((result) => result.value.id),
+		).to.deep.equal(["a"]);
+		await index.put(new BatchDocument("c", "peerbit"));
+		expect(
+			(await iterator.all()).map((result) => result.value.id),
+		).to.deep.equal(["b"]);
+		expect(iterator.done()).to.equal(true);
+
+		await indices.drop();
+	});
+
+	it("cancels an in-flight unsorted next when closed", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+		await index.putBatch?.([
+			new BatchDocument("a", "peerbit"),
+			new BatchDocument("b", "peerbit"),
+		]);
+		const iterator = index.iterate({
+			query: new StringMatch({
+				key: "tag",
+				value: "peerbit",
+				method: StringMatchMethod.exact,
+			}),
+		});
+
+		const next = iterator.next(2);
+		await iterator.close();
+
+		expect(await next).to.deep.equal([]);
+		expect(iterator.done()).to.equal(true);
+		expect(await iterator.next(1)).to.deep.equal([]);
+		await indices.drop();
+	});
+
+	it("cancels an in-flight unsorted pending scan when closed", async () => {
+		const indices = create();
+		await indices.start();
+		const index = await indices.init({ schema: BatchDocument });
+		await index.putBatch?.([
+			new BatchDocument("a", "peerbit"),
+			new BatchDocument("b", "peerbit"),
+		]);
+		const iterator = index.iterate({
+			query: new StringMatch({
+				key: "tag",
+				value: "peerbit",
+				method: StringMatchMethod.exact,
+			}),
+		});
+
+		const pending = iterator.pending();
+		await iterator.close();
+
+		expect(await pending).to.equal(0);
+		expect(iterator.done()).to.equal(true);
+		expect(await iterator.all()).to.deep.equal([]);
+		await indices.drop();
+	});
 });

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -54,12 +54,14 @@ type NativePeerbitBackboneHandle = {
 		end1: string,
 		start2: string,
 		end2: string,
+		limit?: number,
 	) => unknown[];
 	entry_hash_numbers_in_range_u64?: (
 		start1: string,
 		end1: string,
 		start2: string,
 		end2: string,
+		limit?: number,
 	) => BigUint64Array;
 	count_entry_coordinates_in_ranges: (
 		start1: string[],
@@ -6332,6 +6334,7 @@ export class NativePeerbitBackbone {
 		end1: bigint | number | string;
 		start2: bigint | number | string;
 		end2: bigint | number | string;
+		limit?: number;
 	}): bigint[] {
 		return rowsToNumbers(
 			"u64",
@@ -6340,6 +6343,7 @@ export class NativePeerbitBackbone {
 				integerString(range.end1),
 				integerString(range.start2),
 				integerString(range.end2),
+				range.limit,
 			),
 		) as bigint[];
 	}
@@ -6349,6 +6353,7 @@ export class NativePeerbitBackbone {
 		end1: bigint | number | string;
 		start2: bigint | number | string;
 		end2: bigint | number | string;
+		limit?: number;
 	}): BigUint64Array | undefined {
 		if (
 			typeof BigUint64Array === "undefined" ||
@@ -6361,6 +6366,7 @@ export class NativePeerbitBackbone {
 			integerString(range.end1),
 			integerString(range.start2),
 			integerString(range.end2),
+			range.limit,
 		);
 	}
 

--- a/packages/utils/native-backbone/src/shared_log_plan.rs
+++ b/packages/utils/native-backbone/src/shared_log_plan.rs
@@ -310,9 +310,10 @@ impl NativePeerbitBackbone {
         end1: String,
         start2: String,
         end2: String,
+        limit: Option<u32>,
     ) -> Result<Array, JsValue> {
         self.shared_log
-            .entry_hash_numbers_in_range(start1, end1, start2, end2)
+            .entry_hash_numbers_in_range(start1, end1, start2, end2, limit)
     }
 
     pub fn entry_hash_numbers_in_range_u64(
@@ -321,9 +322,10 @@ impl NativePeerbitBackbone {
         end1: String,
         start2: String,
         end2: String,
+        limit: Option<u32>,
     ) -> Result<BigUint64Array, JsValue> {
         self.shared_log
-            .entry_hash_numbers_in_range_u64(start1, end1, start2, end2)
+            .entry_hash_numbers_in_range_u64(start1, end1, start2, end2, limit)
     }
 
     pub fn count_entry_coordinates_in_ranges(

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -2436,6 +2436,33 @@ describe("native peerbit backbone", () => {
 		expect(backbone.hasCoordinateIndexHash("hash-e")).equal(true);
 	});
 
+	it("bounds wrapped native hash-number range materialization", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+		});
+		backbone.putEntryCoordinates("low-a", "gid-low-a", [1n], false, 1, 5n);
+		backbone.putEntryCoordinates("low-b", "gid-low-b", [2n], false, 1, 8n);
+		backbone.putEntryCoordinates("high-a", "gid-high-a", [3n], false, 1, 90n);
+		backbone.putEntryCoordinates("high-b", "gid-high-b", [4n], false, 1, 90n);
+
+		const range = {
+			start1: 80n,
+			end1: 100n,
+			start2: 0n,
+			end2: 10n,
+		};
+		expect(
+			backbone.getEntryHashNumbersInRange({ ...range, limit: 3 }),
+		).to.deep.equal([90n, 90n, 5n]);
+		expect(
+			Array.from(
+				backbone.getEntryHashNumbersInRangeU64({ ...range, limit: 2 })!,
+			),
+		).to.deep.equal([90n, 90n]);
+	});
+
 	it("coalesces storage-backed no-next append with shared-log coordinate state", async () => {
 		const backbone = await createNativePeerbitBackbone({
 			clockId: publicKey,


### PR DESCRIPTION
## Summary

- cap receive-side rateless range materialization at 16,384 entries by default, using a cap-plus-one overflow sentinel
- enforce the cap in TypeScript, shared-log Rust, and native-backbone range paths
- fall back on overflow to the existing exact-hash Simple sync path
- page Simple coordinate lookups and make unsorted in-memory index next(n) lazy and finite

This is the first focused runtime slice following the evidence in #1288 and the investigation in #1286. It does not change wire formats, placement, pruning, or ownership semantics.

## Safety

A rateless overflow sends RequestAll. The source correlates both sync id and peer, then runs Simple sync over the exact outgoing hashes. The fallback does not synthesize a delivery, convergence, or prune acknowledgement.

The in-memory unsorted iterator retains at most one lookahead beyond the requested page and stops raw traversal at the map size captured on first consumption. Sorted iteration retains its existing eager snapshot behavior. Unsorted iteration has documented weak-snapshot behavior under concurrent mutation, and close cancels in-flight next and pending work.

## Architecture follow-up

The audit found that the planner can be entry-free, but execution must page the local frontier with a durable collision-safe keyset cursor. A durable handoff still needs view-fenced plan and move ids, destination retention pins and receipts after all ledger stores cross a durability barrier, concurrent-write catch-up, source prune intents, and restartable idempotent stages. A versioned placement unit is also required: gid is indivisible in the hash domain, while the time domain places entries independently.

## Non-goals

- no durable ownership-transfer protocol in this PR
- no weakening of checked-prune safeguards
- no claim that startup hydration, repair, rebalance, and prune scans are all bounded yet
- no solution for a 100M-entry single gid in the current hash domain

## Verification

- pnpm run build
- pnpm run test
- focused shared-log rateless and Simple-sync tests
- shared-log-rust and native-backbone cargo tests
- indexer-simple Node, browser, and web-worker suites
- ESLint, cargo fmt, and git diff checks

Refs #1286.
Evidence: #1288.