### PR TITLE
feat(native): read bounded rebalance collision buckets

### DIFF
--- a/.changeset/native-rebalance-collision-buckets.md
+++ b/.changeset/native-rebalance-collision-buckets.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/shared-log-rust": patch
+"@peerbit/native-backbone": patch
+---
+
+Add bounded, complete native collision-bucket reads for shared-log rebalance scans.

--- a/packages/programs/data/shared-log/rust/src/error.rs
+++ b/packages/programs/data/shared-log/rust/src/error.rs
@@ -20,6 +20,10 @@ pub enum SharedLogError {
     ExpectedLeaderIntersectingBool,
     MismatchedInputLengths(&'static str),
     MissingCompactAppendFacts,
+    InvalidRebalanceCollisionBucketLimit(&'static str),
+    RebalanceCollisionBucketIndexInconsistent,
+    RebalanceCollisionBucketResolutionMismatch,
+    RebalanceCollisionBucketAccountingOverflow,
 }
 
 impl std::fmt::Display for SharedLogError {
@@ -53,6 +57,21 @@ impl std::fmt::Display for SharedLogError {
             }
             SharedLogError::MissingCompactAppendFacts => {
                 f.write_str("Missing compact append facts")
+            }
+            SharedLogError::InvalidRebalanceCollisionBucketLimit(label) => {
+                write!(
+                    f,
+                    "Invalid native rebalance collision bucket limit: {label}"
+                )
+            }
+            SharedLogError::RebalanceCollisionBucketIndexInconsistent => {
+                f.write_str("Native rebalance collision bucket index is inconsistent")
+            }
+            SharedLogError::RebalanceCollisionBucketResolutionMismatch => {
+                f.write_str("Native rebalance collision bucket value exceeds its resolution")
+            }
+            SharedLogError::RebalanceCollisionBucketAccountingOverflow => {
+                f.write_str("Native rebalance collision bucket accounting overflow")
             }
         }
     }

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -1,5 +1,74 @@
 export type RangeResolution = "u32" | "u64";
 
+export type NativeRebalanceCollisionBucketLimits = Readonly<{
+	maxRows: number;
+	maxIdentifierBytes: number;
+	maxIdentifierBytesTotal: number;
+	maxCoordinateValues: number;
+	maxCoordinateBytes: number;
+	maxBytes: number;
+}>;
+
+export const MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS: NativeRebalanceCollisionBucketLimits =
+	Object.freeze({
+		maxRows: 1024,
+		maxIdentifierBytes: 512,
+		maxIdentifierBytesTotal: 4 * 1024 * 1024,
+		maxCoordinateValues: 1024 * 100,
+		maxCoordinateBytes: 4 * 1024 * 1024,
+		maxBytes: 4 * 1024 * 1024,
+	});
+
+export type NativeRebalanceCollisionBucketOverflowCode =
+	| "rows"
+	| "identifier"
+	| "identifier-bytes"
+	| "coordinate-values"
+	| "coordinate-bytes"
+	| "bytes";
+
+export class NativeRebalanceCollisionBucketOverflowError extends Error {
+	constructor(readonly code: NativeRebalanceCollisionBucketOverflowCode) {
+		super(`Native rebalance collision bucket exceeded ${code}`);
+		this.name = "NativeRebalanceCollisionBucketOverflowError";
+	}
+}
+
+type NativeRebalanceCollisionBucketResultFor<R extends RangeResolution> =
+	| Readonly<{
+			resolution: R;
+			eof: true;
+			visited: 0;
+			results: 0;
+			bytes: 0;
+			identifierBytes: 0;
+			coordinateValues: 0;
+			coordinateBytes: 0;
+			candidates: readonly [];
+	  }>
+	| Readonly<{
+			resolution: R;
+			eof: false;
+			hashNumber: R extends "u64" ? bigint : number;
+			visited: number;
+			results: number;
+			bytes: number;
+			identifierBytes: number;
+			coordinateValues: number;
+			coordinateBytes: number;
+			candidates: ReadonlyArray<
+				Readonly<{
+					hash: string;
+					coordinates: ReadonlyArray<R extends "u64" ? bigint : number>;
+					assignedToRangeBoundary: boolean;
+				}>
+			>;
+	  }>;
+
+export type NativeRebalanceCollisionBucketResult =
+	| NativeRebalanceCollisionBucketResultFor<"u32">
+	| NativeRebalanceCollisionBucketResultFor<"u64">;
+
 export type NativeReplicationRange = {
 	id: string;
 	hash: string;
@@ -347,6 +416,15 @@ type NativeSharedLogStateHandle = {
 		start2: string,
 		end2: string,
 	) => BigUint64Array;
+	read_next_rebalance_collision_bucket: (
+		afterHashNumber: string | undefined,
+		maxRows: number,
+		maxIdentifierBytes: number,
+		maxIdentifierBytesTotal: number,
+		maxCoordinateValues: number,
+		maxCoordinateBytes: number,
+		maxBytes: number,
+	) => unknown[];
 	commit_entry_coordinates: (
 		hash: string,
 		gid: string,
@@ -627,6 +705,67 @@ const asIntegerString = (value: bigint | number | string) =>
 			? Math.trunc(value).toString()
 			: value;
 
+const MAX_NATIVE_REBALANCE_U32 = 0xffff_ffffn;
+const MAX_NATIVE_REBALANCE_U64 = 0xffff_ffff_ffff_ffffn;
+const canonicalUnsignedInteger = /^(0|[1-9][0-9]*)$/;
+
+const rebalanceCollisionBucketCursor = (
+	resolution: RangeResolution,
+	value: bigint | number | string | undefined,
+): string | undefined => {
+	if (value == null) return undefined;
+	const maximum =
+		resolution === "u32" ? MAX_NATIVE_REBALANCE_U32 : MAX_NATIVE_REBALANCE_U64;
+	let parsed: bigint;
+	if (typeof value === "string") {
+		const maximumDigits = resolution === "u32" ? 10 : 20;
+		if (
+			value.length === 0 ||
+			value.length > maximumDigits ||
+			!canonicalUnsignedInteger.test(value)
+		) {
+			throw new Error("Invalid native rebalance collision bucket cursor");
+		}
+		parsed = BigInt(value);
+	} else if (typeof value === "bigint") {
+		parsed = value;
+	} else {
+		if (!Number.isSafeInteger(value) || value < 0) {
+			throw new Error("Invalid native rebalance collision bucket cursor");
+		}
+		parsed = BigInt(value);
+	}
+	if (parsed < 0n || parsed > maximum) {
+		throw new Error("Invalid native rebalance collision bucket cursor");
+	}
+	return parsed.toString();
+};
+
+const rebalanceCollisionBucketLimits = (
+	limits: NativeRebalanceCollisionBucketLimits,
+): NativeRebalanceCollisionBucketLimits => {
+	if (!limits || typeof limits !== "object") {
+		throw new Error("Invalid native rebalance collision bucket limits");
+	}
+	const out = {} as Record<keyof NativeRebalanceCollisionBucketLimits, number>;
+	for (const name of Object.keys(
+		MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	) as Array<keyof NativeRebalanceCollisionBucketLimits>) {
+		const value = limits[name];
+		if (
+			!Number.isSafeInteger(value) ||
+			value <= 0 ||
+			value > MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS[name]
+		) {
+			throw new Error(
+				`Invalid native rebalance collision bucket limit: ${name}`,
+			);
+		}
+		out[name] = value;
+	}
+	return out as NativeRebalanceCollisionBucketLimits;
+};
+
 const iterableToArray = <T>(values?: Iterable<T>): T[] => {
 	if (!values) {
 		return [];
@@ -666,6 +805,70 @@ const rowsToHashNumberMap = (rows: unknown[]): Map<bigint, string[]> => {
 		out.set(BigInt(hashNumber), hashes);
 	}
 	return out;
+};
+
+const rebalanceCollisionBucketOverflowCodes =
+	new Set<NativeRebalanceCollisionBucketOverflowCode>([
+		"rows",
+		"identifier",
+		"identifier-bytes",
+		"coordinate-values",
+		"coordinate-bytes",
+		"bytes",
+	]);
+
+const rebalanceCollisionBucketFromRow = (
+	resolution: RangeResolution,
+	row: unknown[],
+): NativeRebalanceCollisionBucketResult => {
+	const status = row[0];
+	if (status === 2) {
+		const code = row[1] as NativeRebalanceCollisionBucketOverflowCode;
+		if (!rebalanceCollisionBucketOverflowCodes.has(code)) {
+			throw new Error("Invalid native rebalance collision bucket overflow");
+		}
+		throw new NativeRebalanceCollisionBucketOverflowError(code);
+	}
+	if (status === 0) {
+		return {
+			resolution,
+			eof: true,
+			visited: 0,
+			results: 0,
+			bytes: 0,
+			identifierBytes: 0,
+			coordinateValues: 0,
+			coordinateBytes: 0,
+			candidates: [],
+		} as NativeRebalanceCollisionBucketResult;
+	}
+	if (status !== 1 || !Array.isArray(row[6])) {
+		throw new Error("Invalid native rebalance collision bucket result");
+	}
+	const candidates = row[6].map((value) => {
+		const [hash, coordinateRows, assignedToRangeBoundary] = value as [
+			string,
+			unknown[],
+			boolean,
+		];
+		return {
+			hash,
+			coordinates: rowsToNumbers(resolution, coordinateRows),
+			assignedToRangeBoundary,
+		};
+	});
+	return {
+		resolution,
+		eof: false,
+		hashNumber: rowsToNumbers(resolution, [row[1]])[0]!,
+		visited: candidates.length,
+		results: candidates.length,
+		bytes: row[2] as number,
+		identifierBytes: row[3] as number,
+		coordinateValues: row[4] as number,
+		coordinateBytes: row[5] as number,
+		candidates,
+	} as NativeRebalanceCollisionBucketResult;
 };
 
 const appendCoordinatePlanFromRow = (
@@ -1120,6 +1323,30 @@ export class SharedLogNativeState {
 
 	getEntryCoordinateHashes(): string[] {
 		return this.native.entry_coordinate_hashes();
+	}
+
+	/**
+	 * Returns one complete physical collision bucket in hash-number keyset
+	 * order. Successful `visited` and `results` are both the exact bucket size;
+	 * oversize buckets throw before exposing a partial prefix.
+	 */
+	readNextRebalanceCollisionBucket(
+		afterHashNumber: bigint | number | string | undefined,
+		limits: NativeRebalanceCollisionBucketLimits,
+	): NativeRebalanceCollisionBucketResult {
+		const bounded = rebalanceCollisionBucketLimits(limits);
+		return rebalanceCollisionBucketFromRow(
+			this.resolution,
+			this.native.read_next_rebalance_collision_bucket(
+				rebalanceCollisionBucketCursor(this.resolution, afterHashNumber),
+				bounded.maxRows,
+				bounded.maxIdentifierBytes,
+				bounded.maxIdentifierBytesTotal,
+				bounded.maxCoordinateValues,
+				bounded.maxCoordinateBytes,
+				bounded.maxBytes,
+			),
+		);
 	}
 
 	getEntryHashesForHashNumbers(

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -3,6 +3,7 @@ use js_sys::{Array, BigUint64Array, Uint8Array};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::ops::Bound::{Excluded, Unbounded};
 use wasm_bindgen::prelude::*;
 
 mod error;
@@ -13,6 +14,10 @@ const MODE_NON_STRICT: u8 = 0;
 const MAX_U32: u64 = u32::MAX as u64;
 const MAX_U64: u64 = u64::MAX;
 const CONTAINMENT_BUCKETS: usize = 4096;
+const MAX_REBALANCE_COLLISION_BUCKET_ROWS: usize = 1024;
+const MAX_REBALANCE_COLLISION_BUCKET_IDENTIFIER_BYTES: usize = 512;
+const MAX_REBALANCE_COLLISION_BUCKET_COORDINATE_VALUES: usize = 1024 * 100;
+const MAX_REBALANCE_COLLISION_BUCKET_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Resolution {
@@ -1455,6 +1460,53 @@ struct EntryCoordinateState {
     requested_replicas: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RebalanceCollisionBucketLimits {
+    max_rows: usize,
+    max_identifier_bytes: usize,
+    max_identifier_bytes_total: usize,
+    max_coordinate_values: usize,
+    max_coordinate_bytes: usize,
+    max_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RebalanceCollisionBucketOverflow {
+    Rows,
+    Identifier,
+    IdentifierBytes,
+    CoordinateValues,
+    CoordinateBytes,
+    Bytes,
+}
+
+impl RebalanceCollisionBucketOverflow {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Rows => "rows",
+            Self::Identifier => "identifier",
+            Self::IdentifierBytes => "identifier-bytes",
+            Self::CoordinateValues => "coordinate-values",
+            Self::CoordinateBytes => "coordinate-bytes",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RebalanceCollisionBucketPreflight {
+    Eof,
+    Overflow(RebalanceCollisionBucketOverflow),
+    Bucket {
+        hash_number: u64,
+        rows: usize,
+        identifier_bytes: usize,
+        coordinate_values: usize,
+        coordinate_bytes: usize,
+        bytes: usize,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EntryCoordinateCommit {
     pub hash: String,
@@ -1526,6 +1578,170 @@ impl SharedLogStateInner {
         }
         true
     }
+
+    fn preflight_next_rebalance_collision_bucket(
+        &self,
+        after_hash_number: Option<u64>,
+        limits: RebalanceCollisionBucketLimits,
+    ) -> Result<RebalanceCollisionBucketPreflight, SharedLogError> {
+        validate_rebalance_collision_bucket_limits(limits)?;
+        if self.range_planner.resolution == Resolution::U32
+            && after_hash_number.is_some_and(|value| value > MAX_U32)
+        {
+            return Err(SharedLogError::RebalanceCollisionBucketResolutionMismatch);
+        }
+        let next = match after_hash_number {
+            Some(after) => self
+                .entry_hashes_by_hash_number
+                .range((Excluded(after), Unbounded))
+                .next(),
+            None => self.entry_hashes_by_hash_number.iter().next(),
+        };
+        let Some((&hash_number, hashes)) = next else {
+            return Ok(RebalanceCollisionBucketPreflight::Eof);
+        };
+        if hashes.is_empty() {
+            return Err(SharedLogError::RebalanceCollisionBucketIndexInconsistent);
+        }
+        // BTreeMap/IndexSet cardinality proves the exact cap+1 overflow case
+        // without scanning or materializing a partial prefix.
+        if hashes.len() > limits.max_rows {
+            return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                RebalanceCollisionBucketOverflow::Rows,
+            ));
+        }
+        if self.range_planner.resolution == Resolution::U32 && hash_number > MAX_U32 {
+            return Err(SharedLogError::RebalanceCollisionBucketResolutionMismatch);
+        }
+
+        let coordinate_width = match self.range_planner.resolution {
+            Resolution::U32 => 4,
+            Resolution::U64 => 8,
+        };
+        for hash in hashes {
+            if hash.is_empty() {
+                return Err(SharedLogError::RebalanceCollisionBucketIndexInconsistent);
+            }
+            if hash.len() > limits.max_identifier_bytes {
+                return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                    RebalanceCollisionBucketOverflow::Identifier,
+                ));
+            }
+        }
+        let mut identifier_bytes = 0usize;
+        for hash in hashes {
+            identifier_bytes = identifier_bytes
+                .checked_add(hash.len())
+                .ok_or(SharedLogError::RebalanceCollisionBucketAccountingOverflow)?;
+            if identifier_bytes > limits.max_identifier_bytes_total {
+                return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                    RebalanceCollisionBucketOverflow::IdentifierBytes,
+                ));
+            }
+        }
+        let mut coordinate_values = 0usize;
+        for hash in hashes {
+            let entry = self
+                .entry_coordinates
+                .get(hash)
+                .ok_or(SharedLogError::RebalanceCollisionBucketIndexInconsistent)?;
+            if entry.hash_number != hash_number {
+                return Err(SharedLogError::RebalanceCollisionBucketIndexInconsistent);
+            }
+            coordinate_values = coordinate_values
+                .checked_add(entry.coordinates.len())
+                .ok_or(SharedLogError::RebalanceCollisionBucketAccountingOverflow)?;
+            if coordinate_values > limits.max_coordinate_values {
+                return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                    RebalanceCollisionBucketOverflow::CoordinateValues,
+                ));
+            }
+        }
+        let coordinate_bytes = coordinate_values
+            .checked_mul(coordinate_width)
+            .ok_or(SharedLogError::RebalanceCollisionBucketAccountingOverflow)?;
+        if coordinate_bytes > limits.max_coordinate_bytes {
+            return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                RebalanceCollisionBucketOverflow::CoordinateBytes,
+            ));
+        }
+        // Logical returned bytes are the bucket key, UTF-8 identifiers, one
+        // boundary byte per row, and fixed-width coordinates.
+        let bytes = coordinate_width
+            .checked_add(identifier_bytes)
+            .and_then(|value| value.checked_add(hashes.len()))
+            .and_then(|value| value.checked_add(coordinate_bytes))
+            .ok_or(SharedLogError::RebalanceCollisionBucketAccountingOverflow)?;
+        if bytes > limits.max_bytes {
+            return Ok(RebalanceCollisionBucketPreflight::Overflow(
+                RebalanceCollisionBucketOverflow::Bytes,
+            ));
+        }
+        if self.range_planner.resolution == Resolution::U32 {
+            for hash in hashes {
+                let entry = self
+                    .entry_coordinates
+                    .get(hash)
+                    .ok_or(SharedLogError::RebalanceCollisionBucketIndexInconsistent)?;
+                // Coordinate contents are scanned only after their total count
+                // and byte width have passed the caller and native hard caps.
+                if entry.coordinates.iter().any(|value| *value > MAX_U32) {
+                    return Err(SharedLogError::RebalanceCollisionBucketResolutionMismatch);
+                }
+            }
+        }
+        Ok(RebalanceCollisionBucketPreflight::Bucket {
+            hash_number,
+            rows: hashes.len(),
+            identifier_bytes,
+            coordinate_values,
+            coordinate_bytes,
+            bytes,
+        })
+    }
+}
+
+fn validate_rebalance_collision_bucket_limits(
+    limits: RebalanceCollisionBucketLimits,
+) -> Result<(), SharedLogError> {
+    let valid = [
+        (
+            limits.max_rows,
+            MAX_REBALANCE_COLLISION_BUCKET_ROWS,
+            "maxRows",
+        ),
+        (
+            limits.max_identifier_bytes,
+            MAX_REBALANCE_COLLISION_BUCKET_IDENTIFIER_BYTES,
+            "maxIdentifierBytes",
+        ),
+        (
+            limits.max_identifier_bytes_total,
+            MAX_REBALANCE_COLLISION_BUCKET_BYTES,
+            "maxIdentifierBytesTotal",
+        ),
+        (
+            limits.max_coordinate_values,
+            MAX_REBALANCE_COLLISION_BUCKET_COORDINATE_VALUES,
+            "maxCoordinateValues",
+        ),
+        (
+            limits.max_coordinate_bytes,
+            MAX_REBALANCE_COLLISION_BUCKET_BYTES,
+            "maxCoordinateBytes",
+        ),
+        (
+            limits.max_bytes,
+            MAX_REBALANCE_COLLISION_BUCKET_BYTES,
+            "maxBytes",
+        ),
+    ];
+    for (value, maximum, label) in valid {
+        if value == 0 || value > maximum {
+            return Err(SharedLogError::InvalidRebalanceCollisionBucketLimit(label));
+        }
+    }
+    Ok(())
 }
 
 #[wasm_bindgen]
@@ -2482,6 +2698,99 @@ impl NativeSharedLogState {
 
     pub fn entry_hashes_for_hash_numbers_flat_u64(&self, hash_numbers: BigUint64Array) -> Array {
         self.entry_hashes_for_hash_number_values_flat(hash_numbers.to_vec())
+    }
+
+    /// Reads the complete smallest physical hash-number collision bucket
+    /// strictly after `after_hash_number`. Status row 0 is authoritative EOF,
+    /// status 1 is a complete bucket, and status 2 identifies the exceeded
+    /// preflight limit. All limits are checked before any candidate JS output
+    /// exists.
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_next_rebalance_collision_bucket(
+        &self,
+        after_hash_number: Option<String>,
+        max_rows: usize,
+        max_identifier_bytes: usize,
+        max_identifier_bytes_total: usize,
+        max_coordinate_values: usize,
+        max_coordinate_bytes: usize,
+        max_bytes: usize,
+    ) -> Result<Array, JsValue> {
+        let after_hash_number = after_hash_number
+            .map(|value| parse_u64(&value))
+            .transpose()?;
+        let preflight = self.inner.preflight_next_rebalance_collision_bucket(
+            after_hash_number,
+            RebalanceCollisionBucketLimits {
+                max_rows,
+                max_identifier_bytes,
+                max_identifier_bytes_total,
+                max_coordinate_values,
+                max_coordinate_bytes,
+                max_bytes,
+            },
+        )?;
+        let out = Array::new();
+        match preflight {
+            RebalanceCollisionBucketPreflight::Eof => {
+                out.push(&JsValue::from_f64(0.0));
+            }
+            RebalanceCollisionBucketPreflight::Overflow(overflow) => {
+                out.push(&JsValue::from_f64(2.0));
+                out.push(&JsValue::from_str(overflow.code()));
+            }
+            RebalanceCollisionBucketPreflight::Bucket {
+                hash_number,
+                rows,
+                identifier_bytes,
+                coordinate_values,
+                coordinate_bytes,
+                bytes,
+            } => {
+                let hashes = self
+                    .inner
+                    .entry_hashes_by_hash_number
+                    .get(&hash_number)
+                    .ok_or(SharedLogError::RebalanceCollisionBucketIndexInconsistent)?;
+                if hashes.len() != rows {
+                    return Err(SharedLogError::RebalanceCollisionBucketIndexInconsistent.into());
+                }
+                // Sorting occurs only after the whole bucket passed every cap.
+                let mut ordered_hashes: Vec<&str> = hashes.iter().map(String::as_str).collect();
+                ordered_hashes.sort_unstable();
+                let candidates = Array::new();
+                for hash in ordered_hashes {
+                    let entry = self
+                        .inner
+                        .entry_coordinates
+                        .get(hash)
+                        .ok_or(SharedLogError::RebalanceCollisionBucketIndexInconsistent)?;
+                    let coordinates = Array::new();
+                    for coordinate in &entry.coordinates {
+                        coordinates.push(&number_to_row(
+                            *coordinate,
+                            self.inner.range_planner.resolution,
+                        ));
+                    }
+                    let candidate = Array::new();
+                    candidate.push(&JsValue::from_str(hash));
+                    candidate.push(&coordinates);
+                    candidate.push(&JsValue::from_bool(entry.assigned_to_range_boundary));
+                    candidates.push(&candidate);
+                }
+                out.push(&JsValue::from_f64(1.0));
+                out.push(&number_to_row(
+                    hash_number,
+                    self.inner.range_planner.resolution,
+                ));
+                out.push(&JsValue::from_f64(bytes as f64));
+                out.push(&JsValue::from_f64(identifier_bytes as f64));
+                out.push(&JsValue::from_f64(coordinate_values as f64));
+                out.push(&JsValue::from_f64(coordinate_bytes as f64));
+                out.push(&candidates);
+            }
+        }
+        Ok(out)
     }
 
     fn entry_hashes_for_hash_number_values(&self, hash_numbers: Vec<u64>) -> Array {
@@ -4242,10 +4551,23 @@ fn samples_to_rows(samples: Vec<LeaderSample>) -> Array {
 #[cfg(test)]
 mod tests {
     use super::{
-        find_leaders_with_prepared_options, LeaderSample, NativeSharedLogState, RangePlanner,
-        ReplicationRange, SampleOptions, SharedLogError, MAX_U64,
+        find_leaders_with_prepared_options, EntryCoordinateState, LeaderSample,
+        NativeSharedLogState, RangePlanner, RebalanceCollisionBucketLimits,
+        RebalanceCollisionBucketOverflow, RebalanceCollisionBucketPreflight, ReplicationRange,
+        SampleOptions, SharedLogError, MAX_U32, MAX_U64,
     };
     use indexmap::IndexSet;
+
+    fn rebalance_bucket_limits() -> RebalanceCollisionBucketLimits {
+        RebalanceCollisionBucketLimits {
+            max_rows: 1024,
+            max_identifier_bytes: 512,
+            max_identifier_bytes_total: 4 * 1024 * 1024,
+            max_coordinate_values: 1024 * 100,
+            max_coordinate_bytes: 4 * 1024 * 1024,
+            max_bytes: 4 * 1024 * 1024,
+        }
+    }
 
     #[test]
     fn returns_intersecting_leader() {
@@ -4961,6 +5283,165 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "Mismatched gid leader batch input lengths"
+        );
+    }
+
+    #[test]
+    fn rebalance_bucket_preflight_handles_max_u64_and_exact_byte_cap() {
+        let mut state = NativeSharedLogState::new("u64".to_string());
+        state.inner.put_entry_coordinate_state(
+            "h".to_string(),
+            EntryCoordinateState {
+                gid: "g".to_string(),
+                hash_number: MAX_U64,
+                coordinates: vec![MAX_U64],
+                assigned_to_range_boundary: true,
+                requested_replicas: 1,
+            },
+        );
+        let mut exact = rebalance_bucket_limits();
+        // u64 key + one identifier + one boundary byte + one u64 coordinate.
+        exact.max_bytes = 18;
+        assert_eq!(
+            state
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, exact)
+                .unwrap(),
+            RebalanceCollisionBucketPreflight::Bucket {
+                hash_number: MAX_U64,
+                rows: 1,
+                identifier_bytes: 1,
+                coordinate_values: 1,
+                coordinate_bytes: 8,
+                bytes: 18,
+            }
+        );
+        exact.max_bytes = 17;
+        assert_eq!(
+            state
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, exact)
+                .unwrap(),
+            RebalanceCollisionBucketPreflight::Overflow(RebalanceCollisionBucketOverflow::Bytes)
+        );
+        assert_eq!(
+            state
+                .inner
+                .preflight_next_rebalance_collision_bucket(Some(MAX_U64), rebalance_bucket_limits())
+                .unwrap(),
+            RebalanceCollisionBucketPreflight::Eof
+        );
+    }
+
+    #[test]
+    fn rebalance_bucket_preflight_rejects_corrupt_indexes_and_u32_values() {
+        let mut missing = NativeSharedLogState::new("u32".to_string());
+        missing
+            .inner
+            .entry_hashes_by_hash_number
+            .entry(1)
+            .or_default()
+            .insert("ghost".to_string());
+        assert_eq!(
+            missing
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, rebalance_bucket_limits())
+                .unwrap_err(),
+            SharedLogError::RebalanceCollisionBucketIndexInconsistent
+        );
+
+        let mut mismatched = NativeSharedLogState::new("u32".to_string());
+        mismatched.inner.put_entry_coordinate_state(
+            "head".to_string(),
+            EntryCoordinateState {
+                gid: "g".to_string(),
+                hash_number: 1,
+                coordinates: vec![1],
+                assigned_to_range_boundary: false,
+                requested_replicas: 1,
+            },
+        );
+        mismatched
+            .inner
+            .entry_coordinates
+            .get_mut("head")
+            .unwrap()
+            .hash_number = 2;
+        assert_eq!(
+            mismatched
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, rebalance_bucket_limits())
+                .unwrap_err(),
+            SharedLogError::RebalanceCollisionBucketIndexInconsistent
+        );
+
+        let mut resolution = NativeSharedLogState::new("u32".to_string());
+        resolution.inner.put_entry_coordinate_state(
+            "head".to_string(),
+            EntryCoordinateState {
+                gid: "g".to_string(),
+                hash_number: 1,
+                coordinates: vec![MAX_U32 + 1],
+                assigned_to_range_boundary: false,
+                requested_replicas: 1,
+            },
+        );
+        assert_eq!(
+            resolution
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, rebalance_bucket_limits())
+                .unwrap_err(),
+            SharedLogError::RebalanceCollisionBucketResolutionMismatch
+        );
+
+        let mut oversized_coordinates = NativeSharedLogState::new("u32".to_string());
+        oversized_coordinates.inner.put_entry_coordinate_state(
+            "oversized".to_string(),
+            EntryCoordinateState {
+                gid: "g".to_string(),
+                hash_number: 1,
+                coordinates: vec![MAX_U32 + 1; 1024 * 100 + 1],
+                assigned_to_range_boundary: false,
+                requested_replicas: 1,
+            },
+        );
+        assert_eq!(
+            oversized_coordinates
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, rebalance_bucket_limits())
+                .unwrap(),
+            RebalanceCollisionBucketPreflight::Overflow(
+                RebalanceCollisionBucketOverflow::CoordinateValues
+            )
+        );
+
+        let mut oversized_hash_number = NativeSharedLogState::new("u32".to_string());
+        oversized_hash_number.inner.put_entry_coordinate_state(
+            "head".to_string(),
+            EntryCoordinateState {
+                gid: "g".to_string(),
+                hash_number: MAX_U32 + 1,
+                coordinates: vec![1],
+                assigned_to_range_boundary: false,
+                requested_replicas: 1,
+            },
+        );
+        assert_eq!(
+            oversized_hash_number
+                .inner
+                .preflight_next_rebalance_collision_bucket(None, rebalance_bucket_limits())
+                .unwrap_err(),
+            SharedLogError::RebalanceCollisionBucketResolutionMismatch
+        );
+        assert_eq!(
+            resolution
+                .inner
+                .preflight_next_rebalance_collision_bucket(
+                    Some(MAX_U32 + 1),
+                    rebalance_bucket_limits()
+                )
+                .unwrap_err(),
+            SharedLogError::RebalanceCollisionBucketResolutionMismatch
         );
     }
 

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -1,5 +1,34 @@
 import { expect } from "chai";
