### PR TITLE
fix(shared-log): make owner sampling deterministic

### DIFF
--- a/.changeset/young-owners-agree.md
+++ b/.changeset/young-owners-agree.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/shared-log": patch
+"@peerbit/shared-log-rust": patch
+---
+
+Make shared-log owner sampling independent of mixed-maturity range order and
+align TypeScript fallback tie-breaking with the native deterministic order.

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -369,7 +369,7 @@ impl RangePlanner {
     /// consumers must only rely on membership.
     pub fn get_samples(&self, cursors: &[u64], options: &SampleOptions) -> Vec<LeaderSample> {
         let mut leaders: IndexMap<String, bool> = IndexMap::new();
-        let mut matured = 0usize;
+        let mut mature_owners: HashSet<String> = HashSet::new();
         let mut unique_visited: IndexSet<String> = IndexSet::new();
 
         for (i, point) in cursors.iter().copied().enumerate() {
@@ -383,14 +383,14 @@ impl RangePlanner {
                     continue;
                 }
                 unique_visited.insert(range.hash.clone());
+                if range.is_matured(options.now, options.role_age_ms) {
+                    mature_owners.insert(range.hash.clone());
+                }
                 match leaders.get_mut(&range.hash) {
                     Some(intersecting) => {
                         *intersecting = true;
                     }
                     None => {
-                        if range.is_matured(options.now, options.role_age_ms) {
-                            matured += 1;
-                        }
                         leaders.insert(range.hash.clone(), true);
                     }
                 }
@@ -405,7 +405,7 @@ impl RangePlanner {
                 }
             }
 
-            if options.only_intersecting || matured > i {
+            if options.only_intersecting || mature_owners.len() > i {
                 continue;
             }
 
@@ -418,11 +418,11 @@ impl RangePlanner {
                 if !range.is_matured(options.now, options.role_age_ms) {
                     continue;
                 }
+                mature_owners.insert(range.hash.clone());
                 if !leaders.contains_key(&range.hash) {
-                    matured += 1;
                     leaders.insert(range.hash.clone(), false);
                 }
-                if matured > i {
+                if mature_owners.len() > i {
                     break;
                 }
             }
@@ -441,7 +441,7 @@ impl RangePlanner {
         target_hash: &str,
     ) -> bool {
         let mut leaders: HashSet<String> = HashSet::new();
-        let mut matured = 0usize;
+        let mut mature_owners: HashSet<String> = HashSet::new();
         let mut unique_visited: HashSet<String> = HashSet::new();
 
         for (i, point) in cursors.iter().copied().enumerate() {
@@ -458,11 +458,10 @@ impl RangePlanner {
                     return true;
                 }
                 unique_visited.insert(range.hash.clone());
-                if leaders.insert(range.hash.clone())
-                    && range.is_matured(options.now, options.role_age_ms)
-                {
-                    matured += 1;
+                if range.is_matured(options.now, options.role_age_ms) {
+                    mature_owners.insert(range.hash.clone());
                 }
+                leaders.insert(range.hash.clone());
             }
 
             if let Some(unique_replicators) = &options.unique_replicators {
@@ -474,7 +473,7 @@ impl RangePlanner {
                 }
             }
 
-            if options.only_intersecting || matured > i {
+            if options.only_intersecting || mature_owners.len() > i {
                 continue;
             }
 
@@ -490,10 +489,9 @@ impl RangePlanner {
                 if !range.is_matured(options.now, options.role_age_ms) {
                     continue;
                 }
-                if leaders.insert(range.hash.clone()) {
-                    matured += 1;
-                }
-                if matured > i {
+                mature_owners.insert(range.hash.clone());
+                leaders.insert(range.hash.clone());
+                if mature_owners.len() > i {
                     break;
                 }
             }
@@ -773,6 +771,34 @@ impl RangePlanner {
             .find_map(|key| self.candidate_from_key(key, peer_filter, seen_ids))
     }
 
+    fn first_candidate_from_descending_key_groups<'a, I>(
+        &'a self,
+        keys: I,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&'a ReplicationRange>
+    where
+        I: IntoIterator<Item = &'a RangeIndexKey>,
+    {
+        let mut current_value = None;
+        let mut best = None;
+        for key in keys {
+            if current_value != Some(key.value) {
+                if best.is_some() {
+                    return best;
+                }
+                current_value = Some(key.value);
+            }
+            // The keys arrive in full reverse order: coordinate descending and
+            // metadata descending. Keep replacing within one coordinate group
+            // so the last eligible row is the metadata-lowest candidate.
+            if let Some(candidate) = self.candidate_from_key(key, peer_filter, seen_ids) {
+                best = Some(candidate);
+            }
+        }
+        best
+    }
+
     fn closest_start_candidate(
         &self,
         point: u64,
@@ -790,13 +816,17 @@ impl RangePlanner {
                 self.first_candidate_from_keys(self.by_start1.iter(), peer_filter, seen_ids)
             })
         } else {
-            self.first_candidate_from_keys(
+            self.first_candidate_from_descending_key_groups(
                 self.by_start1.range(..=RangeIndexKey::max_at(point)).rev(),
                 peer_filter,
                 seen_ids,
             )
             .or_else(|| {
-                self.first_candidate_from_keys(self.by_start1.iter().rev(), peer_filter, seen_ids)
+                self.first_candidate_from_descending_key_groups(
+                    self.by_start1.iter().rev(),
+                    peer_filter,
+                    seen_ids,
+                )
             })
         }
     }
@@ -816,13 +846,17 @@ impl RangePlanner {
             )
             .or_else(|| self.first_candidate_from_keys(self.by_end2.iter(), peer_filter, seen_ids))
         } else {
-            self.first_candidate_from_keys(
+            self.first_candidate_from_descending_key_groups(
                 self.by_end2.range(..=RangeIndexKey::max_at(point)).rev(),
                 peer_filter,
                 seen_ids,
             )
             .or_else(|| {
-                self.first_candidate_from_keys(self.by_end2.iter().rev(), peer_filter, seen_ids)
+                self.first_candidate_from_descending_key_groups(
+                    self.by_end2.iter().rev(),
+                    peer_filter,
+                    seen_ids,
+                )
             })
         }
     }
@@ -4610,6 +4644,133 @@ mod tests {
         assert!(!samples[0].intersecting);
         assert_eq!(samples[1].hash, "peer-b");
         assert!(!samples[1].intersecting);
+    }
+
+    #[test]
+    fn counts_mature_evidence_for_an_existing_owner_in_any_put_order() {
+        for immature_first in [true, false] {
+            let mut planner = RangePlanner::new("u32");
+            let immature =
+                ReplicationRange::new("a-immature", "peer-a", 950, 40, 60, 40, 60, 20, 0);
+            let mature = ReplicationRange::new("a-mature", "peer-a", 0, 40, 60, 40, 60, 20, 0);
+            if immature_first {
+                planner.put(immature);
+                planner.put(mature);
+            } else {
+                planner.put(mature);
+                planner.put(immature);
+            }
+            planner.put(ReplicationRange::new(
+                "b-fallback",
+                "peer-b",
+                0,
+                70,
+                80,
+                70,
+                80,
+                10,
+                0,
+            ));
+            let options = SampleOptions {
+                role_age_ms: 100,
+                now: 1_000,
+                ..Default::default()
+            };
+
+            assert_eq!(
+                planner.get_samples(&[50], &options),
+                vec![LeaderSample {
+                    hash: "peer-a".to_string(),
+                    intersecting: true,
+                }],
+            );
+            assert!(planner.contains_sample_hash(&[50], &options, "peer-a"));
+            assert!(!planner.contains_sample_hash(&[50], &options, "peer-b"));
+        }
+    }
+
+    #[test]
+    fn breaks_exact_cross_direction_fallback_ties_by_total_order() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new(
+            "z-below", "peer-z", 0, 40, 45, 40, 45, 5, 0,
+        ));
+        planner.put(ReplicationRange::new(
+            "a-above", "peer-a", 0, 55, 60, 55, 60, 5, 0,
+        ));
+        let options = SampleOptions {
+            now: 1_000,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            planner.get_samples(&[50], &options),
+            vec![LeaderSample {
+                hash: "peer-a".to_string(),
+                intersecting: false,
+            }],
+        );
+        assert!(planner.contains_sample_hash(&[50], &options, "peer-a"));
+        assert!(!planner.contains_sample_hash(&[50], &options, "peer-z"));
+    }
+
+    #[test]
+    fn keeps_metadata_ascending_within_descending_coordinate_groups() {
+        for (cursor, below_start, below_end) in [
+            (50, 40, 45),
+            // Exercise the wrapped descending fallback when no endpoint is
+            // directly below the cursor.
+            (5, MAX_U32 - 10, MAX_U32 - 5),
+        ] {
+            let mut planner = RangePlanner::new("u32");
+            planner.put(ReplicationRange::new(
+                "z-below",
+                "peer-z",
+                0,
+                below_start,
+                below_end,
+                below_start,
+                below_end,
+                5,
+                0,
+            ));
+            planner.put(ReplicationRange::new(
+                "a-below",
+                "peer-a",
+                0,
+                below_start,
+                below_end,
+                below_start,
+                below_end,
+                5,
+                0,
+            ));
+            planner.put(ReplicationRange::new(
+                "far-above",
+                "peer-m",
+                0,
+                100,
+                105,
+                100,
+                105,
+                5,
+                0,
+            ));
+            let options = SampleOptions {
+                now: 1_000,
+                ..Default::default()
+            };
+
+            assert_eq!(
+                planner.get_samples(&[cursor], &options),
+                vec![LeaderSample {
+                    hash: "peer-a".to_string(),
+                    intersecting: false,
+                }],
+            );
+            assert!(planner.contains_sample_hash(&[cursor], &options, "peer-a"));
+            assert!(!planner.contains_sample_hash(&[cursor], &options, "peer-z"));
+        }
     }
 
     #[test]

--- a/packages/programs/data/shared-log/rust/test/node.parity.ts
+++ b/packages/programs/data/shared-log/rust/test/node.parity.ts
@@ -20,7 +20,9 @@ type AnyRange = {
 	mode: number;
 };
 type SharedLogModules = {
-	bytesToNumber: (resolution: Resolution) => (bytes: Uint8Array) => number | bigint;
+	bytesToNumber: (
+		resolution: Resolution,
+	) => (bytes: Uint8Array) => number | bigint;
 	createNumbers: (resolution: Resolution) => any;
 	denormalizer: (resolution: Resolution) => (value: number) => number | bigint;
 	ReplicationIntent: {
@@ -48,10 +50,8 @@ const loadSharedLog = async (): Promise<SharedLogModules> => {
 	if (!sharedLog) {
 		const integersPath = "../../../dist/src/integers.js";
 		const rangesPath = "../../../dist/src/ranges.js";
-		const [{ bytesToNumber, createNumbers, denormalizer }, ranges] = await Promise.all([
-			import(integersPath),
-			import(rangesPath),
-		]);
+		const [{ bytesToNumber, createNumbers, denormalizer }, ranges] =
+			await Promise.all([import(integersPath), import(rangesPath)]);
 		sharedLog = {
 			bytesToNumber,
 			createNumbers,
@@ -105,6 +105,29 @@ const createRange = (
 	});
 };
 
+const createExactRange = (
+	resolution: Resolution,
+	properties: {
+		id: number;
+		hash: string;
+		offset: number;
+		width: number;
+		timestamp?: bigint;
+		mode?: number;
+	},
+): AnyRange => {
+	const value = (input: number) =>
+		resolution === "u32" ? input : BigInt(input);
+	return new (rangeClass(resolution) as any)({
+		id: deterministicId(properties.id),
+		publicKeyHash: properties.hash,
+		offset: value(properties.offset),
+		width: value(properties.width),
+		timestamp: properties.timestamp,
+		mode: properties.mode,
+	});
+};
+
 const toNativeRange = (range: AnyRange): NativeReplicationRange => ({
 	id: range.idString,
 	hash: range.hash,
@@ -117,8 +140,9 @@ const toNativeRange = (range: AnyRange): NativeReplicationRange => ({
 	mode: range.mode,
 });
 
-const mapEntries = (map: Map<string, { intersecting: boolean }>) =>
-	[...map.entries()];
+const mapEntries = (map: Map<string, { intersecting: boolean }>) => [
+	...map.entries(),
+];
 
 const sortedMapEntries = (map: Map<string, { intersecting: boolean }>) =>
 	mapEntries(map).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
@@ -209,6 +233,7 @@ const expectNativeParity = async (
 			mapEntries(actual),
 			properties.message,
 		);
+		return actual;
 	} finally {
 		await indices.stop();
 	}
@@ -392,6 +417,77 @@ describe("native shared-log range planner parity", () => {
 			});
 		});
 
+		it(`matches exact cross-direction fallback ties for ${resolution}`, async () => {
+			const below = createExactRange(resolution, {
+				id: 1,
+				hash: "peer-z",
+				offset: 40,
+				width: 5,
+				timestamp: 0n,
+			});
+			const above = createExactRange(resolution, {
+				id: 2,
+				hash: "peer-a",
+				offset: 55,
+				width: 5,
+				timestamp: 0n,
+			});
+			const cursor = resolution === "u32" ? 50 : 50n;
+
+			for (const ranges of [
+				[below, above],
+				[above, below],
+			]) {
+				const actual = await expectNativeParity(resolution, {
+					ranges,
+					cursors: [cursor],
+					ignoreOrder: true,
+				});
+				expect(mapEntries(actual)).to.deep.equal([
+					["peer-a", { intersecting: false }],
+				]);
+			}
+		});
+
+		it(`keeps metadata ascending within a descending coordinate tie for ${resolution}`, async () => {
+			const belowA = createExactRange(resolution, {
+				id: 1,
+				hash: "peer-a",
+				offset: 40,
+				width: 5,
+				timestamp: 0n,
+			});
+			const belowZ = createExactRange(resolution, {
+				id: 2,
+				hash: "peer-z",
+				offset: 40,
+				width: 5,
+				timestamp: 0n,
+			});
+			const fartherAbove = createExactRange(resolution, {
+				id: 3,
+				hash: "peer-m",
+				offset: 100,
+				width: 5,
+				timestamp: 0n,
+			});
+			const cursor = resolution === "u32" ? 50 : 50n;
+
+			for (const ranges of [
+				[belowA, belowZ, fartherAbove],
+				[belowZ, belowA, fartherAbove],
+			]) {
+				const actual = await expectNativeParity(resolution, {
+					ranges,
+					cursors: [cursor],
+					ignoreOrder: true,
+				});
+				expect(mapEntries(actual)).to.deep.equal([
+					["peer-a", { intersecting: false }],
+				]);
+			}
+		});
+
 		it(`matches TypeScript only-intersecting behavior for ${resolution}`, async () => {
 			const ranges = [
 				createRange(resolution, {
@@ -452,6 +548,47 @@ describe("native shared-log range planner parity", () => {
 				cursors: [denormalize(0.5)],
 				roleAge,
 			});
+		});
+
+		it(`counts mature evidence for an existing owner in any put order for ${resolution}`, async () => {
+			const now = Date.now();
+			const immature = createExactRange(resolution, {
+				id: 1,
+				hash: "peer-a",
+				offset: 40,
+				width: 20,
+				timestamp: BigInt(now + MATURITY_MARGIN_MS),
+			});
+			const mature = createExactRange(resolution, {
+				id: 2,
+				hash: "peer-a",
+				offset: 40,
+				width: 20,
+				timestamp: 0n,
+			});
+			const fallback = createExactRange(resolution, {
+				id: 3,
+				hash: "peer-b",
+				offset: 70,
+				width: 10,
+				timestamp: 0n,
+			});
+			const cursor = resolution === "u32" ? 50 : 50n;
+
+			for (const ranges of [
+				[immature, mature, fallback],
+				[mature, immature, fallback],
+			]) {
+				const actual = await expectNativeParity(resolution, {
+					ranges,
+					cursors: [cursor],
+					roleAge: 100,
+					ignoreOrder: true,
+				});
+				expect(mapEntries(actual)).to.deep.equal([
+					["peer-a", { intersecting: true }],
+				]);
+			}
 		});
 
 		it(`matches TypeScript boundary maturity classification around the cutoff for ${resolution}`, async () => {

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -1813,13 +1813,44 @@ const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
 	direction: "above" | "below" | "closest",
 	numbers: Numbers<R>,
 ): IndexIterator<ReplicationRangeIndexable<R>, S> => {
+	type QueuedResult = {
+		result: IndexedResult<ReturnTypeFromShape<ReplicationRangeIndexable<R>, S>>;
+		dist: NumberFromType<R>;
+	};
+
+	const compareQueuedResults = (left: QueuedResult, right: QueuedResult) => {
+		if (left.dist < right.dist) return -1;
+		if (left.dist > right.dist) return 1;
+
+		// Match the native closest-range total order. The shaped iterator users do
+		// not always project every tie field, so only compare a field when both
+		// results carry it; getSamples uses complete ranges and therefore always
+		// follows distance, timestamp, owner hash, then range id.
+		const leftValue = left.result.value as Partial<
+			ReplicationRangeIndexable<R>
+		>;
+		const rightValue = right.result.value as Partial<
+			ReplicationRangeIndexable<R>
+		>;
+		if (leftValue.timestamp != null && rightValue.timestamp != null) {
+			if (leftValue.timestamp < rightValue.timestamp) return -1;
+			if (leftValue.timestamp > rightValue.timestamp) return 1;
+		}
+		if (leftValue.hash != null && rightValue.hash != null) {
+			if (leftValue.hash < rightValue.hash) return -1;
+			if (leftValue.hash > rightValue.hash) return 1;
+		}
+		const leftId = leftValue.id == null ? undefined : toBase64(leftValue.id);
+		const rightId = rightValue.id == null ? undefined : toBase64(rightValue.id);
+		if (leftId != null && rightId != null) {
+			if (leftId < rightId) return -1;
+			if (leftId > rightId) return 1;
+		}
+		return 0;
+	};
+
 	let queues: {
-		elements: {
-			result: IndexedResult<
-				ReturnTypeFromShape<ReplicationRangeIndexable<R>, S>
-			>;
-			dist: NumberFromType<R>;
-		}[];
+		elements: QueuedResult[];
 	}[] = [];
 
 	return {
@@ -1887,13 +1918,16 @@ const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
 
 			for (let i = 0; i < count; i++) {
 				let closestQueue = -1;
-				let closestDist: bigint | number = Number.MAX_VALUE;
+				let selected: QueuedResult | undefined;
 				for (let j = 0; j < queues.length; j++) {
 					let queue = queues[j];
 					if (queue && queue.elements.length > 0) {
-						let closest = queue.elements[0];
-						if (closest.dist < closestDist) {
-							closestDist = closest.dist;
+						const candidate = queue.elements[0];
+						if (
+							candidate &&
+							(!selected || compareQueuedResults(candidate, selected) < 0)
+						) {
+							selected = candidate;
 							closestQueue = j;
 						}
 					}
@@ -1903,7 +1937,7 @@ const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
 					break;
 				}
 
-				let closest = queues[closestQueue]?.elements.shift();
+				const closest = queues[closestQueue]?.elements.shift();
 				if (closest) {
 					results.push(closest.result);
 				}
@@ -2131,7 +2165,7 @@ export const getSamples = async <R extends "u32" | "u64">(
 	}
 
 	const now = +new Date();
-	let matured = 0;
+	const matureOwners = new Set<string>();
 
 	let uniqueVisited = new Set<string>();
 	const peerFilter = options?.peerFilter;
@@ -2149,10 +2183,10 @@ export const getSamples = async <R extends "u32" | "u64">(
 			}
 			uniqueVisited.add(rect.value.hash);
 			let prev = leaders.get(rect.value.hash);
+			if (isMatured(rect.value, now, roleAge)) {
+				matureOwners.add(rect.value.hash);
+			}
 			if (!prev) {
-				if (isMatured(rect.value, now, roleAge)) {
-					matured++;
-				}
 				leaders.set(rect.value.hash, { intersecting: true });
 			} else {
 				prev.intersecting = true;
@@ -2168,7 +2202,7 @@ export const getSamples = async <R extends "u32" | "u64">(
 			}
 		}
 
-		if (options?.onlyIntersecting || matured > i) {
+		if (options?.onlyIntersecting || matureOwners.size > i) {
 			continue;
 		}
 
@@ -2183,11 +2217,11 @@ export const getSamples = async <R extends "u32" | "u64">(
 				uniqueVisited.add(rect.hash);
 				const prev = leaders.get(rect.hash);
 				if (m) {
+					matureOwners.add(rect.hash);
 					if (!prev) {
-						matured++;
 						leaders.set(rect.hash, { intersecting: false });
 					}
-					if (matured > i) {
+					if (matureOwners.size > i) {
 						foundOneUniqueMatured = true;
 					}
 				}

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -1446,6 +1446,43 @@ resolutions.forEach((resolution) => {
 					});
 				});
 
+				it("uses the native total order for an exact below-above tie", async () => {
+					const [lowerHashOwner, higherHashOwner] = [a, c].sort(
+						(left, right) => (left.hashcode() < right.hashcode() ? -1 : 1),
+					);
+					const below = createReplicationRange({
+						id: new Uint8Array([1]),
+						publicKey: higherHashOwner,
+						offset: 40,
+						width: 5,
+						timestamp: 0n,
+					});
+					const above = createReplicationRange({
+						id: new Uint8Array([2]),
+						publicKey: lowerHashOwner,
+						offset: 55,
+						width: 5,
+						timestamp: 0n,
+					});
+
+					for (const ranges of [
+						[below, above],
+						[above, below],
+					]) {
+						await create(...ranges);
+						const leaders = await getSamplesMap(
+							[coerceNumber(50)],
+							peers,
+							0,
+							numbers,
+						);
+
+						expect([...leaders.entries()]).to.deep.equal([
+							[lowerHashOwner.hashcode(), { intersecting: false }],
+						]);
+					}
+				});
+
 				it("factor 0 ", async () => {
 					await create(
 						createReplicationRangeFromNormalized({
@@ -1577,6 +1614,47 @@ resolutions.forEach((resolution) => {
 				});
 
 				describe("maturity", () => {
+					it("counts mature evidence for an existing owner in any input order", async () => {
+						for (const immatureFirst of [true, false]) {
+							const immature = createReplicationRange({
+								id: new Uint8Array([1]),
+								publicKey: a,
+								offset: 40,
+								width: 20,
+								timestamp: BigInt(Date.now() + 60_000),
+							});
+							const mature = createReplicationRange({
+								id: new Uint8Array([2]),
+								publicKey: a,
+								offset: 40,
+								width: 20,
+								timestamp: 0n,
+							});
+							const fallback = createReplicationRange({
+								id: new Uint8Array([3]),
+								publicKey: b,
+								offset: 70,
+								width: 10,
+								timestamp: 0n,
+							});
+							await create(
+								...(immatureFirst
+									? [immature, mature, fallback]
+									: [mature, immature, fallback]),
+							);
+
+							const leaders = await getSamplesMap(
+								[coerceNumber(50)],
+								peers,
+								100,
+								numbers,
+							);
+							expect([...leaders.entries()]).to.deep.equal([
+								[a.hashcode(), { intersecting: true }],
+							]);
+						}
+					});
+
 					it("starting at unmatured", async () => {
 						await create(
 							createReplicationRangeFromNormalized({


### PR DESCRIPTION
## Summary

- count mature placement evidence per owner in both TypeScript and Rust, regardless of which overlapping range is observed first
- keep Rust's optimized membership check aligned with full leader selection
- make TypeScript closest-range ties use the native total order: distance, timestamp, owner hash, then range ID
- fix Rust descending coordinate searches so equal-coordinate candidates keep metadata ascending, including wrapped fallback
- add direct JS, Rust-core, and u32/u64 JS-to-WASM parity regressions

Stacked on #1296. The repository's master-only changeset/build guards remain red for stacked PR bases and will become actionable when this slice is retargeted after its parent lands.

## Runtime compatibility

This intentionally corrects placement behavior in mixed-maturity and exact-tie corner cases where JavaScript and Rust could already disagree. The shared closest-iterator tie rule also affects related closest/cover/adjacency consumers.

Mixed old/new deployments can therefore disagree on these corner cases. The future bounded planner must bind an explicit planner semantic version in the placement-view digest.

## Scope boundary

This is a semantics/parity fix, not the bounded planner. It does not remove existing Index `.all()` paths, the native fallback's quadratic worst case, containment-bucket amplification, or add transfer/receipt/prune behavior.

## Tests

- Rust core: 31/31
- shared-log ranges: 1504/1504
- native planner/parity: 132/132
- focused u32/u64 differential regressions: 6/6
- TypeScript builds for both packages
- ESLint and Prettier
- `cargo fmt --check`
- shard coverage guard
- `git diff --check`