### PR TITLE
feat(shared-log): lease rebalance work persistence

### DIFF
--- a/.changeset/leased-rebalance-work-persistence.md
+++ b/.changeset/leased-rebalance-work-persistence.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Add an internal bounded memory adapter and an atomically leased Node persistence factory for durable rebalance work.

--- a/packages/programs/data/shared-log/src/rebalance-work-persistence.ts
+++ b/packages/programs/data/shared-log/src/rebalance-work-persistence.ts
@@ -1,0 +1,531 @@
+import { toHexString } from "@peerbit/crypto";
+import type {
+	NativeBackboneCoordinatePersistenceStore,
+	NativeDurabilityLease,
+} from "@peerbit/native-backbone";
+import {
+	DEFAULT_REBALANCE_WORK_LIMITS,
+	REBALANCE_WORK_FILES,
+	type RebalanceWorkLimits,
+	type RebalanceWorkPersistence,
+	RebalanceWorkStore,
+} from "./rebalance-work-store.js";
+
+const REBALANCE_WORK_DIRECTORY = "rebalance-work";
+const MAX_REBALANCE_WORK_LOG_ID_BYTES = 64;
+const allowedFiles = new Set<string>(REBALANCE_WORK_FILES);
+const openMemoryNamespaces = new WeakSet<Map<string, Uint8Array>>();
+
+type NativeBackboneModule = Readonly<{
+	NativeBackboneNodeCoordinatePersistenceStore: new (
+		directory: string,
+	) => NativeBackboneCoordinatePersistenceStore;
+	acquireNativeDurabilityNodeLease(
+		directory: string,
+	): Promise<NativeDurabilityLease>;
+}>;
+
+export type RebalanceWorkNodeDirectoryHandle = Readonly<{
+	sync(): Promise<void>;
+	close(): Promise<void>;
+}>;
+
+export type RebalanceWorkNodeFileSystem = Readonly<{
+	realpath(path: string): Promise<string>;
+	stat(path: string): Promise<Readonly<{ isDirectory(): boolean }>>;
+	mkdir(path: string): Promise<unknown>;
+	open(path: string, flags: "r"): Promise<RebalanceWorkNodeDirectoryHandle>;
+}>;
+
+export type RebalanceWorkNodePath = Readonly<{
+	join(...parts: string[]): string;
+	dirname(path: string): string;
+}>;
+
+export type RebalanceWorkNodeModules = Readonly<{
+	fs: RebalanceWorkNodeFileSystem;
+	path: RebalanceWorkNodePath;
+	native: NativeBackboneModule;
+}>;
+
+/** @internal Deterministic fault-injection seam for the direct adapter spec. */
+export type RebalanceWorkNodePersistenceDependencies = Readonly<{
+	loadNodeModules?(): Promise<RebalanceWorkNodeModules>;
+	onPersistenceCreated?(persistence: RebalanceWorkPersistence): void;
+}>;
+
+export type OpenRebalanceWorkStoreOptions = Readonly<{
+	limits?: Partial<RebalanceWorkLimits>;
+}>;
+
+export type OpenNodeRebalanceWorkStoreOptions = OpenRebalanceWorkStoreOptions &
+	Readonly<{
+		nodeDirectory: string;
+		logId: Uint8Array;
+	}>;
+
+const dynamicImport = <T>(specifier: string): Promise<T> =>
+	import(/* @vite-ignore */ specifier) as Promise<T>;
+
+const validateFileName = (name: string): string => {
+	if (!allowedFiles.has(name)) {
+		throw new Error(`Invalid rebalance work persistence file: ${name}`);
+	}
+	return name;
+};
+
+const validateReadLimit = (maxBytes: number): number => {
+	if (
+		!Number.isSafeInteger(maxBytes) ||
+		maxBytes < 0 ||
+		maxBytes > DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes
+	) {
+		throw new RangeError(
+			`Rebalance work persistence read limit must be a non-negative safe integer no larger than ${DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes}`,
+		);
+	}
+	return maxBytes;
+};
+
+const captureWrite = (bytes: Uint8Array): Uint8Array => {
+	if (!(bytes instanceof Uint8Array)) {
+		throw new TypeError("Rebalance work persistence writes require bytes");
+	}
+	if (bytes.byteLength > DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes) {
+		throw new RangeError(
+			`Rebalance work persistence write exceeds ${DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes} bytes`,
+		);
+	}
+	return new Uint8Array(bytes);
+};
+
+const captureLimits = (
+	limits: Partial<RebalanceWorkLimits> | undefined,
+): RebalanceWorkLimits => {
+	const captured = {
+		...DEFAULT_REBALANCE_WORK_LIMITS,
+		...limits,
+	};
+	for (const key of Object.keys(
+		DEFAULT_REBALANCE_WORK_LIMITS,
+	) as (keyof RebalanceWorkLimits)[]) {
+		const value = captured[key];
+		if (
+			!Number.isSafeInteger(value) ||
+			value <= 0 ||
+			value > DEFAULT_REBALANCE_WORK_LIMITS[key]
+		) {
+			throw new RangeError(
+				`Rebalance work limit ${key} must be a positive safe integer no larger than ${DEFAULT_REBALANCE_WORK_LIMITS[key]}`,
+			);
+		}
+	}
+	return Object.freeze(captured);
+};
+
+const closeAfterOpenFailure = async (
+	persistence: RebalanceWorkPersistence,
+	error: unknown,
+): Promise<never> => {
+	let closeFailed = false;
+	let closeError: unknown;
+	try {
+		await persistence.close?.({ flush: false });
+	} catch (cleanupError) {
+		closeFailed = true;
+		closeError = cleanupError;
+	}
+	if (closeFailed) {
+		throw new AggregateError(
+			[error, closeError],
+			"Failed to open and close rebalance work persistence",
+		);
+	}
+	throw error;
+};
+
+/**
+ * In-process restart persistence for tests and non-persistent nodes. A backing
+ * map is exclusively owned until close and may then be supplied to a new
+ * adapter. It is never a strict durability capability.
+ */
+export class RebalanceWorkMemoryPersistence
+	implements RebalanceWorkPersistence
+{
+	private closed = false;
+	private closePromise?: Promise<void>;
+
+	constructor(readonly files: Map<string, Uint8Array> = new Map()) {
+		if (!(files instanceof Map)) {
+			throw new TypeError("Rebalance work memory persistence requires a Map");
+		}
+		if (openMemoryNamespaces.has(files)) {
+			throw new Error("Rebalance work memory persistence is already open");
+		}
+		openMemoryNamespaces.add(files);
+	}
+
+	async read(name: string, maxBytes: number): Promise<Uint8Array | undefined> {
+		this.assertOpen();
+		const validName = validateFileName(name);
+		const limit = validateReadLimit(maxBytes);
+		const bytes = this.files.get(validName);
+		if (bytes && bytes.byteLength > limit) {
+			throw new RangeError(
+				`Rebalance work persistence file ${validName} exceeds the ${limit} byte read limit`,
+			);
+		}
+		return bytes ? new Uint8Array(bytes) : undefined;
+	}
+
+	async write(name: string, bytes: Uint8Array): Promise<void> {
+		this.assertOpen();
+		this.files.set(validateFileName(name), captureWrite(bytes));
+	}
+
+	close(): Promise<void> {
+		if (this.closePromise) {
+			return this.closePromise;
+		}
+		this.closed = true;
+		openMemoryNamespaces.delete(this.files);
+		this.closePromise = Promise.resolve();
+		return this.closePromise;
+	}
+
+	private assertOpen(): void {
+		if (this.closed) {
+			throw new Error("Rebalance work memory persistence is closed");
+		}
+	}
+}
+
+export const openMemoryRebalanceWorkStore = async (
+	options: OpenRebalanceWorkStoreOptions &
+		Readonly<{ files?: Map<string, Uint8Array> }> = {},
+): Promise<RebalanceWorkStore> => {
+	const limits = captureLimits(options.limits);
+	const persistence = new RebalanceWorkMemoryPersistence(options.files);
+	try {
+		return await RebalanceWorkStore.open({
+			persistence,
+			durability: "memory",
+			limits,
+		});
+	} catch (error) {
+		return closeAfterOpenFailure(persistence, error);
+	}
+};
+
+const hasErrorCode = (error: unknown, code: string): boolean => {
+	const seen = new Set<unknown>();
+	let current = error;
+	while (current != null && typeof current === "object" && !seen.has(current)) {
+		seen.add(current);
+		if ((current as { code?: unknown }).code === code) {
+			return true;
+		}
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
+};
+
+const syncDirectoryStrict = async (
+	fs: RebalanceWorkNodeFileSystem,
+	directory: string,
+): Promise<void> => {
+	let handle: RebalanceWorkNodeDirectoryHandle | undefined;
+	let operationFailed = false;
+	let operationError: unknown;
+	try {
+		handle = await fs.open(directory, "r");
+		await handle.sync();
+	} catch (error) {
+		operationFailed = true;
+		operationError = error;
+	}
+	let closeFailed = false;
+	let closeError: unknown;
+	try {
+		await handle?.close();
+	} catch (error) {
+		closeFailed = true;
+		closeError = error;
+	}
+	if (operationFailed && closeFailed) {
+		throw new AggregateError(
+			[operationError, closeError],
+			`Failed to sync and close rebalance work directory ${directory}`,
+		);
+	}
+	if (operationFailed) throw operationError;
+	if (closeFailed) throw closeError;
+};
+
+const ensureCanonicalChildDirectory = async (
+	fs: RebalanceWorkNodeFileSystem,
+	path: RebalanceWorkNodePath,
+	canonicalParent: string,
+	name: string,
+): Promise<string> => {
+	const requested = path.join(canonicalParent, name);
+	try {
+		await fs.mkdir(requested);
+	} catch (error) {
+		if (!hasErrorCode(error, "EEXIST")) {
+			throw error;
+		}
+	}
+	const facts = await fs.stat(requested);
+	if (!facts.isDirectory()) {
+		throw new Error(`Rebalance work path is not a directory: ${requested}`);
+	}
+	// Repeat this on every open, including EEXIST retries. A previous creation
+	// may have become visible before its parent-directory sync failed.
+	await syncDirectoryStrict(fs, canonicalParent);
+	const canonical = await fs.realpath(requested);
+	if (canonical !== requested || path.dirname(canonical) !== canonicalParent) {
+		throw new Error(
+			`Rebalance work directory is not its canonical requested path: ${canonical}`,
+		);
+	}
+	return canonical;
+};
+
+const loadNodeModules = async (): Promise<RebalanceWorkNodeModules> => {
+	const processLike = (
+		globalThis as { process?: { versions?: { node?: string } } }
+	).process;
+	if (!processLike?.versions?.node) {
+		throw new Error("Persistent rebalance work is only supported in Node.js");
+	}
+	const [fs, path, native] = await Promise.all([
+		dynamicImport<RebalanceWorkNodeFileSystem>("node:fs/promises"),
+		dynamicImport<RebalanceWorkNodePath>("node:path"),
+		dynamicImport<NativeBackboneModule>("@peerbit/native-backbone"),
+	]);
+	return { fs, path, native };
+};
+
+const captureNodeOptions = (
+	options: OpenNodeRebalanceWorkStoreOptions,
+): Readonly<{
+	nodeDirectory: string;
+	logId: Uint8Array;
+	limits: RebalanceWorkLimits;
+}> => {
+	if (typeof options?.nodeDirectory !== "string" || !options.nodeDirectory) {
+		throw new TypeError("nodeDirectory must be a non-empty string");
+	}
+	if (
+		!(options.logId instanceof Uint8Array) ||
+		options.logId.byteLength === 0 ||
+		options.logId.byteLength > MAX_REBALANCE_WORK_LOG_ID_BYTES
+	) {
+		throw new TypeError(
+			`logId must contain 1-${MAX_REBALANCE_WORK_LOG_ID_BYTES} bytes`,
+		);
+	}
+	return Object.freeze({
+		nodeDirectory: options.nodeDirectory,
+		logId: new Uint8Array(options.logId),
+		limits: captureLimits(options.limits),
+	});
+};
+
+class NodeRebalanceWorkPersistence implements RebalanceWorkPersistence {
+	private tail: Promise<void> = Promise.resolve();
+	private closing = false;
+	private closed = false;
+	private closePromise?: Promise<void>;
+
+	constructor(
+		private readonly raw: NativeBackboneCoordinatePersistenceStore,
+		private readonly lease: NativeDurabilityLease,
+		private readonly fs: RebalanceWorkNodeFileSystem,
+		private readonly namespace: string,
+	) {}
+
+	read(name: string, maxBytes: number): Promise<Uint8Array | undefined> {
+		this.assertAccepting();
+		const validName = validateFileName(name);
+		const limit = validateReadLimit(maxBytes);
+		return this.enqueue(() => this.raw.read(validName, limit));
+	}
+
+	write(name: string, bytes: Uint8Array): Promise<void> {
+		this.assertAccepting();
+		const validName = validateFileName(name);
+		const captured = captureWrite(bytes);
+		return this.enqueue(() => this.raw.write(validName, captured));
+	}
+
+	durableBarrier(name?: string): Promise<void> {
+		this.assertAccepting();
+		const validName = validateFileName(name ?? "");
+		return this.enqueue(async () => {
+			if (typeof this.raw.durableBarrier !== "function") {
+				throw new Error(
+					"Node rebalance work persistence requires a named file barrier",
+				);
+			}
+			await this.raw.durableBarrier(validName);
+			// The coordinate adapter intentionally tolerates unsupported directory
+			// syncs. Strict work frames cannot: first-file namespace metadata must be
+			// durable before the barrier can authorize a restart checkpoint.
+			await syncDirectoryStrict(this.fs, this.namespace);
+		});
+	}
+
+	flush(name?: string): Promise<void> {
+		this.assertAccepting();
+		const validName = name === undefined ? undefined : validateFileName(name);
+		return this.enqueue(async () => {
+			await this.raw.flush?.(validName);
+		});
+	}
+
+	close(_options?: { flush?: boolean }): Promise<void> {
+		if (this.closePromise) {
+			return this.closePromise;
+		}
+		this.closing = true;
+		this.closePromise = (async () => {
+			await this.tail;
+			let rawFailed = false;
+			let rawError: unknown;
+			try {
+				await this.lease.runWhileHeld(async () => {
+					await this.raw.close?.({ flush: false });
+				});
+			} catch (error) {
+				rawFailed = true;
+				rawError = error;
+			}
+			let leaseFailed = false;
+			let leaseError: unknown;
+			try {
+				await this.lease.close();
+			} catch (error) {
+				leaseFailed = true;
+				leaseError = error;
+			} finally {
+				this.closed = true;
+			}
+			if (rawFailed && leaseFailed) {
+				throw new AggregateError(
+					[rawError, leaseError],
+					"Failed to close rebalance work persistence and lease",
+				);
+			}
+			if (rawFailed) throw rawError;
+			if (leaseFailed) throw leaseError;
+		})();
+		return this.closePromise;
+	}
+
+	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		this.assertAccepting();
+		const result = this.tail.then(() => this.lease.runWhileHeld(operation));
+		this.tail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
+	private assertAccepting(): void {
+		if (this.closing || this.closed) {
+			throw new Error("Rebalance work persistence is closing");
+		}
+	}
+}
+
+const createNodePersistence = async (
+	options: ReturnType<typeof captureNodeOptions>,
+	dependencies: RebalanceWorkNodePersistenceDependencies,
+): Promise<NodeRebalanceWorkPersistence> => {
+	const { fs, path, native } = await (
+		dependencies.loadNodeModules ?? loadNodeModules
+	)();
+	const canonicalRoot = await fs.realpath(options.nodeDirectory);
+	const rootFacts = await fs.stat(canonicalRoot);
+	if (!rootFacts.isDirectory()) {
+		throw new Error(
+			`Peerbit node directory is not a directory: ${canonicalRoot}`,
+		);
+	}
+	const workRoot = await ensureCanonicalChildDirectory(
+		fs,
+		path,
+		canonicalRoot,
+		REBALANCE_WORK_DIRECTORY,
+	);
+	const namespace = await ensureCanonicalChildDirectory(
+		fs,
+		path,
+		workRoot,
+		toHexString(options.logId),
+	);
+	// Probe strict directory-sync support before acquiring the lifetime lock.
+	await syncDirectoryStrict(fs, namespace);
+
+	const lease = await native.acquireNativeDurabilityNodeLease(namespace);
+	let raw: NativeBackboneCoordinatePersistenceStore | undefined;
+	try {
+		raw = new native.NativeBackboneNodeCoordinatePersistenceStore(namespace);
+		if (typeof raw.durableBarrier !== "function") {
+			throw new Error(
+				"Native Node persistence does not expose a physical durability barrier",
+			);
+		}
+		return new NodeRebalanceWorkPersistence(raw, lease, fs, namespace);
+	} catch (error) {
+		const errors: unknown[] = [error];
+		if (raw) {
+			try {
+				await lease.runWhileHeld(async () => {
+					await raw!.close?.({ flush: false });
+				});
+			} catch (cleanupError) {
+				errors.push(cleanupError);
+			}
+		}
+		try {
+			await lease.close();
+		} catch (cleanupError) {
+			errors.push(cleanupError);
+		}
+		if (errors.length > 1) {
+			throw new AggregateError(
+				errors,
+				"Failed to construct rebalance work persistence and close its lease",
+			);
+		}
+		throw error;
+	}
+};
+
+/**
+ * Open one strict Node work store atomically with its lifetime namespace lease.
+ * The leased persistence adapter is intentionally not exposed, so every failed
+ * store preflight and recovery path can release ownership before returning.
+ * This does not validate placement-view currency and grants no prune authority.
+ */
+export const openNodeRebalanceWorkStore = async (
+	input: OpenNodeRebalanceWorkStoreOptions,
+	dependencies: RebalanceWorkNodePersistenceDependencies = {},
+): Promise<RebalanceWorkStore> => {
+	const options = captureNodeOptions(input);
+	const persistence = await createNodePersistence(options, dependencies);
+	try {
+		dependencies.onPersistenceCreated?.(persistence);
+		return await RebalanceWorkStore.open({
+			persistence,
+			durability: "strict",
+			limits: options.limits,
+		});
+	} catch (error) {
+		return closeAfterOpenFailure(persistence, error);
+	}
+};

--- a/packages/programs/data/shared-log/test/rebalance-work-persistence.spec.ts
+++ b/packages/programs/data/shared-log/test/rebalance-work-persistence.spec.ts
@@ -1,0 +1,496 @@
+import { toHexString } from "@peerbit/crypto";
+import { expect } from "chai";
+import {
+	mkdir,
+	mkdtemp,
+	readdir,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { type RebalanceScanPlan, ReplicationIntent } from "../src/ranges.js";
+import {
+	RebalanceWorkMemoryPersistence,
+	type RebalanceWorkNodeModules,
+	openMemoryRebalanceWorkStore,
+	openNodeRebalanceWorkStore,
+} from "../src/rebalance-work-persistence.js";
+import {
+	DEFAULT_REBALANCE_WORK_LIMITS,
+	REBALANCE_WORK_FILES,
+	type RebalanceWorkPersistence,
+} from "../src/rebalance-work-store.js";
+
+const viewId = (character: string) => character.repeat(64);
+
+const makePlan = (offset = 10): RebalanceScanPlan<"u32"> => ({
+	boundary: false,
+	geometryRanges: [
+		{
+			start1: offset,
+			end1: offset + 10,
+			start2: offset,
+			end2: offset + 10,
+			mode: ReplicationIntent.Strict,
+		},
+	],
+	ownedIntervals: [
+		{ start: BigInt(offset), end: BigInt(offset + 10), geometryTask: 0 },
+	],
+	taskCount: 1,
+	historyMutations: [{ rangeHash: `range-${offset}`, present: true }],
+});
+
+const install = async (
+	store: Awaited<ReturnType<typeof openNodeRebalanceWorkStore>>,
+	character = "a",
+) =>
+	store.install(store.snapshot().revision, {
+		resolution: "u32",
+		viewId: viewId(character),
+		plan: makePlan(),
+	});
+
+const fakeNodeModules = (
+	options: {
+		missingBarrier?: boolean;
+		rawCloseError?: Error;
+		leaseCloseError?: Error;
+	} = {},
+) => {
+	const events: string[] = [];
+	const directories = new Set(["/node"]);
+	const files = new Map<string, Uint8Array>();
+	let nextSyncFailure:
+		| Readonly<{ directory: string; error: Error }>
+		| undefined;
+
+	const fs = {
+		async realpath(path: string) {
+			return path;
+		},
+		async stat(path: string) {
+			return { isDirectory: () => directories.has(path) };
+		},
+		async mkdir(path: string) {
+			if (directories.has(path)) {
+				throw Object.assign(new Error("exists"), { code: "EEXIST" });
+			}
+			directories.add(path);
+		},
+		async open(path: string, _flags: "r") {
+			return {
+				async sync() {
+					events.push(`fs:sync:${path}`);
+					if (nextSyncFailure?.directory === path) {
+						const failure = nextSyncFailure.error;
+						nextSyncFailure = undefined;
+						throw failure;
+					}
+				},
+				async close() {
+					events.push(`fs:close:${path}`);
+				},
+			};
+		},
+	};
+
+	class RawStore {
+		readonly durableBarrier = options.missingBarrier
+			? undefined
+			: async (name?: string) => {
+					events.push(`raw:barrier:${name}`);
+				};
+
+		async read(name: string, maxBytes?: number) {
+			events.push(`raw:read:${name}:${maxBytes}`);
+			const bytes = files.get(name);
+			return bytes ? new Uint8Array(bytes) : undefined;
+		}
+
+		async write(name: string, bytes: Uint8Array) {
+			events.push(`raw:write:${name}`);
+			files.set(name, new Uint8Array(bytes));
+		}
+
+		async append() {}
+
+		async flush(name?: string) {
+			events.push(`raw:flush:${name}`);
+		}
+
+		async close() {
+			events.push("raw:close");
+			if (options.rawCloseError) throw options.rawCloseError;
+		}
+	}
+
+	const lease = {
+		fence: Object.freeze({ epoch: 1n, ownerId: "owner", domainId: "domain" }),
+		async assertHeld() {},
+		async runWhileHeld<T>(operation: () => Promise<T>): Promise<T> {
+			return operation();
+		},
+		async close() {
+			events.push("lease:close");
+			if (options.leaseCloseError) throw options.leaseCloseError;
+		},
+	};
+
+	const modules = {
+		fs,
+		path: { join, dirname },
+		native: {
+			NativeBackboneNodeCoordinatePersistenceStore: RawStore,
+			async acquireNativeDurabilityNodeLease(directory: string) {
+				events.push(`lease:acquire:${directory}`);
+				return lease;
+			},
+		},
+	} as RebalanceWorkNodeModules;
+
+	return {
+		events,
+		files,
+		namespace: "/node/rebalance-work/01",
+		dependencies: {
+			async loadNodeModules() {
+				return modules;
+			},
+		},
+		failNextSync(directory: string, error: Error) {
+			nextSyncFailure = { directory, error };
+		},
+	};
+};
+
+describe("rebalance work store persistence", function () {
+	this.timeout(30_000);
+
+	const directories = new Set<string>();
+
+	const temporaryDirectory = async (prefix: string): Promise<string> => {
+		const directory = await mkdtemp(join(tmpdir(), prefix));
+		directories.add(directory);
+		return directory;
+	};
+
+	afterEach(async () => {
+		for (const directory of directories) {
+			await rm(directory, { recursive: true, force: true });
+		}
+		directories.clear();
+	});
+
+	it("bounds and defensively copies memory persistence", async () => {
+		const files = new Map<string, Uint8Array>();
+		const persistence = new RebalanceWorkMemoryPersistence(files);
+		const input = new Uint8Array([1, 2, 3]);
+		await persistence.write(REBALANCE_WORK_FILES[0], input);
+		input[0] = 9;
+
+		const first = await persistence.read(REBALANCE_WORK_FILES[0], 3);
+		expect([...first!]).to.deep.equal([1, 2, 3]);
+		first![1] = 9;
+		expect([
+			...(await persistence.read(REBALANCE_WORK_FILES[0], 3))!,
+		]).to.deep.equal([1, 2, 3]);
+
+		await expect(
+			persistence.read(REBALANCE_WORK_FILES[0], 2),
+		).to.be.rejectedWith("exceeds the 2 byte read limit");
+		await expect(persistence.read("other", 3)).to.be.rejectedWith(
+			"Invalid rebalance work persistence file",
+		);
+		await expect(
+			persistence.write("other", new Uint8Array()),
+		).to.be.rejectedWith("Invalid rebalance work persistence file");
+		expect(() => new RebalanceWorkMemoryPersistence(files)).to.throw(
+			"already open",
+		);
+
+		await persistence.close();
+		await expect(
+			persistence.read(REBALANCE_WORK_FILES[0], 3),
+		).to.be.rejectedWith("closed");
+		const reopened = new RebalanceWorkMemoryPersistence(files);
+		await reopened.close();
+	});
+
+	it("reopens memory work from the same bounded namespace", async () => {
+		const files = new Map<string, Uint8Array>();
+		const first = await openMemoryRebalanceWorkStore({ files });
+		const installed = await first.install(0n, {
+			resolution: "u32",
+			viewId: viewId("b"),
+			plan: makePlan(),
+		});
+		await first.close();
+
+		const reopened = await openMemoryRebalanceWorkStore({ files });
+		expect(reopened.snapshot()).to.deep.equal(installed.snapshot);
+		expect(reopened.currentDurableCommit()).to.equal(undefined);
+		await reopened.close();
+	});
+
+	it("persists strict work under the canonical per-log namespace", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-work-");
+		const logId = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+		const namespace = join(directory, "rebalance-work", toHexString(logId));
+
+		const first = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		const installed = await install(first);
+		expect(installed.durableCommit).to.exist;
+		await first.close();
+
+		expect(await readdir(namespace)).to.include.members([
+			...REBALANCE_WORK_FILES,
+			".peerbit-native-durability-lease",
+		]);
+		const reopened = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		expect(reopened.snapshot()).to.deep.equal(installed.snapshot);
+		expect(reopened.currentDurableCommit()).to.deep.include({ revision: 2n });
+		await reopened.close();
+	});
+
+	it("holds one canonical namespace lease and isolates log ids", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-lock-");
+		const alias = `${directory}-alias`;
+		directories.add(alias);
+		await symlink(directory, alias, "dir");
+		const logId = new Uint8Array([1, 2, 3]);
+		const otherLogId = new Uint8Array([1, 2, 4]);
+
+		const first = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		await expect(
+			openNodeRebalanceWorkStore({ nodeDirectory: alias, logId }),
+		).to.be.rejectedWith("already open");
+
+		const other = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId: otherLogId,
+		});
+		await other.close();
+		await first.close();
+
+		const reopened = await openNodeRebalanceWorkStore({
+			nodeDirectory: alias,
+			logId,
+		});
+		await reopened.close();
+	});
+
+	it("releases the namespace lease after failed recovery", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-invalid-");
+		const logId = new Uint8Array([7, 8, 9]);
+		const namespace = join(directory, "rebalance-work", toHexString(logId));
+		await mkdir(namespace, { recursive: true });
+		await writeFile(join(namespace, REBALANCE_WORK_FILES[0]), "invalid");
+
+		await expect(
+			openNodeRebalanceWorkStore({ nodeDirectory: directory, logId }),
+		).to.be.rejectedWith("No valid rebalance work generation remains");
+		await rm(join(namespace, REBALANCE_WORK_FILES[0]));
+
+		const recovered = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		await recovered.close();
+	});
+
+	it("recovers a valid frame when the stale slot exceeds the read cap", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-cap-");
+		const logId = new Uint8Array([4, 5, 6]);
+		const namespace = join(directory, "rebalance-work", toHexString(logId));
+		const first = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		const installed = await install(first, "c");
+		await first.close();
+
+		// The first install writes the cleared baseline to B and the active frame
+		// to A. Recovery must settle both bounded reads and retain the valid A frame.
+		await writeFile(
+			join(namespace, REBALANCE_WORK_FILES[1]),
+			new Uint8Array(DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes + 1),
+		);
+		const reopened = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		expect(reopened.snapshot()).to.deep.equal(installed.snapshot);
+		await reopened.close();
+	});
+
+	it("rejects limit widening before it creates or leases a namespace", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-limit-");
+		const logId = new Uint8Array([9]);
+		await expect(
+			openNodeRebalanceWorkStore({
+				nodeDirectory: directory,
+				logId,
+				limits: {
+					maxFrameBytes: DEFAULT_REBALANCE_WORK_LIMITS.maxFrameBytes + 1,
+				},
+			}),
+		).to.be.rejectedWith("maxFrameBytes");
+		expect(await readdir(directory)).to.deep.equal([]);
+
+		const opened = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId,
+		});
+		await opened.close();
+	});
+
+	it("rejects a same-parent namespace symlink instead of crossing log ids", async () => {
+		const directory = await temporaryDirectory("peerbit-rebalance-alias-");
+		const firstId = new Uint8Array([10]);
+		const secondId = new Uint8Array([11]);
+		const workRoot = join(directory, "rebalance-work");
+		const firstNamespace = join(workRoot, toHexString(firstId));
+		const secondNamespace = join(workRoot, toHexString(secondId));
+
+		const first = await openNodeRebalanceWorkStore({
+			nodeDirectory: directory,
+			logId: firstId,
+		});
+		await install(first, "d");
+		await first.close();
+		await symlink(firstNamespace, secondNamespace, "dir");
+
+		await expect(
+			openNodeRebalanceWorkStore({
+				nodeDirectory: directory,
+				logId: secondId,
+			}),
+		).to.be.rejectedWith("not its canonical requested path");
+	});
+
+	it("strictly syncs the namespace after each raw file barrier", async () => {
+		const fake = fakeNodeModules();
+		const store = await openNodeRebalanceWorkStore(
+			{ nodeDirectory: "/node", logId: new Uint8Array([1]) },
+			fake.dependencies,
+		);
+		fake.events.length = 0;
+		await install(store, "e");
+
+		const firstWrite = fake.events.indexOf(
+			`raw:write:${REBALANCE_WORK_FILES[1]}`,
+		);
+		const firstBarrier = fake.events.indexOf(
+			`raw:barrier:${REBALANCE_WORK_FILES[1]}`,
+		);
+		const firstDirectorySync = fake.events.indexOf(`fs:sync:${fake.namespace}`);
+		expect(firstWrite).to.be.at.least(0);
+		expect(firstBarrier).to.be.greaterThan(firstWrite);
+		expect(firstDirectorySync).to.be.greaterThan(firstBarrier);
+		await store.close();
+		expect(fake.events.indexOf("raw:close")).to.be.lessThan(
+			fake.events.indexOf("lease:close"),
+		);
+	});
+
+	it("fails closed when the strict namespace sync fails after a file barrier", async () => {
+		const fake = fakeNodeModules();
+		const store = await openNodeRebalanceWorkStore(
+			{ nodeDirectory: "/node", logId: new Uint8Array([1]) },
+			fake.dependencies,
+		);
+		fake.events.length = 0;
+		fake.failNextSync(fake.namespace, new Error("namespace sync failed"));
+
+		await expect(install(store, "f")).to.be.rejectedWith(
+			"Failed to persist rebalance work frame",
+		);
+		expect(fake.events).to.include(`raw:barrier:${REBALANCE_WORK_FILES[1]}`);
+		expect(fake.events).to.include(`fs:sync:${fake.namespace}`);
+		await expect(store.close()).to.be.rejectedWith(
+			"Rebalance work store is poisoned",
+		);
+	});
+
+	it("fences direct Node adapter operations and validates flush names", async () => {
+		const fake = fakeNodeModules();
+		let persistence: RebalanceWorkPersistence | undefined;
+		const store = await openNodeRebalanceWorkStore(
+			{ nodeDirectory: "/node", logId: new Uint8Array([1]) },
+			{
+				...fake.dependencies,
+				onPersistenceCreated(value) {
+					persistence = value;
+				},
+			},
+		);
+		await persistence!.flush?.(REBALANCE_WORK_FILES[0]);
+		expect(fake.events).to.include(`raw:flush:${REBALANCE_WORK_FILES[0]}`);
+		expect(() => persistence!.flush?.("other")).to.throw(
+			"Invalid rebalance work persistence file",
+		);
+		await store.close();
+		expect(() =>
+			persistence!.write(REBALANCE_WORK_FILES[0], new Uint8Array()),
+		).to.throw("closing");
+		expect(() => persistence!.flush?.(REBALANCE_WORK_FILES[0])).to.throw(
+			"closing",
+		);
+	});
+
+	it("closes raw storage before its lease and aggregates both failures", async () => {
+		const rawError = new Error("raw close failed");
+		const leaseError = new Error("lease close failed");
+		const fake = fakeNodeModules({
+			rawCloseError: rawError,
+			leaseCloseError: leaseError,
+		});
+		const store = await openNodeRebalanceWorkStore(
+			{ nodeDirectory: "/node", logId: new Uint8Array([1]) },
+			fake.dependencies,
+		);
+
+		let closeError: unknown;
+		try {
+			await store.close();
+		} catch (error) {
+			closeError = error;
+		}
+		expect(closeError).to.be.instanceOf(AggregateError);
+		expect((closeError as AggregateError).errors).to.deep.equal([
+			rawError,
+			leaseError,
+		]);
+		expect(fake.events.indexOf("raw:close")).to.be.lessThan(
+			fake.events.indexOf("lease:close"),
+		);
+	});
+
+	it("closes raw storage and its lease after post-acquisition setup failure", async () => {
+		const fake = fakeNodeModules({ missingBarrier: true });
+		await expect(
+			openNodeRebalanceWorkStore(
+				{ nodeDirectory: "/node", logId: new Uint8Array([1]) },
+				fake.dependencies,
+			),
+		).to.be.rejectedWith("does not expose a physical durability barrier");
+		expect(fake.events.indexOf("raw:close")).to.be.greaterThan(
+			fake.events.findIndex((event) => event.startsWith("lease:acquire:")),
+		);
+		expect(fake.events.indexOf("raw:close")).to.be.lessThan(
+			fake.events.indexOf("lease:close"),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- add an internal bounded memory adapter for non-persistent work-state restart tests
- add an atomic Node factory that opens `RebalanceWorkStore` together with a canonical per-log lifetime lease
- durably create and parent-fsync `rebalance-work/<hex-log-id>`, then strictly sync the exact namespace after every raw named-file barrier
- serialize all reads, writes, barriers, flushes, and close under the OS-released lease
- reject symlink namespace crossing, limit widening, oversized reads, stale ownership, and cleanup ambiguity
- add direct real-filesystem and injected-failure coverage plus a shared-log patch changeset

## Safety boundary

This module is internal and is not exported from the package root or wired into live `SharedLog`. It only supplies opaque bounded persistence. It does not validate placement-view currency, schedule scans, transfer entries, acknowledge destination durability, create retention pins, or authorize pruning.

The Node factory returns an already-open work store rather than exposing its leased persistence object, so setup, preflight, and recovery failures release raw resources and the namespace lease atomically. Browser durable persistence remains unsupported until a worker/lifetime-lock design exists.

## Verification

- `pnpm run build`
- combined rebalance work-store shard: 46 passing
- new persistence suite: 13 passing
- shared-log TypeScript and targeted ESLint
- Prettier, CI shard-coverage guard, and `git diff --check`
- two independent adversarial reviews: no blocker

## Stack

This PR is based on #1294, then #1293, #1292, #1291, and #1290. Evidence PR #1288 and sync-cap PR #1289 remain separate. The stacked base/changeset guard may remain red until the PR is retargeted after its base merges.