-import { createRangePlanner, createSharedLogState } from "../src/index.js";
+import {
+	MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	type NativeRebalanceCollisionBucketLimits,
+	NativeRebalanceCollisionBucketOverflowError,
+	createRangePlanner,
+	createSharedLogState,
+} from "../src/index.js";
+
+const rebalanceBucketLimits = (
+	overrides?: Partial<NativeRebalanceCollisionBucketLimits>,
+): NativeRebalanceCollisionBucketLimits => ({
+	...MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	...overrides,
+});
+
+const expectRebalanceBucketOverflow = (
+	read: () => unknown,
+	code: NativeRebalanceCollisionBucketOverflowError["code"],
+) => {
+	let failure: unknown;
+	try {
+		read();
+	} catch (error) {
+		failure = error;
+	}
+	expect(failure).to.be.instanceOf(NativeRebalanceCollisionBucketOverflowError);
+	expect(
+		(failure as NativeRebalanceCollisionBucketOverflowError).code,
+	).to.equal(code);
+};
 
 const range = (properties: {
 	id: string;
@@ -551,6 +580,242 @@ describe("native shared-log range planner", () => {
 			[42n, ["head-b"]],
 			[7n, ["head-d"]],
 		]);
+	});
+
+	it("reads complete collision buckets in strict keyset order", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("z-head", "gid-z", [20, 21], true, 2, 20);
+		state.putEntryCoordinates("a-head", "gid-a", [22], false, 1, 20);
+		state.putEntryCoordinates("first", "gid-first", [5], false, 1, 5);
+
+		const first = state.readNextRebalanceCollisionBucket(
+			undefined,
+			rebalanceBucketLimits(),
+		);
+		expect(first).to.deep.include({
+			resolution: "u32",
+			eof: false,
+			hashNumber: 5,
+			visited: 1,
+			results: 1,
+		});
+		if (first.eof) throw new Error("expected first bucket");
+		expect(first.candidates).to.deep.equal([
+			{
+				hash: "first",
+				coordinates: [5],
+				assignedToRangeBoundary: false,
+			},
+		]);
+
+		const collision = state.readNextRebalanceCollisionBucket(
+			5,
+			rebalanceBucketLimits(),
+		);
+		if (collision.eof) throw new Error("expected collision bucket");
+		expect(collision.hashNumber).to.equal(20);
+		expect(collision.visited).to.equal(2);
+		expect(collision.results).to.equal(2);
+		expect(collision.candidates).to.deep.equal([
+			{
+				hash: "a-head",
+				coordinates: [22],
+				assignedToRangeBoundary: false,
+			},
+			{
+				hash: "z-head",
+				coordinates: [20, 21],
+				assignedToRangeBoundary: true,
+			},
+		]);
+		const afterMissingCursor = state.readNextRebalanceCollisionBucket(
+			19,
+			rebalanceBucketLimits(),
+		);
+		if (afterMissingCursor.eof) throw new Error("expected strict successor");
+		expect(afterMissingCursor.hashNumber).to.equal(20);
+		expect(
+			state.readNextRebalanceCollisionBucket(20, rebalanceBucketLimits()),
+		).to.deep.equal({
+			resolution: "u32",
+			eof: true,
+			visited: 0,
+			results: 0,
+			bytes: 0,
+			identifierBytes: 0,
+			coordinateValues: 0,
+			coordinateBytes: 0,
+			candidates: [],
+		});
+
+		state.putEntryCoordinates("z-head", "gid-z-moved", [30], true, 1, 30);
+		const afterMoveOld = state.readNextRebalanceCollisionBucket(
+			5,
+			rebalanceBucketLimits(),
+		);
+		if (afterMoveOld.eof) throw new Error("expected old collision bucket");
+		expect(afterMoveOld.hashNumber).to.equal(20);
+		expect(afterMoveOld.candidates.map((row) => row.hash)).to.deep.equal([
+			"a-head",
+		]);
+		const afterMoveNew = state.readNextRebalanceCollisionBucket(
+			20,
+			rebalanceBucketLimits(),
+		);
+		if (afterMoveNew.eof) throw new Error("expected moved collision row");
+		expect(afterMoveNew.hashNumber).to.equal(30);
+		expect(afterMoveNew.candidates.map((row) => row.hash)).to.deep.equal([
+			"z-head",
+		]);
+
+		state.deleteEntryCoordinates("a-head");
+		const afterDelete = state.readNextRebalanceCollisionBucket(
+			5,
+			rebalanceBucketLimits(),
+		);
+		if (afterDelete.eof) throw new Error("expected moved row after deletion");
+		expect(afterDelete.hashNumber).to.equal(30);
+		state.deleteEntryCoordinates("z-head");
+		expect(
+			state.readNextRebalanceCollisionBucket(5, rebalanceBucketLimits()).eof,
+		).to.equal(true);
+	});
+
+	it("preserves u64 bucket keys and coordinates without Number coercion", async () => {
+		const state = await createSharedLogState("u64");
+		const hashNumber = 0xffff_ffff_ffff_ffffn;
+		state.putEntryCoordinates(
+			"u64-head",
+			"gid-u64",
+			[9_007_199_254_740_993n, 0xffff_ffff_ffff_ffffn],
+			true,
+			2,
+			hashNumber,
+		);
+
+		const bucket = state.readNextRebalanceCollisionBucket(
+			undefined,
+			rebalanceBucketLimits(),
+		);
+		if (bucket.eof) throw new Error("expected u64 bucket");
+		expect(bucket.resolution).to.equal("u64");
+		expect(bucket.hashNumber).to.equal(hashNumber);
+		expect(bucket.candidates[0]?.coordinates).to.deep.equal([
+			9_007_199_254_740_993n,
+			0xffff_ffff_ffff_ffffn,
+		]);
+		expect(
+			state.readNextRebalanceCollisionBucket(
+				0xffff_ffff_ffff_ffffn,
+				rebalanceBucketLimits(),
+			).eof,
+		).to.equal(true);
+	});
+
+	it("accepts exact bucket caps and rejects every cap without truncation", async () => {
+		const state = await createSharedLogState("u32");
+		state.putEntryCoordinates("bb", "gid-b", [2, 3], true, 2, 7);
+		state.putEntryCoordinates("a", "gid-a", [1], false, 1, 7);
+		const exact = rebalanceBucketLimits({
+			maxRows: 2,
+			maxIdentifierBytes: 2,
+			maxIdentifierBytesTotal: 3,
+			maxCoordinateValues: 3,
+			maxCoordinateBytes: 12,
+			maxBytes: 21,
+		});
+
+		const bucket = state.readNextRebalanceCollisionBucket(undefined, exact);
+		if (bucket.eof) throw new Error("expected exact-cap bucket");
+		expect(bucket).to.deep.include({
+			visited: 2,
+			results: 2,
+			bytes: 21,
+			identifierBytes: 3,
+			coordinateValues: 3,
+			coordinateBytes: 12,
+		});
+		expect(bucket.candidates.map((row) => row.hash)).to.deep.equal(["a", "bb"]);
+
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxRows: 1,
+				}),
+			"rows",
+		);
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxIdentifierBytes: 1,
+				}),
+			"identifier",
+		);
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxIdentifierBytesTotal: 2,
+				}),
+			"identifier-bytes",
+		);
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxCoordinateValues: 2,
+				}),
+			"coordinate-values",
+		);
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxCoordinateBytes: 11,
+				}),
+			"coordinate-bytes",
+		);
+		expectRebalanceBucketOverflow(
+			() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...exact,
+					maxBytes: 20,
+				}),
+			"bytes",
+		);
+
+		const retry = state.readNextRebalanceCollisionBucket(undefined, exact);
+		if (retry.eof) throw new Error("expected retry bucket");
+		expect(retry.candidates.map((row) => row.hash)).to.deep.equal(["a", "bb"]);
+	});
+
+	it("rejects lossy cursors and invalid public wrapper limits", async () => {
+		const state = await createSharedLogState("u32");
+		for (const cursor of [
+			-1,
+			1.5,
+			Number.MAX_SAFE_INTEGER + 1,
+			-1n,
+			0x1_0000_0000n,
+			"01",
+			"-1",
+			"4294967296",
+			"9".repeat(1000),
+		]) {
+			expect(() =>
+				state.readNextRebalanceCollisionBucket(cursor, rebalanceBucketLimits()),
+			).to.throw("Invalid native rebalance collision bucket cursor");
+		}
+		for (const maxRows of [0, 1.5, Number.MAX_SAFE_INTEGER]) {
+			expect(() =>
+				state.readNextRebalanceCollisionBucket(undefined, {
+					...rebalanceBucketLimits(),
+					maxRows,
+				}),
+			).to.throw("Invalid native rebalance collision bucket limit: maxRows");
+		}
 	});
 
 	it("lists resident entry hash numbers in a requested range", async () => {

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -9,6 +9,75 @@ export * from "./durability/storage.js";
 
 export type RangeResolution = "u32" | "u64";
 
+export type NativeRebalanceCollisionBucketLimits = Readonly<{
+	maxRows: number;
+	maxIdentifierBytes: number;
+	maxIdentifierBytesTotal: number;
+	maxCoordinateValues: number;
+	maxCoordinateBytes: number;
+	maxBytes: number;
+}>;
+
+export const MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS: NativeRebalanceCollisionBucketLimits =
+	Object.freeze({
+		maxRows: 1024,
+		maxIdentifierBytes: 512,
+		maxIdentifierBytesTotal: 4 * 1024 * 1024,
+		maxCoordinateValues: 1024 * 100,
+		maxCoordinateBytes: 4 * 1024 * 1024,
+		maxBytes: 4 * 1024 * 1024,
+	});
+
+export type NativeRebalanceCollisionBucketOverflowCode =
+	| "rows"
+	| "identifier"
+	| "identifier-bytes"
+	| "coordinate-values"
+	| "coordinate-bytes"
+	| "bytes";
+
+export class NativeRebalanceCollisionBucketOverflowError extends Error {
+	constructor(readonly code: NativeRebalanceCollisionBucketOverflowCode) {
+		super(`Native rebalance collision bucket exceeded ${code}`);
+		this.name = "NativeRebalanceCollisionBucketOverflowError";
+	}
+}
+
+type NativeRebalanceCollisionBucketResultFor<R extends RangeResolution> =
+	| Readonly<{
+			resolution: R;
+			eof: true;
+			visited: 0;
+			results: 0;
+			bytes: 0;
+			identifierBytes: 0;
+			coordinateValues: 0;
+			coordinateBytes: 0;
+			candidates: readonly [];
+	  }>
+	| Readonly<{
+			resolution: R;
+			eof: false;
+			hashNumber: R extends "u64" ? bigint : number;
+			visited: number;
+			results: number;
+			bytes: number;
+			identifierBytes: number;
+			coordinateValues: number;
+			coordinateBytes: number;
+			candidates: ReadonlyArray<
+				Readonly<{
+					hash: string;
+					coordinates: ReadonlyArray<R extends "u64" ? bigint : number>;
+					assignedToRangeBoundary: boolean;
+				}>
+			>;
+	  }>;
+
+export type NativeRebalanceCollisionBucketResult =
+	| NativeRebalanceCollisionBucketResultFor<"u32">
+	| NativeRebalanceCollisionBucketResultFor<"u64">;
+
 type NativePeerbitBackboneHandle = {
 	log_len: () => number;
 	block_len: () => number;
@@ -61,6 +130,15 @@ type NativePeerbitBackboneHandle = {
 		start2: string,
 		end2: string,
 	) => BigUint64Array;
+	read_next_rebalance_collision_bucket: (
+		afterHashNumber: string | undefined,
+		maxRows: number,
+		maxIdentifierBytes: number,
+		maxIdentifierBytesTotal: number,
+		maxCoordinateValues: number,
+		maxCoordinateBytes: number,
+		maxBytes: number,
+	) => unknown[];
 	count_entry_coordinates_in_ranges: (
 		start1: string[],
 		end1: string[],
@@ -3379,6 +3457,70 @@ const rowsToHashNumberMap = (rows: unknown[]): Map<bigint, string[]> => {
 	return out;
 };
 
+const rebalanceCollisionBucketOverflowCodes =
+	new Set<NativeRebalanceCollisionBucketOverflowCode>([
+		"rows",
+		"identifier",
+		"identifier-bytes",
+		"coordinate-values",
+		"coordinate-bytes",
+		"bytes",
+	]);
+
+const rebalanceCollisionBucketFromRow = (
+	resolution: RangeResolution,
+	row: unknown[],
+): NativeRebalanceCollisionBucketResult => {
+	const status = row[0];
+	if (status === 2) {
+		const code = row[1] as NativeRebalanceCollisionBucketOverflowCode;
+		if (!rebalanceCollisionBucketOverflowCodes.has(code)) {
+			throw new Error("Invalid native rebalance collision bucket overflow");
+		}
+		throw new NativeRebalanceCollisionBucketOverflowError(code);
+	}
+	if (status === 0) {
+		return {
+			resolution,
+			eof: true,
+			visited: 0,
+			results: 0,
+			bytes: 0,
+			identifierBytes: 0,
+			coordinateValues: 0,
+			coordinateBytes: 0,
+			candidates: [],
+		} as NativeRebalanceCollisionBucketResult;
+	}
+	if (status !== 1 || !Array.isArray(row[6])) {
+		throw new Error("Invalid native rebalance collision bucket result");
+	}
+	const candidates = row[6].map((value) => {
+		const [hash, coordinateRows, assignedToRangeBoundary] = value as [
+			string,
+			unknown[],
+			boolean,
+		];
+		return {
+			hash,
+			coordinates: rowsToNumbers(resolution, coordinateRows),
+			assignedToRangeBoundary,
+		};
+	});
+	return {
+		resolution,
+		eof: false,
+		hashNumber: rowsToNumbers(resolution, [row[1]])[0]!,
+		visited: candidates.length,
+		results: candidates.length,
+		bytes: row[2] as number,
+		identifierBytes: row[3] as number,
+		coordinateValues: row[4] as number,
+		coordinateBytes: row[5] as number,
+		candidates,
+	} as NativeRebalanceCollisionBucketResult;
+};
+
 const rowsToSamples = (
 	rows: unknown[] | undefined,
 ): Map<string, NativeBackboneLeaderSample> | undefined => {
@@ -5654,6 +5796,67 @@ const integerString = (value: bigint | number | string): string =>
 			? Math.trunc(value).toString()
 			: value.toString();
 
+const MAX_NATIVE_REBALANCE_U32 = 0xffff_ffffn;
+const MAX_NATIVE_REBALANCE_U64 = 0xffff_ffff_ffff_ffffn;
+const canonicalUnsignedInteger = /^(0|[1-9][0-9]*)$/;
+
+const rebalanceCollisionBucketCursor = (
+	resolution: RangeResolution,
+	value: bigint | number | string | undefined,
+): string | undefined => {
+	if (value == null) return undefined;
+	const maximum =
+		resolution === "u32" ? MAX_NATIVE_REBALANCE_U32 : MAX_NATIVE_REBALANCE_U64;
+	let parsed: bigint;
+	if (typeof value === "string") {
+		const maximumDigits = resolution === "u32" ? 10 : 20;
+		if (
+			value.length === 0 ||
+			value.length > maximumDigits ||
+			!canonicalUnsignedInteger.test(value)
+		) {
+			throw new Error("Invalid native rebalance collision bucket cursor");
+		}
+		parsed = BigInt(value);
+	} else if (typeof value === "bigint") {
+		parsed = value;
+	} else {
+		if (!Number.isSafeInteger(value) || value < 0) {
+			throw new Error("Invalid native rebalance collision bucket cursor");
+		}
+		parsed = BigInt(value);
+	}
+	if (parsed < 0n || parsed > maximum) {
+		throw new Error("Invalid native rebalance collision bucket cursor");
+	}
+	return parsed.toString();
+};
+
+const rebalanceCollisionBucketLimits = (
+	limits: NativeRebalanceCollisionBucketLimits,
+): NativeRebalanceCollisionBucketLimits => {
+	if (!limits || typeof limits !== "object") {
+		throw new Error("Invalid native rebalance collision bucket limits");
+	}
+	const out = {} as Record<keyof NativeRebalanceCollisionBucketLimits, number>;
+	for (const name of Object.keys(
+		MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	) as Array<keyof NativeRebalanceCollisionBucketLimits>) {
+		const value = limits[name];
+		if (
+			!Number.isSafeInteger(value) ||
+			value <= 0 ||
+			value > MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS[name]
+		) {
+			throw new Error(
+				`Invalid native rebalance collision bucket limit: ${name}`,
+			);
+		}
+		out[name] = value;
+	}
+	return out as NativeRebalanceCollisionBucketLimits;
+};
+
 const iterableToArray = <T>(values?: Iterable<T>): T[] => {
 	if (!values) {
 		return [];
@@ -6290,6 +6493,30 @@ export class NativePeerbitBackbone {
 		return coordinates
 			? rowsToNumbers(this.resolution, coordinates)
 			: undefined;
+	}
+
+	/**
+	 * Returns one complete physical collision bucket in hash-number keyset
+	 * order. Successful `visited` and `results` are both the exact bucket size;
+	 * oversize buckets throw before exposing a partial prefix.
+	 */
+	readNextRebalanceCollisionBucket(
+		afterHashNumber: bigint | number | string | undefined,
+		limits: NativeRebalanceCollisionBucketLimits,
+	): NativeRebalanceCollisionBucketResult {
+		const bounded = rebalanceCollisionBucketLimits(limits);
+		return rebalanceCollisionBucketFromRow(
+			this.resolution,
+			this.native.read_next_rebalance_collision_bucket(
+				rebalanceCollisionBucketCursor(this.resolution, afterHashNumber),
+				bounded.maxRows,
+				bounded.maxIdentifierBytes,
+				bounded.maxIdentifierBytesTotal,
+				bounded.maxCoordinateValues,
+				bounded.maxCoordinateBytes,
+				bounded.maxBytes,
+			),
+		);
 	}
 
 	getEntryHashesForHashNumbers(

--- a/packages/utils/native-backbone/src/shared_log_plan.rs
+++ b/packages/utils/native-backbone/src/shared_log_plan.rs
@@ -304,6 +304,28 @@ impl NativePeerbitBackbone {
             .entry_hashes_for_hash_numbers_flat_u64(hash_numbers)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_next_rebalance_collision_bucket(
+        &self,
+        after_hash_number: Option<String>,
+        max_rows: usize,
+        max_identifier_bytes: usize,
+        max_identifier_bytes_total: usize,
+        max_coordinate_values: usize,
+        max_coordinate_bytes: usize,
+        max_bytes: usize,
+    ) -> Result<Array, JsValue> {
+        self.shared_log.read_next_rebalance_collision_bucket(
+            after_hash_number,
+            max_rows,
+            max_identifier_bytes,
+            max_identifier_bytes_total,
+            max_coordinate_values,
+            max_coordinate_bytes,
+            max_bytes,
+        )
+    }
+
     pub fn entry_hash_numbers_in_range(
         &self,
         start1: String,

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { benchmarkPlainCommittedNoNextStorageAppendTransactionLoop } from "../src/benchmark.js";
 import {
+	MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
 	NativeBackboneBufferedCoordinatePersistenceStore,
 	NativeBackboneCoordinatePersistence,
 	type NativeBackboneCoordinatePersistenceStore,
@@ -9,12 +10,21 @@ import {
 	NativeBackboneNodeCoordinatePersistenceStore,
 	NativeBackboneOPFSCoordinatePersistenceStore,
 	type NativeBackboneOPFSDirectoryHandle,
+	type NativeRebalanceCollisionBucketLimits,
+	NativeRebalanceCollisionBucketOverflowError,
 	createBufferedNativeBackboneCoordinatePersistence,
 	createBufferedNativeBackboneNodeCoordinatePersistence,
 	createNativeBackboneCoordinatePersistence,
 	createNativePeerbitBackbone,
 	defaultNativeBackboneCoordinateFlushMaxPendingBytes,
 } from "../src/index.js";
+
+const rebalanceBucketLimits = (
+	overrides?: Partial<NativeRebalanceCollisionBucketLimits>,
+): NativeRebalanceCollisionBucketLimits => ({
+	...MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	...overrides,
+});
 
 const fromHex = (hex: string) =>
 	Uint8Array.from(
@@ -2434,6 +2444,91 @@ describe("native peerbit backbone", () => {
 		expect(backbone.hasCoordinateIndexHash("hash-c")).equal(false);
 		expect(backbone.hasCoordinateIndexHash("hash-d")).equal(true);
 		expect(backbone.hasCoordinateIndexHash("hash-e")).equal(true);
+	});
+
+	it("matches the complete native rebalance collision-bucket wrapper contract", async () => {
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+			resolution: "u64",
+		});
+		const hashNumber = 0xffff_ffff_ffff_ffffn;
+		backbone.putEntryCoordinates(
+			"beta",
+			"gid-beta",
+			[2n, 3n],
+			true,
+			2,
+			hashNumber,
+		);
+		backbone.putEntryCoordinates(
+			"alpha",
+			"gid-alpha",
+			[1n],
+			false,
+			1,
+			hashNumber,
+		);
+
+		const bucket = backbone.readNextRebalanceCollisionBucket(
+			undefined,
+			rebalanceBucketLimits(),
+		);
+		if (bucket.eof) throw new Error("expected native-backbone bucket");
+		expect(bucket).to.deep.include({
+			resolution: "u64",
+			hashNumber,
+			visited: 2,
+			results: 2,
+			identifierBytes: 9,
+			coordinateValues: 3,
+			coordinateBytes: 24,
+			bytes: 43,
+		});
+		expect(bucket.candidates).to.deep.equal([
+			{
+				hash: "alpha",
+				coordinates: [1n],
+				assignedToRangeBoundary: false,
+			},
+			{
+				hash: "beta",
+				coordinates: [2n, 3n],
+				assignedToRangeBoundary: true,
+			},
+		]);
+		expect(
+			backbone.readNextRebalanceCollisionBucket(
+				hashNumber,
+				rebalanceBucketLimits(),
+			).eof,
+		).to.equal(true);
+
+		let overflow: unknown;
+		try {
+			backbone.readNextRebalanceCollisionBucket(
+				undefined,
+				rebalanceBucketLimits({ maxRows: 1 }),
+			);
+		} catch (error) {
+			overflow = error;
+		}
+		expect(overflow).to.be.instanceOf(
+			NativeRebalanceCollisionBucketOverflowError,
+		);
+		expect(
+			(overflow as NativeRebalanceCollisionBucketOverflowError).code,
+		).to.equal("rows");
+		expect(() =>
+			backbone.readNextRebalanceCollisionBucket(1.5, rebalanceBucketLimits()),
+		).to.throw("Invalid native rebalance collision bucket cursor");
+		expect(() =>
+			backbone.readNextRebalanceCollisionBucket(undefined, {
+				...rebalanceBucketLimits(),
+				maxRows: 0,
+			}),
+		).to.throw("Invalid native rebalance collision bucket limit: maxRows");
 	});
 
 	it("coalesces storage-backed no-next append with shared-log coordinate state", async () => {


### PR DESCRIPTION
## Summary

- add an authoritative native strict-successor read over the resident shared-log hash-number index
- return either EOF or one complete collision bucket, never a truncated prefix
- preflight caller limits and immutable native ceilings before candidate JS allocation
- preserve u64 keys and coordinates exactly, with typed overflow and fail-closed index-consistency errors
- expose equivalent standalone shared-log Rust and native-backbone wrappers with conformance tests

## Safety boundary

This PR is a plan-agnostic resident-state primitive only. It does not wire the rebalance executor into ordinary maintenance and does not change ownership, transfer, acknowledgement, or pruning behavior.

It intentionally provides no snapshot/write-journal fence, destination receipt, retention pin, or prune authority. Inserts behind a durable cursor and the existing full native-state hydration remain follow-up work.

## Stack

- base: #1292 bounded durable scan executor
- below that: #1291 durable work store and #1290 entry-free scan planner
- #1288 remains the measurement/evidence PR
- #1289 remains the separate receive-side sync-bound slice

Because this is a stacked PR whose base is not `master`, the repository changeset workflow may stop at its base-branch guard until the stack is retargeted.

## Verification

- `pnpm run build`
- shared-log Rust: 28 tests passed
- native-backbone Rust: 58 tests passed
- standalone wasm wrapper: 4 focused tests passed
- native-backbone wasm wrapper: 1 focused test passed
- both package builds and TypeScript no-emit checks passed
- ESLint, Cargo fmt checks, and `git diff --check` passed
