### PR TITLE
feat(shared-log): bound rebalance work persistence

### DIFF
--- a/.changeset/bounded-native-named-file-reads.md
+++ b/.changeset/bounded-native-named-file-reads.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/native-backbone": patch
+"@peerbit/shared-log": patch
+---
+
+Add pre-allocation byte caps to native named-file reads and a crash-safe terminal fence for durable rebalance work.

--- a/packages/programs/data/shared-log/src/rebalance-work-store.ts
+++ b/packages/programs/data/shared-log/src/rebalance-work-store.ts
@@ -1143,6 +1143,10 @@ const decodeFrame = (
 export class RebalanceWorkStore {
 	private frame!: LoadedFrame;
 	private tail: Promise<void> = Promise.resolve();
+	private dropping = false;
+	private dropPromise?: Promise<RebalanceWorkMutationResult>;
+	private dropFailed = false;
+	private dropFailure?: unknown;
 	private closing = false;
 	private closed = false;
 	private closePromise?: Promise<void>;
@@ -1318,6 +1322,67 @@ export class RebalanceWorkStore {
 		});
 	}
 
+	/**
+	 * @internal
+	 * Terminally fence this instance and durably forget any active scan before
+	 * lower shared-log state is destroyed. This is local lifecycle metadata,
+	 * not transfer acknowledgement or prune authority. A recovery path must call
+	 * beginDrop again after reopening before it resumes destructive cleanup.
+	 */
+	beginDrop(): Promise<RebalanceWorkMutationResult> {
+		// Once close releases the persistence lease, a cached result is stale: a
+		// new owner may already have installed newer work in the same namespace.
+		if (this.closed) {
+			return Promise.reject(new Error("Rebalance work store is closing"));
+		}
+		if (this.dropPromise) {
+			return this.dropPromise;
+		}
+		if (this.closing) {
+			return Promise.reject(new Error("Rebalance work store is closing"));
+		}
+		if (this.poisoned) {
+			return Promise.reject(
+				new Error("Rebalance work store is poisoned", {
+					cause: this.poisonCause,
+				}),
+			);
+		}
+
+		// Fence synchronously, before the terminal operation waits for mutations
+		// that were already admitted to the serialized tail.
+		this.dropping = true;
+		const result = this.tail.then(async () => {
+			if (this.poisoned) {
+				throw new Error("Rebalance work store is poisoned", {
+					cause: this.poisonCause,
+				});
+			}
+			// An explicit cleared frame was already physically confirmed on write or
+			// reopen. An implicit frame means the exclusively held namespace has no
+			// persisted work to forget; avoiding its first write also avoids creating
+			// a lone generation with no fallback if that write tears. Only active work
+			// needs a higher cleared generation.
+			if (this.frame.active) {
+				await this.writeNextFrame(undefined);
+			}
+			return this.mutationResult();
+		});
+		this.dropPromise = result.then(
+			(value) => value,
+			(error) => {
+				this.dropFailed = true;
+				this.dropFailure = error;
+				throw error;
+			},
+		);
+		this.tail = this.dropPromise.then(
+			() => undefined,
+			() => undefined,
+		);
+		return this.dropPromise;
+	}
+
 	close(): Promise<void> {
 		if (this.closePromise) {
 			return this.closePromise;
@@ -1336,19 +1401,27 @@ export class RebalanceWorkStore {
 				this.closed = true;
 				this.releasePersistenceLease();
 			}
-			const poisonError = this.poisoned
-				? new Error("Rebalance work store is poisoned", {
-						cause: this.poisonCause,
-					})
-				: undefined;
-			if (closeFailed && poisonError) {
+			let lifecycleFailed = false;
+			let lifecycleError: unknown;
+			if (this.poisoned) {
+				lifecycleFailed = true;
+				lifecycleError = new Error("Rebalance work store is poisoned", {
+					cause: this.poisonCause,
+				});
+			} else if (this.dropFailed) {
+				lifecycleFailed = true;
+				lifecycleError = this.dropFailure;
+			}
+			if (closeFailed && lifecycleFailed) {
 				throw new AggregateError(
-					[poisonError, closeError],
-					"Failed to close poisoned rebalance work store",
+					[lifecycleError, closeError],
+					this.poisoned
+						? "Failed to close poisoned rebalance work store"
+						: "Failed to close rebalance work store after terminal drop",
 				);
 			}
 			if (closeFailed) throw closeError;
-			if (poisonError) throw poisonError;
+			if (lifecycleFailed) throw lifecycleError;
 		})();
 		return this.closePromise;
 	}
@@ -1408,6 +1481,9 @@ export class RebalanceWorkStore {
 	}
 
 	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		if (this.dropping) {
+			return Promise.reject(new Error("Rebalance work store is dropping"));
+		}
 		if (this.closing || this.closed) {
 			return Promise.reject(new Error("Rebalance work store is closing"));
 		}
@@ -1555,6 +1631,9 @@ export class RebalanceWorkStore {
 		}
 		if (this.closing || this.closed) {
 			throw new Error("Rebalance work store is closing");
+		}
+		if (this.dropping) {
+			throw new Error("Rebalance work store is dropping");
 		}
 	}
 

--- a/packages/programs/data/shared-log/test/rebalance-work-store.spec.ts
+++ b/packages/programs/data/shared-log/test/rebalance-work-store.spec.ts
@@ -20,6 +20,8 @@ class MemoryPersistence implements RebalanceWorkPersistence {
 	readonly barriers: string[] = [];
 	readonly flushes: string[] = [];
 	closeCalls = 0;
+	private writeFailureArmed = false;
+	private writeFailure: unknown;
 	private barrierFailureArmed = false;
 	private barrierFailure: unknown;
 	private closeFailureArmed = false;
@@ -57,6 +59,10 @@ class MemoryPersistence implements RebalanceWorkPersistence {
 	}
 
 	async write(name: string, bytes: Uint8Array) {
+		if (this.writeFailureArmed) {
+			this.writeFailureArmed = false;
+			throw this.writeFailure;
+		}
 		this.writes.push(name);
 		this.files.set(name, new Uint8Array(bytes));
 	}
@@ -120,6 +126,11 @@ class MemoryPersistence implements RebalanceWorkPersistence {
 	failNextBarrierWith(error: unknown) {
 		this.barrierFailureArmed = true;
 		this.barrierFailure = error;
+	}
+
+	failNextWriteWith(error: unknown) {
+		this.writeFailureArmed = true;
+		this.writeFailure = error;
 	}
 
 	failNextCloseWith(error: unknown) {
@@ -1007,6 +1018,278 @@ describe("rebalance work store", () => {
 		await store.close();
 		const reopened = await openStrict(persistence);
 		await reopened.close();
+	});
+
+	it("terminally drops incomplete work and keeps ownership until close", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		const installed = await store.install(0n, {
+			resolution: "u32",
+			viewId: viewId("0"),
+			plan: makePlanU32(),
+		});
+		const fence = installed.durableCommit!.fence!;
+		const writesBeforeDrop = persistence.writes.length;
+
+		await expect(store.clear(fence, 2n)).to.be.rejectedWith(
+			"Cannot clear incomplete rebalance work",
+		);
+		const dropping = store.beginDrop();
+		expect(store.beginDrop()).to.equal(dropping);
+		expect(() => store.snapshot()).to.throw("dropping");
+		expect(() => store.currentDurableCommit()).to.throw("dropping");
+		await expect(
+			store.checkpoint(fence, 2n, { taskOrdinal: 0 }),
+		).to.be.rejectedWith("dropping");
+		await expect(store.clear(fence, 2n)).to.be.rejectedWith("dropping");
+
+		const dropped = await dropping;
+		expect(dropped.snapshot).to.deep.equal({
+			revision: 3n,
+			active: undefined,
+		});
+		expect(dropped.durableCommit).to.deep.include({
+			revision: 3n,
+			fence: undefined,
+		});
+		expect(persistence.writes).to.have.length(writesBeforeDrop + 1);
+		await expect(openStrict(persistence)).to.be.rejectedWith("already open");
+
+		await store.close();
+		const reopened = await openStrict(persistence);
+		const writesBeforeRetry = persistence.writes.length;
+		const retry = reopened.beginDrop();
+		expect(reopened.beginDrop()).to.equal(retry);
+		expect((await retry).snapshot).to.deep.equal(dropped.snapshot);
+		expect(persistence.writes).to.have.length(writesBeforeRetry);
+		await reopened.close();
+	});
+
+	it("rejects a cached drop result after the persistence lease is released", async () => {
+		const persistence = new MemoryPersistence();
+		const original = await openStrict(persistence);
+		await original.install(0n, {
+			resolution: "u32",
+			viewId: viewId("4"),
+			plan: makePlanU32(),
+		});
+		const dropped = await original.beginDrop();
+		await original.close();
+
+		const replacement = await openStrict(persistence);
+		const installed = await replacement.install(dropped.snapshot.revision, {
+			resolution: "u32",
+			viewId: viewId("5"),
+			plan: makePlanU32(30),
+		});
+		await expect(original.beginDrop()).to.be.rejectedWith("closing");
+		expect(replacement.snapshot()).to.deep.equal(installed.snapshot);
+		expect(replacement.snapshot().active).not.to.equal(undefined);
+		await replacement.close();
+	});
+
+	it("treats an implicit empty namespace as authoritative cleared state", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		const dropped = await store.beginDrop();
+
+		expect(dropped.snapshot).to.deep.equal({
+			revision: 0n,
+			active: undefined,
+		});
+		expect(dropped.durableCommit).to.equal(undefined);
+		expect(persistence.writes).to.have.length(0);
+		expect(persistence.barriers).to.have.length(0);
+		await store.close();
+		const reopened = await openStrict(persistence);
+		expect(reopened.snapshot()).to.deep.equal(dropped.snapshot);
+		expect(persistence.writes).to.have.length(0);
+		await reopened.close();
+	});
+
+	it("drains admitted success and stale failure before drop and close", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		const installed = await store.install(0n, {
+			resolution: "u32",
+			viewId: viewId("1"),
+			plan: makePlanU32(),
+		});
+		const fence = installed.durableCommit!.fence!;
+		const admittedGate = persistence.blockNextBarrier();
+		const admitted = store.checkpoint(fence, 2n, {
+			taskOrdinal: 0,
+			bucket: {
+				hashNumber: 11,
+				hashes: ["hash-11"],
+				nextIndex: 0,
+			},
+		});
+		await admittedGate.entered;
+		const stale = store.checkpoint(fence, 2n, { taskOrdinal: 0 });
+		const staleRejected = expect(stale).to.be.rejectedWith(
+			"Stale rebalance work revision",
+		);
+		const dropping = store.beginDrop();
+		expect(store.beginDrop()).to.equal(dropping);
+		const dropGate = persistence.blockNextBarrier();
+		const closing = store.close();
+		expect(store.close()).to.equal(closing);
+		expect(store.beginDrop()).to.equal(dropping);
+
+		await expect(
+			store.checkpoint(fence, 3n, { taskOrdinal: 0 }),
+		).to.be.rejectedWith("dropping");
+		await expect(openStrict(persistence)).to.be.rejectedWith("already open");
+		admittedGate.release();
+		await admitted;
+		await staleRejected;
+		await dropGate.entered;
+		expect(persistence.closeCalls).to.equal(0);
+		await expect(openStrict(persistence)).to.be.rejectedWith("already open");
+		dropGate.release();
+
+		const dropped = await dropping;
+		expect(dropped.snapshot).to.deep.equal({
+			revision: 4n,
+			active: undefined,
+		});
+		await closing;
+		expect(persistence.closeCalls).to.equal(1);
+	});
+
+	it("lets close win admission before a terminal drop starts", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		const closing = store.close();
+		await expect(store.beginDrop()).to.be.rejectedWith("closing");
+		await closing;
+		expect(persistence.writes).to.have.length(0);
+	});
+
+	it("retries terminal drop after a falsey pre-write failure and reopen", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		await store.install(0n, {
+			resolution: "u32",
+			viewId: viewId("2"),
+			plan: makePlanU32(),
+		});
+		const writesBeforeDrop = persistence.writes.length;
+		persistence.failNextWriteWith(null);
+		await expect(store.beginDrop()).to.be.rejectedWith(
+			"Failed to persist rebalance work frame",
+		);
+		expect(persistence.writes).to.have.length(writesBeforeDrop);
+		await expect(store.close()).to.be.rejectedWith("poisoned");
+
+		const recoveredPersistence = persistence.fork();
+		const recovered = await openStrict(recoveredPersistence);
+		expect(recovered.snapshot().active).not.to.equal(undefined);
+		expect(recovered.snapshot().revision).to.equal(2n);
+		const dropped = await recovered.beginDrop();
+		expect(dropped.snapshot).to.deep.equal({
+			revision: 3n,
+			active: undefined,
+		});
+		expect(recoveredPersistence.writes).to.have.length(1);
+		await recovered.close();
+	});
+
+	it("recovers an ambiguous falsey-barrier drop without sequence churn", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		const installed = await store.install(0n, {
+			resolution: "u32",
+			viewId: viewId("2"),
+			plan: makePlanU32(),
+		});
+		persistence.failNextBarrierWith(undefined);
+		const dropping = store.beginDrop();
+		expect(store.beginDrop()).to.equal(dropping);
+		persistence.failNextCloseWith(0);
+		const closing = store.close();
+		const closeOutcome = closing.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await expect(dropping).to.be.rejectedWith(
+			"Failed to persist rebalance work frame",
+		);
+		expect(() => store.snapshot()).to.throw("poisoned");
+		await expect(
+			store.checkpoint(installed.durableCommit!.fence!, 2n, {
+				taskOrdinal: 0,
+			}),
+		).to.be.rejectedWith("dropping");
+		const closeFailure = await closeOutcome;
+		expect(closeFailure).to.be.instanceOf(AggregateError);
+		expect((closeFailure as AggregateError).message).to.include("poisoned");
+		expect((closeFailure as AggregateError).errors[1]).to.equal(0);
+		expect(persistence.closeCalls).to.equal(1);
+
+		const recoveredPersistence = persistence.fork();
+		const recovered = await openStrict(recoveredPersistence);
+		expect(recovered.snapshot()).to.deep.equal({
+			revision: 3n,
+			active: undefined,
+		});
+		const writesBeforeRetry = recoveredPersistence.writes.length;
+		const retried = await recovered.beginDrop();
+		expect(retried.snapshot.revision).to.equal(3n);
+		expect(retried.durableCommit?.revision).to.equal(3n);
+		expect(recoveredPersistence.writes).to.have.length(writesBeforeRetry);
+		await recovered.close();
+	});
+
+	it("enforces sequence bounds for active and cleared terminal state", async () => {
+		const persistence = new MemoryPersistence();
+		const store = await openStrict(persistence);
+		await store.install(0n, {
+			resolution: "u32",
+			viewId: viewId("3"),
+			plan: makePlanU32(),
+		});
+		await store.close();
+
+		const activeFile = REBALANCE_WORK_FILES[0];
+		const { payload } = readFrame(persistence.files.get(activeFile)!);
+		payload.sequence = (MAX_U64 - 1n).toString();
+		persistence.files.set(activeFile, encodeFramePayload(payload));
+		const lastWritable = await openStrict(persistence);
+		const writesBeforeLast = persistence.writes.length;
+		const finalTombstone = await lastWritable.beginDrop();
+		expect(finalTombstone.snapshot.revision).to.equal(MAX_U64);
+		expect(persistence.writes).to.have.length(writesBeforeLast + 1);
+		await lastWritable.close();
+
+		payload.sequence = MAX_U64.toString();
+		persistence.files.set(activeFile, encodeFramePayload(payload));
+		persistence.files.delete(REBALANCE_WORK_FILES[1]);
+		const atMaximum = await openStrict(persistence);
+		const writesAtMaximum = persistence.writes.length;
+		const failedDrop = atMaximum.beginDrop();
+		await expect(failedDrop).to.be.rejectedWith(
+			"Rebalance work sequence exhausted",
+		);
+		expect(atMaximum.beginDrop()).to.equal(failedDrop);
+		expect(persistence.writes).to.have.length(writesAtMaximum);
+		await expect(atMaximum.close()).to.be.rejectedWith(
+			"Rebalance work sequence exhausted",
+		);
+
+		payload.state = "cleared";
+		payload.value = null;
+		persistence.files.set(activeFile, encodeFramePayload(payload));
+		const alreadyCleared = await openStrict(persistence);
+		const writesBeforeClearedDrop = persistence.writes.length;
+		const dropped = await alreadyCleared.beginDrop();
+		expect(dropped.snapshot).to.deep.equal({
+			revision: MAX_U64,
+			active: undefined,
+		});
+		expect(persistence.writes).to.have.length(writesBeforeClearedDrop);
+		await alreadyCleared.close();
 	});
 
 	it("drains admitted work on close and rejects late mutations", async () => {

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -3036,7 +3036,11 @@ export type NativeBackboneCoordinatePersistenceOptions =
 	};
 
 export type NativeBackboneCoordinatePersistenceStore = {
-	read(name: string): Promise<Uint8Array | undefined>;
+	/**
+	 * When `maxBytes` is supplied, reject before materializing a larger value.
+	 * Custom stores must preserve this pre-allocation bound.
+	 */
+	read(name: string, maxBytes?: number): Promise<Uint8Array | undefined>;
 	write(name: string, bytes: Uint8Array): Promise<void>;
 	/**
 	 * Appends `bytes` to the named file. Callers hand over ownership of
@@ -3054,6 +3058,21 @@ export type NativeBackboneCoordinatePersistenceStore = {
 	flush?(name?: string): Promise<void>;
 	close?(options?: { flush?: boolean }): Promise<void>;
 };
+
+export class NativeBackboneCoordinatePersistenceReadLimitError extends Error {
+	readonly code = "ERR_NATIVE_BACKBONE_COORDINATE_READ_LIMIT";
+
+	constructor(
+		readonly file: string,
+		readonly maxBytes: number,
+		readonly observedBytes: bigint,
+	) {
+		super(
+			`Native backbone coordinate persistence file ${file} exceeds the ${maxBytes} byte read limit (${observedBytes.toString()} bytes)`,
+		);
+		this.name = "NativeBackboneCoordinatePersistenceReadLimitError";
+	}
+}
 
 export type NativeBackboneCoordinatePersistenceAdapter = {
 	/**
@@ -3227,6 +3246,13 @@ type NativeBackboneNodeFs = {
 
 type NativeBackboneNodeAppendFileHandle = {
 	write(data: Uint8Array): Promise<{ bytesWritten: number }>;
+	read?(
+		buffer: Uint8Array,
+		offset: number,
+		length: number,
+		position: number,
+	): Promise<{ bytesRead: number }>;
+	stat?(options: { bigint: true }): Promise<{ size: bigint }>;
 	sync?(): Promise<unknown>;
 	close(): Promise<unknown>;
 };
@@ -3336,6 +3362,34 @@ const validateCoordinatePersistenceName = (name: string): string => {
 		);
 	}
 	return name;
+};
+
+const validateCoordinatePersistenceReadMaxBytes = (
+	maxBytes: number | undefined,
+): number | undefined => {
+	if (
+		maxBytes !== undefined &&
+		(!Number.isSafeInteger(maxBytes) || maxBytes < 0)
+	) {
+		throw new RangeError(
+			"Native backbone coordinate persistence read limit must be a non-negative safe integer",
+		);
+	}
+	return maxBytes;
+};
+
+const assertCoordinatePersistenceReadWithinLimit = (
+	name: string,
+	maxBytes: number | undefined,
+	observedBytes: number | bigint,
+): void => {
+	if (maxBytes !== undefined && BigInt(observedBytes) > BigInt(maxBytes)) {
+		throw new NativeBackboneCoordinatePersistenceReadLimitError(
+			name,
+			maxBytes,
+			BigInt(observedBytes),
+		);
+	}
 };
 
 type NativeBackboneCoordinateDropTombstoneBody = {
@@ -8808,8 +8862,17 @@ export class NativeBackboneMemoryCoordinatePersistenceStore
 {
 	readonly files = new Map<string, Uint8Array>();
 
-	async read(name: string): Promise<Uint8Array | undefined> {
-		const file = this.files.get(validateCoordinatePersistenceName(name));
+	async read(name: string, maxBytes?: number): Promise<Uint8Array | undefined> {
+		const validName = validateCoordinatePersistenceName(name);
+		const limit = validateCoordinatePersistenceReadMaxBytes(maxBytes);
+		const file = this.files.get(validName);
+		if (file) {
+			assertCoordinatePersistenceReadWithinLimit(
+				validName,
+				limit,
+				file.byteLength,
+			);
+		}
 		return file ? copyBytes(file) : undefined;
 	}
 
@@ -8904,15 +8967,118 @@ export class NativeBackboneNodeCoordinatePersistenceStore
 		return handle;
 	}
 
-	async read(name: string): Promise<Uint8Array | undefined> {
+	async read(name: string, maxBytes?: number): Promise<Uint8Array | undefined> {
+		const validName = validateCoordinatePersistenceName(name);
+		const limit = validateCoordinatePersistenceReadMaxBytes(maxBytes);
 		const fs = await this.nodeFs();
+		const path = await this.filePath(validName);
+		if (limit === undefined) {
+			try {
+				return await fs.readFile(path);
+			} catch (error) {
+				if (isNotFoundError(error)) {
+					return undefined;
+				}
+				throw error;
+			}
+		}
+		if (!fs.open) {
+			throw new Error(
+				"Node coordinate persistence bounded reads require FileHandle.open",
+			);
+		}
+		let handle: NativeBackboneNodeAppendFileHandle | undefined;
 		try {
-			return await fs.readFile(await this.filePath(name));
+			handle = await fs.open(path, "r");
 		} catch (error) {
 			if (isNotFoundError(error)) {
 				return undefined;
 			}
 			throw error;
+		}
+		try {
+			if (!handle.stat || !handle.read) {
+				throw new Error(
+					"Node coordinate persistence bounded reads require FileHandle.stat and FileHandle.read",
+				);
+			}
+			const initial = await handle.stat({ bigint: true });
+			if (typeof initial.size !== "bigint" || initial.size < 0n) {
+				throw new Error(
+					"Node coordinate persistence returned an invalid bigint file size",
+				);
+			}
+			assertCoordinatePersistenceReadWithinLimit(
+				validName,
+				limit,
+				initial.size,
+			);
+			if (initial.size > BigInt(Number.MAX_SAFE_INTEGER)) {
+				throw new RangeError(
+					"Node coordinate persistence file is too large to materialize safely",
+				);
+			}
+			const byteLength = Number(initial.size);
+			const bytes = new Uint8Array(byteLength);
+			let offset = 0;
+			while (offset < byteLength) {
+				const { bytesRead } = await handle.read(
+					bytes,
+					offset,
+					byteLength - offset,
+					offset,
+				);
+				if (
+					!Number.isSafeInteger(bytesRead) ||
+					bytesRead <= 0 ||
+					bytesRead > byteLength - offset
+				) {
+					throw new Error(
+						"Node coordinate persistence file changed during a bounded read",
+					);
+				}
+				offset += bytesRead;
+			}
+			const growthProbe = new Uint8Array(1);
+			const { bytesRead: growthBytes } = await handle.read(
+				growthProbe,
+				0,
+				1,
+				byteLength,
+			);
+			if (
+				!Number.isSafeInteger(growthBytes) ||
+				growthBytes < 0 ||
+				growthBytes > 1
+			) {
+				throw new Error(
+					"Node coordinate persistence returned invalid bounded read progress",
+				);
+			}
+			const final = await handle.stat({ bigint: true });
+			if (typeof final.size !== "bigint" || final.size < 0n) {
+				throw new Error(
+					"Node coordinate persistence returned an invalid bigint file size",
+				);
+			}
+			if (growthBytes !== 0 || final.size > initial.size) {
+				assertCoordinatePersistenceReadWithinLimit(
+					validName,
+					limit,
+					final.size > initial.size ? final.size : initial.size + 1n,
+				);
+				throw new Error(
+					"Node coordinate persistence file changed during a bounded read",
+				);
+			}
+			if (final.size !== initial.size) {
+				throw new Error(
+					"Node coordinate persistence file changed during a bounded read",
+				);
+			}
+			return bytes;
+		} finally {
+			await handle.close();
 		}
 	}
 
@@ -9100,14 +9266,27 @@ export class NativeBackboneOPFSCoordinatePersistenceStore
 		return parts.map(validateCoordinatePersistenceName);
 	}
 
-	async read(name: string): Promise<Uint8Array | undefined> {
+	async read(name: string, maxBytes?: number): Promise<Uint8Array | undefined> {
+		const validName = validateCoordinatePersistenceName(name);
+		const limit = validateCoordinatePersistenceReadMaxBytes(maxBytes);
 		try {
-			const handle = await this.directory.getFileHandle(
-				validateCoordinatePersistenceName(name),
-				{ create: false },
-			);
+			const handle = await this.directory.getFileHandle(validName, {
+				create: false,
+			});
 			const file = await handle.getFile();
-			return new Uint8Array(await file.arrayBuffer());
+			if (!Number.isSafeInteger(file.size) || file.size < 0) {
+				throw new Error(
+					"OPFS coordinate persistence returned an invalid file size",
+				);
+			}
+			assertCoordinatePersistenceReadWithinLimit(validName, limit, file.size);
+			const buffer = await file.arrayBuffer();
+			if (buffer.byteLength !== file.size) {
+				throw new Error(
+					"OPFS coordinate persistence file changed during a bounded read",
+				);
+			}
+			return new Uint8Array(buffer);
 		} catch (error) {
 			if (isNotFoundError(error)) {
 				return undefined;
@@ -9264,9 +9443,46 @@ export class NativeBackboneBufferedCoordinatePersistenceStore
 		return buffer;
 	}
 
-	async read(name: string): Promise<Uint8Array | undefined> {
-		await this.flush(name);
-		return this.inner.read(name);
+	async read(name: string, maxBytes?: number): Promise<Uint8Array | undefined> {
+		const limit = validateCoordinatePersistenceReadMaxBytes(maxBytes);
+		if (limit === undefined) {
+			await this.flush(name);
+			return this.inner.read(name);
+		}
+		const validName = validateCoordinatePersistenceName(name);
+		const pending = this.buffers.get(validName);
+		if (!pending || pending.length === 0) {
+			return this.inner.read(validName, limit);
+		}
+		const pendingLength = pending.length;
+		let pendingBytes = 0n;
+		for (const chunk of pending) {
+			pendingBytes += BigInt(chunk.byteLength);
+		}
+		assertCoordinatePersistenceReadWithinLimit(validName, limit, pendingBytes);
+		const remaining = limit - Number(pendingBytes);
+		const existingBytes = (await this.inner.read(validName, remaining))
+			?.byteLength;
+		let confirmedPendingBytes = 0n;
+		for (const chunk of pending) {
+			confirmedPendingBytes += BigInt(chunk.byteLength);
+		}
+		if (
+			this.buffers.get(validName) !== pending ||
+			pending.length !== pendingLength ||
+			confirmedPendingBytes !== pendingBytes
+		) {
+			throw new Error(
+				"Native backbone coordinate persistence pending bytes changed during a bounded read",
+			);
+		}
+		assertCoordinatePersistenceReadWithinLimit(
+			validName,
+			limit,
+			pendingBytes + BigInt(existingBytes ?? 0),
+		);
+		await this.flush(validName);
+		return this.inner.read(validName, limit);
 	}
 
 	async write(name: string, bytes: Uint8Array): Promise<void> {

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -4,6 +4,7 @@ import {
 	MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
 	NativeBackboneBufferedCoordinatePersistenceStore,
 	NativeBackboneCoordinatePersistence,
+	NativeBackboneCoordinatePersistenceReadLimitError,
 	type NativeBackboneCoordinatePersistenceStore,
 	NativeBackboneMemoryCoordinatePersistenceStore,
 	NativeBackboneNodeCoordinatePersistence,
@@ -189,10 +190,11 @@ class FakeOPFSFileHandle {
 		arrayBuffer(): Promise<ArrayBuffer>;
 		size: number;
 	}> {
-		const bytes = this.directory.fileBytes(this.name);
 		return {
-			size: bytes.byteLength,
+			size: this.directory.fileSize(this.name),
 			arrayBuffer: async () => {
+				this.directory.arrayBufferCount++;
+				const bytes = this.directory.fileBytes(this.name);
 				const copy = bytes.slice();
 				return copy.buffer.slice(
 					copy.byteOffset,
@@ -274,6 +276,7 @@ class FakeOPFSDirectoryHandle implements NativeBackboneOPFSDirectoryHandle {
 	syncWriteCount = 0;
 	syncFlushCount = 0;
 	syncCloseCount = 0;
+	arrayBufferCount = 0;
 
 	constructor(
 		private readonly syncAccess = false,
@@ -286,6 +289,10 @@ class FakeOPFSDirectoryHandle implements NativeBackboneOPFSDirectoryHandle {
 
 	fileBytes(name: string): Uint8Array {
 		return this.files.get(name)?.slice() ?? new Uint8Array();
+	}
+
+	fileSize(name: string): number {
+		return this.files.get(name)?.byteLength ?? 0;
 	}
 
 	async getDirectoryHandle(): Promise<NativeBackboneOPFSDirectoryHandle> {
@@ -4334,6 +4341,345 @@ describe("native peerbit backbone", () => {
 					?.publicKey ?? [],
 			),
 		).to.deep.equal(Array.from(publicKey));
+	});
+
+	it("bounds memory and buffered named-file reads at exact byte limits", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		await memory.write("bounded.bin", new Uint8Array([1, 2, 3]));
+		const exact = await memory.read("bounded.bin", 3);
+		expect(exact).to.deep.equal(new Uint8Array([1, 2, 3]));
+		exact![0] = 9;
+		expect(await memory.read("bounded.bin", 3)).to.deep.equal(
+			new Uint8Array([1, 2, 3]),
+		);
+		const memoryFailure = await memory.read("bounded.bin", 2).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(memoryFailure).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(
+			(memoryFailure as NativeBackboneCoordinatePersistenceReadLimitError)
+				.observedBytes,
+		).to.equal(3n);
+		await memory.write("empty.bin", new Uint8Array());
+		expect(await memory.read("empty.bin", 0)).to.deep.equal(new Uint8Array());
+
+		const forwardedLimits: Array<number | undefined> = [];
+		const inner: NativeBackboneCoordinatePersistenceStore = {
+			read: (name, maxBytes) => {
+				forwardedLimits.push(maxBytes);
+				return memory.read(name, maxBytes);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: (name, bytes) => memory.append(name, bytes),
+			flush: (name) => memory.flush(name),
+		};
+		const buffered = new NativeBackboneBufferedCoordinatePersistenceStore(
+			inner,
+		);
+		await buffered.append("buffered.bin", new Uint8Array([4, 5, 6]));
+		expect(await buffered.read("buffered.bin", 3)).to.deep.equal(
+			new Uint8Array([4, 5, 6]),
+		);
+		const bufferedFailure = await buffered.read("buffered.bin", 2).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(bufferedFailure).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(forwardedLimits).to.deep.equal([0, 3, 2]);
+	});
+
+	it("preflights existing plus pending bytes before buffered read flush", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		await memory.write("combined.bin", new Uint8Array([1, 2]));
+		const forwardedLimits: Array<number | undefined> = [];
+		let appendCalls = 0;
+		let flushCalls = 0;
+		const inner: NativeBackboneCoordinatePersistenceStore = {
+			read: (name, maxBytes) => {
+				forwardedLimits.push(maxBytes);
+				return memory.read(name, maxBytes);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: async (name, bytes) => {
+				appendCalls++;
+				await memory.append(name, bytes);
+			},
+			flush: async (name) => {
+				flushCalls++;
+				await memory.flush(name);
+			},
+		};
+		const buffered = new NativeBackboneBufferedCoordinatePersistenceStore(
+			inner,
+		);
+		await buffered.append("combined.bin", new Uint8Array([3]));
+		await buffered.append("combined.bin", new Uint8Array([4]));
+
+		const pendingOverflow = await buffered.read("combined.bin", 1).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(pendingOverflow).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(forwardedLimits).to.have.length(0);
+
+		const overflow = await buffered.read("combined.bin", 3).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(overflow).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(appendCalls).to.equal(0);
+		expect(flushCalls).to.equal(0);
+		expect(memory.files.get("combined.bin")).to.deep.equal(
+			new Uint8Array([1, 2]),
+		);
+
+		expect(await buffered.read("combined.bin", 4)).to.deep.equal(
+			new Uint8Array([1, 2, 3, 4]),
+		);
+		expect(appendCalls).to.equal(1);
+		expect(flushCalls).to.equal(1);
+		expect(forwardedLimits).to.deep.equal([1, 2, 4]);
+	});
+
+	it("fails closed when pending bytes change during buffered preflight", async () => {
+		const memory = new NativeBackboneMemoryCoordinatePersistenceStore();
+		await memory.write("concurrent.bin", new Uint8Array([1]));
+		let markReadEntered!: () => void;
+		const readEntered = new Promise<void>((resolve) => {
+			markReadEntered = resolve;
+		});
+		let releaseRead!: () => void;
+		const readBlocked = new Promise<void>((resolve) => {
+			releaseRead = resolve;
+		});
+		let readCalls = 0;
+		let appendCalls = 0;
+		let flushCalls = 0;
+		const forwardedLimits: Array<number | undefined> = [];
+		const inner: NativeBackboneCoordinatePersistenceStore = {
+			read: async (name, maxBytes) => {
+				forwardedLimits.push(maxBytes);
+				readCalls++;
+				if (readCalls === 1) {
+					markReadEntered();
+					await readBlocked;
+				}
+				return memory.read(name, maxBytes);
+			},
+			write: (name, bytes) => memory.write(name, bytes),
+			append: async (name, bytes) => {
+				appendCalls++;
+				await memory.append(name, bytes);
+			},
+			flush: async (name) => {
+				flushCalls++;
+				await memory.flush(name);
+			},
+		};
+		const buffered = new NativeBackboneBufferedCoordinatePersistenceStore(
+			inner,
+		);
+		await buffered.append("concurrent.bin", new Uint8Array([2]));
+		const reading = buffered.read("concurrent.bin", 3);
+		await readEntered;
+		await buffered.append("concurrent.bin", new Uint8Array([3]));
+		releaseRead();
+
+		await expect(reading).to.be.rejectedWith(
+			"pending bytes changed during a bounded read",
+		);
+		expect(appendCalls).to.equal(0);
+		expect(flushCalls).to.equal(0);
+		expect(memory.files.get("concurrent.bin")).to.deep.equal(
+			new Uint8Array([1]),
+		);
+		expect(await buffered.read("concurrent.bin", 3)).to.deep.equal(
+			new Uint8Array([1, 2, 3]),
+		);
+		expect(appendCalls).to.equal(1);
+		expect(flushCalls).to.equal(1);
+		expect(forwardedLimits).to.deep.equal([2, 1, 3]);
+	});
+
+	it("uses bigint stat and capped positional reads for Node named files", async () => {
+		const bytes = new Uint8Array([1, 2, 3]);
+		let readFileCalls = 0;
+		let readCalls = 0;
+		let closeCalls = 0;
+		let statCalls = 0;
+		const store = new NativeBackboneNodeCoordinatePersistenceStore("bounded", {
+			mkdir: async () => {},
+			readFile: async () => {
+				readFileCalls++;
+				throw new Error("readFile must not be used");
+			},
+			writeFile: async () => {},
+			appendFile: async () => {},
+			open: async (_path, flags) => {
+				expect(flags).to.equal("r");
+				return {
+					write: async (data) => ({ bytesWritten: data.byteLength }),
+					stat: async () => {
+						statCalls++;
+						return { size: BigInt(bytes.byteLength) };
+					},
+					read: async (target, offset, length, position) => {
+						readCalls++;
+						const available = Math.max(0, bytes.byteLength - position);
+						const count = Math.min(length, available, 2);
+						target.set(bytes.subarray(position, position + count), offset);
+						return { bytesRead: count };
+					},
+					close: async () => {
+						closeCalls++;
+					},
+				};
+			},
+			rm: async () => {},
+		});
+
+		expect(await store.read("file.bin", 3)).to.deep.equal(bytes);
+		expect(readCalls).to.equal(3);
+		expect(statCalls).to.equal(2);
+		expect(closeCalls).to.equal(1);
+		const capFailure = await store.read("file.bin", 2).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(capFailure).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(readCalls).to.equal(3);
+		expect(closeCalls).to.equal(2);
+		expect(readFileCalls).to.equal(0);
+	});
+
+	it("preserves unbounded Node reads without bounded handle capabilities", async () => {
+		const bytes = new Uint8Array([1, 2, 3]);
+		let readFileCalls = 0;
+		const store = new NativeBackboneNodeCoordinatePersistenceStore("legacy", {
+			mkdir: async () => {},
+			readFile: async () => {
+				readFileCalls++;
+				return bytes.slice();
+			},
+			writeFile: async () => {},
+			appendFile: async () => {},
+			rm: async () => {},
+		});
+
+		expect(await store.read("file.bin")).to.deep.equal(bytes);
+		expect(readFileCalls).to.equal(1);
+		const boundedFailure = await store.read("file.bin", 3).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(boundedFailure)).to.contain(
+			"bounded reads require FileHandle.open",
+		);
+		expect(readFileCalls).to.equal(1);
+	});
+
+	it("rejects short and growing Node named-file reads and always closes", async () => {
+		let shortCloseCalls = 0;
+		const shortStore = new NativeBackboneNodeCoordinatePersistenceStore(
+			"short",
+			{
+				mkdir: async () => {},
+				readFile: async () => new Uint8Array(),
+				writeFile: async () => {},
+				appendFile: async () => {},
+				open: async () => {
+					let calls = 0;
+					return {
+						write: async (data) => ({ bytesWritten: data.byteLength }),
+						stat: async () => ({ size: 3n }),
+						read: async (target) => {
+							calls++;
+							if (calls === 1) {
+								target[0] = 1;
+								return { bytesRead: 1 };
+							}
+							return { bytesRead: 0 };
+						},
+						close: async () => {
+							shortCloseCalls++;
+						},
+					};
+				},
+				rm: async () => {},
+			},
+		);
+		const shortFailure = await shortStore.read("file.bin", 3).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(String(shortFailure)).to.contain("changed during a bounded read");
+		expect(shortCloseCalls).to.equal(1);
+
+		let growthCloseCalls = 0;
+		let growthStatCalls = 0;
+		const growthStore = new NativeBackboneNodeCoordinatePersistenceStore(
+			"growth",
+			{
+				mkdir: async () => {},
+				readFile: async () => new Uint8Array(),
+				writeFile: async () => {},
+				appendFile: async () => {},
+				open: async () => ({
+					write: async (data) => ({ bytesWritten: data.byteLength }),
+					stat: async () => ({
+						size: growthStatCalls++ === 0 ? 2n : 3n,
+					}),
+					read: async (target, offset, length, position) => {
+						const grown = new Uint8Array([1, 2, 3]);
+						const count = Math.min(length, grown.byteLength - position);
+						target.set(grown.subarray(position, position + count), offset);
+						return { bytesRead: count };
+					},
+					close: async () => {
+						growthCloseCalls++;
+					},
+				}),
+				rm: async () => {},
+			},
+		);
+		const growthFailure = await growthStore.read("file.bin", 2).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(growthFailure).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(growthCloseCalls).to.equal(1);
+	});
+
+	it("checks OPFS named-file size before arrayBuffer allocation", async () => {
+		const directory = new FakeOPFSDirectoryHandle();
+		directory.files.set("bounded.bin", new Uint8Array([1, 2, 3]));
+		const store = new NativeBackboneOPFSCoordinatePersistenceStore(directory);
+
+		expect(await store.read("bounded.bin", 3)).to.deep.equal(
+			new Uint8Array([1, 2, 3]),
+		);
+		expect(directory.arrayBufferCount).to.equal(1);
+		const failure = await store.read("bounded.bin", 2).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect(failure).to.be.instanceOf(
+			NativeBackboneCoordinatePersistenceReadLimitError,
+		);
+		expect(directory.arrayBufferCount).to.equal(1);
 	});
 
 	it("persists native coordinate WAL through the node filesystem store", async () => {


### PR DESCRIPTION
## Summary

- add optional byte caps to native named-file reads, with pre-allocation checks for memory, Node, OPFS, and buffered adapters
- add a crash-safe `RebalanceWorkStore.beginDrop()` terminal fence that durably clears active restart work before later lifecycle destruction
- cover torn writes, ambiguous barriers, close/drop races, stale instances, exact caps, file growth/shrink, and buffered concurrency
- add patch changesets for `@peerbit/native-backbone` and `@peerbit/shared-log`

## Safety boundary

This is persistence substrate only. It does not wire the scan executor into `SharedLog`, validate a live placement epoch, schedule transfers, acknowledge destination durability, or authorize pruning. `beginDrop()` is local restart metadata, not a transfer receipt or prune capability.

The new optional read caps also do not change ordinary coordinate hydration, whose existing callers still use unbounded reads. Production work-state wiring still requires a lifetime namespace lease, authenticated/current view validation, and a browser lifetime-lock design before durable OPFS use.

## Verification

- `pnpm run build`
- shared-log rebalance work-store suite: 33 passing
- native-backbone Node suite: 122 passing
- native-backbone Rust suite: 58 passing
- targeted TypeScript, lint, Prettier, and `git diff --check`
- independent final adversarial review: no blocker

## Stack

This PR is based on #1293, which is based on #1292, #1291, and #1290. Evidence PR #1288 and sync-cap PR #1289 remain separate. The stacked changeset base guard may remain red until the PR is retargeted after its base merges.