### PR TITLE
perf(shared-log): bound native fallback planning

### DIFF
--- a/.changeset/linear-native-fallback-streams.md
+++ b/.changeset/linear-native-fallback-streams.md
@@ -1,0 +1,16 @@
+---
+"@peerbit/shared-log": patch
+"@peerbit/shared-log-rust": patch
+"@peerbit/native-backbone": patch
+---
+
+Bound native shared-log fallback sampling to linear endpoint-index work per
+cursor while preserving deterministic owner selection. Replace the synthetic
+maximum metadata sentinel with coordinate-only partitions so maximum-timestamp,
+high-Unicode identifiers remain in their correct fallback segment, and apply
+metadata tie-breaking across circularly aliased zero/MAX endpoints. Split the
+TypeScript directional fallback into disjoint monotone phases, treat exact
+directional equality as zero distance, and exclude the current range from
+same-owner adjacency queries. Keep prefetched join rows visible to iterator
+completion and pending counts so batched fallback scans cannot truncate them,
+drain `all()` through the ordered merge, and release buffered rows on close.

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -2,6 +2,8 @@ use indexmap::{IndexMap, IndexSet};
 use js_sys::{Array, BigUint64Array, Uint8Array};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
+use std::collections::btree_map::Range as BTreeMapRange;
+use std::collections::btree_set::Iter as BTreeSetIter;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ops::Bound::{Excluded, Unbounded};
 use std::ops::ControlFlow;
@@ -154,8 +156,8 @@ pub struct SampleOptions {
 pub struct RangePlanner {
     resolution: Resolution,
     ranges: IndexMap<String, ReplicationRange>,
-    by_start1: BTreeSet<RangeIndexKey>,
-    by_end2: BTreeSet<RangeIndexKey>,
+    by_start1: BTreeMap<u64, BTreeSet<RangeIndexKey>>,
+    by_end2: BTreeMap<u64, BTreeSet<RangeIndexKey>>,
     containment_buckets: Vec<IndexSet<String>>,
     wide_containment_ranges: IndexSet<String>,
     containment_put_order: IndexSet<String>,
@@ -171,56 +173,25 @@ enum ContainmentIndexLocation {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RangeIndexKey {
-    value: u64,
     timestamp: u64,
     hash: String,
     id: String,
 }
 
 impl RangeIndexKey {
-    fn start(range: &ReplicationRange) -> Self {
+    fn from_range(range: &ReplicationRange) -> Self {
         Self {
-            value: range.start1,
             timestamp: range.timestamp,
             hash: range.hash.clone(),
             id: range.id.clone(),
-        }
-    }
-
-    fn end(range: &ReplicationRange) -> Self {
-        Self {
-            value: range.end2,
-            timestamp: range.timestamp,
-            hash: range.hash.clone(),
-            id: range.id.clone(),
-        }
-    }
-
-    fn min_at(value: u64) -> Self {
-        Self {
-            value,
-            timestamp: 0,
-            hash: String::new(),
-            id: String::new(),
-        }
-    }
-
-    fn max_at(value: u64) -> Self {
-        let max_string = char::MAX.to_string();
-        Self {
-            value,
-            timestamp: u64::MAX,
-            hash: max_string.clone(),
-            id: max_string,
         }
     }
 }
 
 impl Ord for RangeIndexKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.value
-            .cmp(&other.value)
-            .then_with(|| self.timestamp.cmp(&other.timestamp))
+        self.timestamp
+            .cmp(&other.timestamp)
             .then_with(|| self.hash.cmp(&other.hash))
             .then_with(|| self.id.cmp(&other.id))
     }
@@ -229,6 +200,198 @@ impl Ord for RangeIndexKey {
 impl PartialOrd for RangeIndexKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FallbackCoordinateOrder {
+    Ascending,
+    Descending,
+}
+
+struct FallbackKeyStream<'a> {
+    primary: BTreeMapRange<'a, u64, BTreeSet<RangeIndexKey>>,
+    wrap: BTreeMapRange<'a, u64, BTreeSet<RangeIndexKey>>,
+    order: FallbackCoordinateOrder,
+    metadata: Option<BTreeSetIter<'a, RangeIndexKey>>,
+    head: Option<&'a RangeIndexKey>,
+    #[cfg(test)]
+    key_advances: usize,
+}
+
+impl<'a> FallbackKeyStream<'a> {
+    fn ascending(
+        index: &'a BTreeMap<u64, BTreeSet<RangeIndexKey>>,
+        point: u64,
+        max_value: u64,
+    ) -> Self {
+        if point == max_value {
+            // circular_distance aliases 0 and MAX. At MAX, descending exposes
+            // MAX while this stream exposes 0 so metadata can break the tie.
+            Self::new(
+                index.range(..point),
+                index.range(point..),
+                FallbackCoordinateOrder::Ascending,
+            )
+        } else {
+            Self::new(
+                index.range(point..),
+                index.range(..point),
+                FallbackCoordinateOrder::Ascending,
+            )
+        }
+    }
+
+    fn descending(index: &'a BTreeMap<u64, BTreeSet<RangeIndexKey>>, point: u64) -> Self {
+        if point == 0 {
+            // At 0, ascending exposes 0 while this stream exposes MAX.
+            Self::new(
+                index.range((Excluded(point), Unbounded)),
+                index.range(..=point),
+                FallbackCoordinateOrder::Descending,
+            )
+        } else {
+            Self::new(
+                index.range(..=point),
+                index.range((Excluded(point), Unbounded)),
+                FallbackCoordinateOrder::Descending,
+            )
+        }
+    }
+
+    fn new(
+        primary: BTreeMapRange<'a, u64, BTreeSet<RangeIndexKey>>,
+        wrap: BTreeMapRange<'a, u64, BTreeSet<RangeIndexKey>>,
+        order: FallbackCoordinateOrder,
+    ) -> Self {
+        Self {
+            primary,
+            wrap,
+            order,
+            metadata: None,
+            head: None,
+            #[cfg(test)]
+            key_advances: 0,
+        }
+    }
+
+    fn next_coordinate_group(&mut self) -> Option<&'a BTreeSet<RangeIndexKey>> {
+        let row = match self.order {
+            FallbackCoordinateOrder::Ascending => self.primary.next().or_else(|| self.wrap.next()),
+            FallbackCoordinateOrder::Descending => {
+                self.primary.next_back().or_else(|| self.wrap.next_back())
+            }
+        };
+        row.map(|(_, metadata)| metadata)
+    }
+
+    fn next_key(&mut self) -> Option<&'a RangeIndexKey> {
+        loop {
+            if let Some(metadata) = &mut self.metadata {
+                if let Some(key) = metadata.next() {
+                    #[cfg(test)]
+                    {
+                        self.key_advances += 1;
+                    }
+                    return Some(key);
+                }
+            }
+            self.metadata = Some(self.next_coordinate_group()?.iter());
+        }
+    }
+
+    fn peek_candidate(
+        &mut self,
+        planner: &'a RangePlanner,
+        peer_filter: Option<&HashSet<String>>,
+        seen_ids: &HashSet<String>,
+    ) -> Option<&'a ReplicationRange> {
+        loop {
+            if let Some(key) = self.head {
+                if let Some(range) = planner.candidate_from_key(key, peer_filter, seen_ids) {
+                    return Some(range);
+                }
+                self.head = None;
+            }
+            let key = self.next_key()?;
+            self.head = Some(key);
+        }
+    }
+}
+
+struct FallbackCandidateStreams<'a> {
+    streams: [FallbackKeyStream<'a>; 4],
+    seen_ids: HashSet<String>,
+    point: u64,
+    max_value: u64,
+    #[cfg(test)]
+    candidate_head_visits: usize,
+}
+
+impl<'a> FallbackCandidateStreams<'a> {
+    fn new(planner: &'a RangePlanner, point: u64) -> Self {
+        let max_value = planner.resolution.max_value();
+        Self {
+            streams: [
+                FallbackKeyStream::ascending(&planner.by_start1, point, max_value),
+                FallbackKeyStream::descending(&planner.by_start1, point),
+                FallbackKeyStream::ascending(&planner.by_end2, point, max_value),
+                FallbackKeyStream::descending(&planner.by_end2, point),
+            ],
+            seen_ids: HashSet::new(),
+            point,
+            max_value,
+            #[cfg(test)]
+            candidate_head_visits: 0,
+        }
+    }
+
+    fn pop_closest(
+        &mut self,
+        planner: &'a RangePlanner,
+        peer_filter: Option<&HashSet<String>>,
+    ) -> Option<&'a ReplicationRange> {
+        let mut best: Option<&ReplicationRange> = None;
+        #[cfg(test)]
+        let mut candidate_head_visits = 0usize;
+
+        for stream in &mut self.streams {
+            let Some(range) = stream.peek_candidate(planner, peer_filter, &self.seen_ids) else {
+                continue;
+            };
+            #[cfg(test)]
+            {
+                candidate_head_visits += 1;
+            }
+            if best.is_none_or(|previous| {
+                compare_closest(range, previous, self.point, self.max_value) == Ordering::Less
+            }) {
+                best = Some(range);
+            }
+        }
+
+        #[cfg(test)]
+        {
+            self.candidate_head_visits += candidate_head_visits;
+        }
+        let best = best?;
+        self.seen_ids.insert(best.id.clone());
+        Some(best)
+    }
+
+    #[cfg(test)]
+    fn key_advances(&self) -> usize {
+        self.streams.iter().map(|stream| stream.key_advances).sum()
+    }
+
+    #[cfg(test)]
+    fn candidate_head_visits(&self) -> usize {
+        self.candidate_head_visits
+    }
+
+    #[cfg(test)]
+    fn emitted_count(&self) -> usize {
+        self.seen_ids.len()
     }
 }
 
@@ -313,8 +476,8 @@ impl RangePlanner {
         Self {
             resolution: Resolution::from_str(resolution),
             ranges: IndexMap::new(),
-            by_start1: BTreeSet::new(),
-            by_end2: BTreeSet::new(),
+            by_start1: BTreeMap::new(),
+            by_end2: BTreeMap::new(),
             containment_buckets: vec![IndexSet::new(); CONTAINMENT_BUCKETS],
             wide_containment_ranges: IndexSet::new(),
             containment_put_order: IndexSet::new(),
@@ -387,7 +550,10 @@ impl RangePlanner {
     /// matches append in closest-distance order. The TypeScript getSamples
     /// inherits unordered sqlite results behind a timing-driven index picker,
     /// so identical calls can answer in different orders there; downstream
-    /// consumers must only rely on membership.
+    /// consumers must only rely on membership. With P caller-side peer
+    /// preparation work, C cursors, K containment candidates per cursor, and N
+    /// fallback-indexed ranges, selection is O(P + C * (K + 4N)): each cursor's
+    /// four endpoint streams advance every fallback key at most once.
     pub fn get_samples(&self, cursors: &[u64], options: &SampleOptions) -> Vec<LeaderSample> {
         let mut leaders: IndexMap<String, bool> = IndexMap::new();
         let mut mature_owners: HashSet<String> = HashSet::new();
@@ -428,11 +594,8 @@ impl RangePlanner {
                 continue;
             }
 
-            let mut seen_closest_ids = HashSet::new();
-            while let Some(range) =
-                self.closest_non_strict(point, options.peer_filter.as_ref(), &seen_closest_ids)
-            {
-                seen_closest_ids.insert(range.id.clone());
+            let mut fallback = FallbackCandidateStreams::new(self, point);
+            while let Some(range) = fallback.pop_closest(self, options.peer_filter.as_ref()) {
                 unique_visited.insert(range.hash.clone());
                 if !range.is_matured(options.now, options.role_age_ms) {
                     continue;
@@ -499,11 +662,8 @@ impl RangePlanner {
                 continue;
             }
 
-            let mut seen_closest_ids = HashSet::new();
-            while let Some(range) =
-                self.closest_non_strict(point, options.peer_filter.as_ref(), &seen_closest_ids)
-            {
-                seen_closest_ids.insert(range.id.clone());
+            let mut fallback = FallbackCandidateStreams::new(self, point);
+            while let Some(range) = fallback.pop_closest(self, options.peer_filter.as_ref()) {
                 if range.hash == target_hash && range.is_matured(options.now, options.role_age_ms) {
                     return true;
                 }
@@ -704,8 +864,9 @@ impl RangePlanner {
 
     fn index_range(&mut self, range: &ReplicationRange) {
         if Self::is_fallback_indexed(range) {
-            self.by_start1.insert(RangeIndexKey::start(range));
-            self.by_end2.insert(RangeIndexKey::end(range));
+            let key = RangeIndexKey::from_range(range);
+            Self::index_fallback_endpoint(&mut self.by_start1, range.start1, key.clone());
+            Self::index_fallback_endpoint(&mut self.by_end2, range.end2, key);
         }
         if Self::is_containment_indexed(range) {
             self.index_containment_range(range);
@@ -718,8 +879,9 @@ impl RangePlanner {
 
     fn unindex_range(&mut self, range: &ReplicationRange) {
         if Self::is_fallback_indexed(range) {
-            self.by_start1.remove(&RangeIndexKey::start(range));
-            self.by_end2.remove(&RangeIndexKey::end(range));
+            let key = RangeIndexKey::from_range(range);
+            Self::unindex_fallback_endpoint(&mut self.by_start1, range.start1, &key);
+            Self::unindex_fallback_endpoint(&mut self.by_end2, range.end2, &key);
         }
         if Self::is_containment_indexed(range) {
             self.unindex_containment_range(range);
@@ -729,6 +891,28 @@ impl RangePlanner {
             if stats.is_empty() {
                 self.peer_ranges.swap_remove(&range.hash);
             }
+        }
+    }
+
+    fn index_fallback_endpoint(
+        index: &mut BTreeMap<u64, BTreeSet<RangeIndexKey>>,
+        coordinate: u64,
+        key: RangeIndexKey,
+    ) {
+        index.entry(coordinate).or_default().insert(key);
+    }
+
+    fn unindex_fallback_endpoint(
+        index: &mut BTreeMap<u64, BTreeSet<RangeIndexKey>>,
+        coordinate: u64,
+        key: &RangeIndexKey,
+    ) {
+        let remove_coordinate = index.get_mut(&coordinate).is_some_and(|keys| {
+            keys.remove(key);
+            keys.is_empty()
+        });
+        if remove_coordinate {
+            index.remove(&coordinate);
         }
     }
 
@@ -929,139 +1113,6 @@ impl RangePlanner {
             return None;
         }
         Some(range)
-    }
-
-    fn first_candidate_from_keys<'a, I>(
-        &'a self,
-        keys: I,
-        peer_filter: Option<&HashSet<String>>,
-        seen_ids: &HashSet<String>,
-    ) -> Option<&'a ReplicationRange>
-    where
-        I: IntoIterator<Item = &'a RangeIndexKey>,
-    {
-        keys.into_iter()
-            .find_map(|key| self.candidate_from_key(key, peer_filter, seen_ids))
-    }
-
-    fn first_candidate_from_descending_key_groups<'a, I>(
-        &'a self,
-        keys: I,
-        peer_filter: Option<&HashSet<String>>,
-        seen_ids: &HashSet<String>,
-    ) -> Option<&'a ReplicationRange>
-    where
-        I: IntoIterator<Item = &'a RangeIndexKey>,
-    {
-        let mut current_value = None;
-        let mut best = None;
-        for key in keys {
-            if current_value != Some(key.value) {
-                if best.is_some() {
-                    return best;
-                }
-                current_value = Some(key.value);
-            }
-            // The keys arrive in full reverse order: coordinate descending and
-            // metadata descending. Keep replacing within one coordinate group
-            // so the last eligible row is the metadata-lowest candidate.
-            if let Some(candidate) = self.candidate_from_key(key, peer_filter, seen_ids) {
-                best = Some(candidate);
-            }
-        }
-        best
-    }
-
-    fn closest_start_candidate(
-        &self,
-        point: u64,
-        above: bool,
-        peer_filter: Option<&HashSet<String>>,
-        seen_ids: &HashSet<String>,
-    ) -> Option<&ReplicationRange> {
-        if above {
-            self.first_candidate_from_keys(
-                self.by_start1.range(RangeIndexKey::min_at(point)..),
-                peer_filter,
-                seen_ids,
-            )
-            .or_else(|| {
-                self.first_candidate_from_keys(self.by_start1.iter(), peer_filter, seen_ids)
-            })
-        } else {
-            self.first_candidate_from_descending_key_groups(
-                self.by_start1.range(..=RangeIndexKey::max_at(point)).rev(),
-                peer_filter,
-                seen_ids,
-            )
-            .or_else(|| {
-                self.first_candidate_from_descending_key_groups(
-                    self.by_start1.iter().rev(),
-                    peer_filter,
-                    seen_ids,
-                )
-            })
-        }
-    }
-
-    fn closest_end_candidate(
-        &self,
-        point: u64,
-        above: bool,
-        peer_filter: Option<&HashSet<String>>,
-        seen_ids: &HashSet<String>,
-    ) -> Option<&ReplicationRange> {
-        if above {
-            self.first_candidate_from_keys(
-                self.by_end2.range(RangeIndexKey::min_at(point)..),
-                peer_filter,
-                seen_ids,
-            )
-            .or_else(|| self.first_candidate_from_keys(self.by_end2.iter(), peer_filter, seen_ids))
-        } else {
-            self.first_candidate_from_descending_key_groups(
-                self.by_end2.range(..=RangeIndexKey::max_at(point)).rev(),
-                peer_filter,
-                seen_ids,
-            )
-            .or_else(|| {
-                self.first_candidate_from_descending_key_groups(
-                    self.by_end2.iter().rev(),
-                    peer_filter,
-                    seen_ids,
-                )
-            })
-        }
-    }
-
-    fn closest_non_strict(
-        &self,
-        point: u64,
-        peer_filter: Option<&HashSet<String>>,
-        seen_ids: &HashSet<String>,
-    ) -> Option<&ReplicationRange> {
-        let max_value = self.resolution.max_value();
-        let mut best: Option<&ReplicationRange> = None;
-
-        for range in [
-            self.closest_start_candidate(point, true, peer_filter, seen_ids),
-            self.closest_start_candidate(point, false, peer_filter, seen_ids),
-            self.closest_end_candidate(point, true, peer_filter, seen_ids),
-            self.closest_end_candidate(point, false, peer_filter, seen_ids),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            if let Some(previous) = best {
-                if compare_closest(range, previous, point, max_value) == Ordering::Less {
-                    best = Some(range);
-                }
-            } else {
-                best = Some(range);
-            }
-        }
-
-        best
     }
 }
 
@@ -4758,13 +4809,16 @@ fn samples_to_rows(samples: Vec<LeaderSample>) -> Array {
 #[cfg(test)]
 mod tests {
     use super::{
-        find_leaders_with_prepared_options, ContainmentIndexLocation, EntryCoordinateState,
-        LeaderSample, NativeSharedLogState, RangePlanner, RebalanceCollisionBucketLimits,
+        compare_closest, find_leaders_with_prepared_options, ContainmentIndexLocation,
+        EntryCoordinateState, FallbackCandidateStreams, FallbackKeyStream, LeaderSample,
+        NativeSharedLogState, RangePlanner, RebalanceCollisionBucketLimits,
         RebalanceCollisionBucketOverflow, RebalanceCollisionBucketPreflight, ReplicationRange,
         SampleOptions, SharedLogError, CONTAINMENT_BUCKETS, CONTAINMENT_RETAINED_CAPACITY_RATIO,
         CONTAINMENT_RETAINED_CAPACITY_SLACK, MAX_CONTAINMENT_BUCKETS_PER_RANGE, MAX_U32, MAX_U64,
+        MODE_NON_STRICT,
     };
     use indexmap::IndexSet;
+    use std::collections::HashSet;
 
     fn rebalance_bucket_limits() -> RebalanceCollisionBucketLimits {
         RebalanceCollisionBucketLimits {
@@ -4809,6 +4863,51 @@ mod tests {
             planner.containment_live_reference_count(),
             planner.nonempty_containment_set_count(),
         );
+    }
+
+    fn fallback_stream_ids(
+        planner: &RangePlanner,
+        point: u64,
+        peer_filter: Option<&HashSet<String>>,
+    ) -> (Vec<String>, usize, usize) {
+        let mut fallback = FallbackCandidateStreams::new(planner, point);
+        let mut ids = Vec::new();
+        while let Some(range) = fallback.pop_closest(planner, peer_filter) {
+            ids.push(range.id.clone());
+        }
+        assert_eq!(fallback.emitted_count(), ids.len());
+        (
+            ids,
+            fallback.key_advances(),
+            fallback.candidate_head_visits(),
+        )
+    }
+
+    fn reference_fallback_ids(
+        planner: &RangePlanner,
+        point: u64,
+        peer_filter: Option<&HashSet<String>>,
+    ) -> Vec<String> {
+        let mut ranges: Vec<_> = planner
+            .ranges
+            .values()
+            .filter(|range| {
+                range.width > 0
+                    && range.mode == MODE_NON_STRICT
+                    && peer_filter.is_none_or(|filter| filter.contains(&range.hash))
+            })
+            .collect();
+        ranges.sort_by(|left, right| {
+            compare_closest(left, right, point, planner.resolution.max_value())
+        });
+        ranges.into_iter().map(|range| range.id.clone()).collect()
+    }
+
+    fn next_random(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
     }
 
     #[test]
@@ -5396,6 +5495,252 @@ mod tests {
             );
             assert!(planner.contains_sample_hash(&[cursor], &options, "peer-a"));
             assert!(!planner.contains_sample_hash(&[cursor], &options, "peer-z"));
+        }
+    }
+
+    #[test]
+    fn fallback_streams_match_total_order_reference_for_randomized_u32_u64_ranges() {
+        for resolution in ["u32", "u64"] {
+            let max_value = if resolution == "u32" {
+                MAX_U32
+            } else {
+                MAX_U64
+            };
+            let mut random = if resolution == "u32" {
+                0x1297_0000_0000_0032
+            } else {
+                0x1297_0000_0000_0064
+            };
+
+            for iteration in 0..24 {
+                let mut planner = RangePlanner::new(resolution);
+                for index in 0..256 {
+                    let mut start = next_random(&mut random);
+                    let mut end = next_random(&mut random);
+                    if resolution == "u32" {
+                        start &= MAX_U32;
+                        end &= MAX_U32;
+                    }
+                    if start == end {
+                        end = if end == max_value { 0 } else { end + 1 };
+                    }
+                    let (start1, end1, start2, end2, width) = if start < end {
+                        (start, end, start, end, end - start)
+                    } else {
+                        (
+                            start,
+                            max_value,
+                            0,
+                            end,
+                            max_value.saturating_sub(start).saturating_add(end),
+                        )
+                    };
+                    let selector = next_random(&mut random);
+                    planner.put(ReplicationRange::new(
+                        format!("range-{iteration}-{index}"),
+                        format!("peer-{}", selector % 17),
+                        next_random(&mut random) % 1_000,
+                        start1,
+                        end1,
+                        start2,
+                        end2,
+                        if selector.is_multiple_of(13) {
+                            0
+                        } else {
+                            width.max(1)
+                        },
+                        if selector.is_multiple_of(7) {
+                            1
+                        } else {
+                            MODE_NON_STRICT
+                        },
+                    ));
+                }
+
+                let point = match iteration {
+                    0 => 0,
+                    1 => max_value,
+                    _ => {
+                        let value = next_random(&mut random);
+                        if resolution == "u32" {
+                            value & MAX_U32
+                        } else {
+                            value
+                        }
+                    }
+                };
+                let filter = (iteration % 3 == 0).then(|| {
+                    (0..17)
+                        .filter(|owner| owner % 2 == 0)
+                        .map(|owner| format!("peer-{owner}"))
+                        .collect::<HashSet<_>>()
+                });
+
+                let (actual, key_advances, head_visits) =
+                    fallback_stream_ids(&planner, point, filter.as_ref());
+                let expected = reference_fallback_ids(&planner, point, filter.as_ref());
+                assert_eq!(actual, expected, "{resolution} iteration {iteration}");
+                assert!(key_advances <= 4 * planner.ranges.len());
+                assert!(head_visits <= 4 * actual.len());
+            }
+        }
+    }
+
+    #[test]
+    fn fallback_streams_bound_adversarial_immature_same_owner_work() {
+        const RANGE_COUNT: usize = 16_384;
+
+        let mut planner = RangePlanner::new("u32");
+        for index in 0..RANGE_COUNT {
+            let coordinate = index as u64 + 1;
+            planner.put(ReplicationRange::new(
+                format!("range-{index:05}"),
+                "peer-same",
+                if index + 1 == RANGE_COUNT { 0 } else { 950 },
+                coordinate,
+                coordinate + 1,
+                coordinate,
+                coordinate + 1,
+                1,
+                MODE_NON_STRICT,
+            ));
+        }
+        let options = SampleOptions {
+            now: 1_000,
+            role_age_ms: 100,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            planner.get_samples(&[0], &options),
+            vec![LeaderSample {
+                hash: "peer-same".to_string(),
+                intersecting: false,
+            }]
+        );
+        assert!(planner.contains_sample_hash(&[0], &options, "peer-same"));
+
+        let (ids, key_advances, head_visits) = fallback_stream_ids(&planner, 0, None);
+        assert_eq!(ids.len(), RANGE_COUNT);
+        assert_eq!(key_advances, 4 * RANGE_COUNT);
+        assert!(head_visits <= 4 * RANGE_COUNT);
+    }
+
+    #[test]
+    fn descending_fallback_partition_handles_max_unicode_metadata_and_wrap() {
+        for resolution in ["u32", "u64"] {
+            let max_value = if resolution == "u32" {
+                MAX_U32
+            } else {
+                MAX_U64
+            };
+            let point = 5;
+            let mut planner = RangePlanner::new(resolution);
+            planner.put(ReplicationRange::new(
+                "normal-at-point",
+                "peer-a",
+                0,
+                10,
+                max_value,
+                0,
+                point,
+                10,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                format!("{}-id-suffix", char::MAX),
+                format!("{}-hash-suffix", char::MAX),
+                MAX_U64,
+                10,
+                max_value,
+                0,
+                point,
+                10,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                "wrapped-coordinate",
+                "peer-wrap",
+                0,
+                10,
+                max_value,
+                0,
+                max_value - 1,
+                10,
+                MODE_NON_STRICT,
+            ));
+
+            let mut descending = FallbackKeyStream::descending(&planner.by_end2, point);
+            let ids: Vec<_> = std::iter::from_fn(|| descending.next_key())
+                .map(|key| key.id.clone())
+                .collect();
+            assert_eq!(
+                ids,
+                [
+                    "normal-at-point".to_string(),
+                    format!("{}-id-suffix", char::MAX),
+                    "wrapped-coordinate".to_string(),
+                ],
+                "{resolution}",
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_zero_max_aliases_use_total_metadata_order_for_u32_u64_apis() {
+        for resolution in ["u32", "u64"] {
+            let max_value = if resolution == "u32" {
+                MAX_U32
+            } else {
+                MAX_U64
+            };
+            let mut planner = RangePlanner::new(resolution);
+            planner.put(ReplicationRange::new(
+                "z-zero",
+                "peer-z",
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                "a-max",
+                "peer-a",
+                0,
+                max_value,
+                max_value,
+                max_value,
+                max_value,
+                1,
+                MODE_NON_STRICT,
+            ));
+            let options = SampleOptions {
+                now: 1_000,
+                ..Default::default()
+            };
+
+            for point in [0, max_value] {
+                let (ids, key_advances, head_visits) = fallback_stream_ids(&planner, point, None);
+                assert_eq!(ids, ["a-max", "z-zero"], "{resolution} point {point}");
+                assert_eq!(
+                    ids,
+                    reference_fallback_ids(&planner, point, None),
+                    "{resolution} point {point}",
+                );
+                assert_eq!(key_advances, 4 * planner.len());
+                assert!(head_visits <= 4 * planner.len());
+
+                assert_eq!(
+                    sample_hashes(planner.get_samples(&[point, point], &options)),
+                    ["peer-a", "peer-z"],
+                    "{resolution} point {point}",
+                );
+                assert!(planner.contains_sample_hash(&[point], &options, "peer-a"));
+                assert!(!planner.contains_sample_hash(&[point], &options, "peer-z"));
+            }
         }
     }
 

--- a/packages/programs/data/shared-log/rust/test/node.parity.ts
+++ b/packages/programs/data/shared-log/rust/test/node.parity.ts
@@ -110,14 +110,14 @@ const createExactRange = (
 	properties: {
 		id: number;
 		hash: string;
-		offset: number;
-		width: number;
+		offset: number | bigint;
+		width: number | bigint;
 		timestamp?: bigint;
 		mode?: number;
 	},
 ): AnyRange => {
-	const value = (input: number) =>
-		resolution === "u32" ? input : BigInt(input);
+	const value = (input: number | bigint) =>
+		resolution === "u32" ? Number(input) : BigInt(input);
 	return new (rangeClass(resolution) as any)({
 		id: deterministicId(properties.id),
 		publicKeyHash: properties.hash,
@@ -286,6 +286,113 @@ describe("native shared-log range planner parity", () => {
 				ranges,
 				cursors: numbers.getGrid(denormalize(0.5), 2),
 			});
+		});
+
+		it(`matches TypeScript zero/MAX alias fallback membership for ${resolution}`, async () => {
+			const rawEmptyRange = (
+				id: number,
+				hash: string,
+				coordinate: number | bigint,
+			) => {
+				const range = createExactRange(resolution, {
+					id,
+					hash,
+					offset: 0,
+					width: 1,
+				});
+				range.start1 = coordinate;
+				range.end1 = coordinate;
+				range.start2 = coordinate;
+				range.end2 = coordinate;
+				range.width = resolution === "u32" ? 1 : 1n;
+				return range;
+			};
+			const ranges = [
+				rawEmptyRange(240, "peer-z", numbers.zero),
+				rawEmptyRange(241, "peer-a", numbers.maxValue),
+			];
+
+			for (const cursor of [numbers.zero, numbers.maxValue]) {
+				const actual = await expectNativeParity(resolution, {
+					ranges,
+					cursors: [cursor],
+					ignoreOrder: true,
+					message: `${resolution} cursor ${String(cursor)}`,
+				});
+				expect(mapEntries(actual)).to.deep.equal([
+					["peer-a", { intersecting: false }],
+				]);
+			}
+		});
+
+		it(`matches TypeScript exact endpoint fallback membership for ${resolution}`, async () => {
+			const ten = resolution === "u32" ? 10 : 10n;
+			const highOffset =
+				resolution === "u32"
+					? Number(numbers.maxValue) - 10
+					: BigInt(numbers.maxValue) - 10n;
+			const fixtures = [
+				{
+					label: "zero/MAX alias",
+					ranges: [
+						createExactRange(resolution, {
+							id: 242,
+							hash: "z-low",
+							offset: numbers.zero,
+							width: ten,
+						}),
+						createExactRange(resolution, {
+							id: 243,
+							hash: "a-high",
+							offset: highOffset,
+							width: ten,
+						}),
+					],
+					cursor: numbers.maxValue,
+					expected: "a-high",
+				},
+				{
+					label: "ordinary exact endpoint",
+					ranges: [
+						createExactRange(resolution, {
+							id: 244,
+							hash: "a-exact",
+							offset: numbers.zero,
+							width: ten,
+						}),
+						createExactRange(resolution, {
+							id: 245,
+							hash: "z-next",
+							offset: resolution === "u32" ? 20 : 20n,
+							width: ten,
+						}),
+					],
+					cursor: ten,
+					expected: "a-exact",
+				},
+			];
+
+			for (const fixture of fixtures) {
+				expect(
+					fixture.ranges.every(
+						(range) =>
+							!(range as AnyRange & { contains(point: any): boolean }).contains(
+								fixture.cursor,
+							),
+					),
+					`${resolution} ${fixture.label} must exercise fallback`,
+				).to.be.true;
+				const actual = await expectNativeParity(resolution, {
+					ranges: fixture.ranges,
+					cursors: [fixture.cursor],
+					roleAge: 0,
+					ignoreOrder: true,
+					message: `${resolution} ${fixture.label}`,
+				});
+				expect(mapEntries(actual)).to.deep.equal([
+					[fixture.expected, { intersecting: false }],
+				]);
+			}
 		});
 
 		it(`matches TypeScript intersecting and peer filtering for ${resolution}`, async () => {

--- a/packages/programs/data/shared-log/src/ranges.ts
+++ b/packages/programs/data/shared-log/src/ranges.ts
@@ -1556,6 +1556,7 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 	options?: {
 		shape?: S;
 		hash?: string;
+		excludeId?: Uint8Array;
 		time?: {
 			roleAgeLimit: number;
 			matured: boolean;
@@ -1563,13 +1564,16 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 		};
 	},
 ): IndexIterator<ReplicationRangeIndexable<R>, S> => {
-	const createQueries = (p: NumberFromType<R>, equality: boolean) => {
+	const createQueries = (
+		p: NumberFromType<R>,
+		phase: "primary" | "wrapped",
+	) => {
 		let queries: Query[];
 		if (direction === "below") {
 			queries = [
 				new IntegerCompare({
 					key: "end2",
-					compare: equality ? Compare.LessOrEqual : Compare.Less,
+					compare: phase === "primary" ? Compare.LessOrEqual : Compare.Greater,
 					value: p,
 				}),
 			];
@@ -1577,7 +1581,7 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 			queries = [
 				new IntegerCompare({
 					key: "start1",
-					compare: equality ? Compare.GreaterOrEqual : Compare.Greater,
+					compare: phase === "primary" ? Compare.GreaterOrEqual : Compare.Less,
 					value: p,
 				}),
 			];
@@ -1611,6 +1615,16 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 		if (options?.hash) {
 			queries.push(new StringMatch({ key: "hash", value: options.hash }));
 		}
+		if (options?.excludeId) {
+			queries.push(
+				new Not(
+					new ByteMatchQuery({
+						key: "id",
+						value: options.excludeId,
+					}),
+				),
+			);
+		}
 		return queries;
 	};
 
@@ -1619,7 +1633,7 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 
 	const iterator = rects.iterate(
 		{
-			query: createQueries(point, false),
+			query: createQueries(point, "primary"),
 			sort: [
 				direction === "below"
 					? new Sort({ key: ["end2"], direction: "desc" })
@@ -1633,10 +1647,7 @@ const getClosest = <S extends Shape | undefined, R extends "u32" | "u64">(
 
 	const iteratorWrapped = rects.iterate(
 		{
-			query: createQueries(
-				direction === "below" ? numbers.maxValue : numbers.zero,
-				true,
-			),
+			query: createQueries(point, "wrapped"),
 			sort: [
 				direction === "below"
 					? new Sort({ key: ["end2"], direction: "desc" })
@@ -1781,10 +1792,11 @@ export function getDistance(
 		value < 0 ? -value : value;
 	const diff = <T extends number | bigint>(a: T, b: T): T => abs(a - b) as T;
 
+	if (from === to) {
+		return typeof from === "number" ? 0 : 0n;
+	}
+
 	if (direction === "closest") {
-		if (from === to) {
-			return typeof from === "number" ? 0 : 0n; // returns 0 of the correct type
-		}
 		return diff(from, to) < diff(end, diff(from, to))
 			? diff(from, to)
 			: diff(end, diff(from, to));
@@ -1807,7 +1819,11 @@ export function getDistance(
 	throw new Error("Invalid direction");
 }
 
-const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
+/** @internal */
+export const joinIterator = <
+	S extends Shape | undefined,
+	R extends "u32" | "u64",
+>(
 	iterators: IndexIterator<ReplicationRangeIndexable<R>, S>[],
 	point: NumberFromType<R>,
 	direction: "above" | "below" | "closest",
@@ -1853,7 +1869,7 @@ const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
 		elements: QueuedResult[];
 	}[] = [];
 
-	return {
+	const joined: IndexIterator<ReplicationRangeIndexable<R>, S> = {
 		next: async (
 			count: number,
 		): Promise<
@@ -1946,25 +1962,43 @@ const joinIterator = <S extends Shape | undefined, R extends "u32" | "u64">(
 		},
 		pending: async () => {
 			let allPending = await Promise.all(iterators.map((x) => x.pending()));
-			return allPending.reduce((acc, x) => acc + x, 0);
+			// A child can be exhausted while this join still owns prefetched rows.
+			// Counting local queues makes the same contract compose through nested joins.
+			const buffered = queues.reduce(
+				(acc, queue) => acc + queue.elements.length,
+				0,
+			);
+			return buffered + allPending.reduce((acc, x) => acc + x, 0);
 		},
-		done: () => iterators.every((x) => x.done() === true),
+		done: () =>
+			queues.every((queue) => queue.elements.length === 0) &&
+			iterators.every((x) => x.done() === true),
 		close: async () => {
-			for (const iterator of iterators) {
-				await iterator.close();
+			queues.length = 0;
+			const settled = await Promise.allSettled(
+				iterators.map(async (iterator) => iterator.close()),
+			);
+			const errors = settled.flatMap((result) =>
+				result.status === "rejected" ? [result.reason] : [],
+			);
+			if (errors.length === 1) {
+				throw errors[0];
+			}
+			if (errors.length > 1) {
+				throw new AggregateError(errors, "Failed to close joined iterators");
 			}
 		},
 		all: async () => {
 			let results: IndexedResult<
 				ReturnTypeFromShape<ReplicationRangeIndexable<R>, S>
 			>[] = [];
-			for (const iterator of iterators) {
-				let res = await iterator.all();
-				results.push(...res);
+			while (!joined.done()) {
+				results.push(...(await joined.next(100)));
 			}
 			return results;
 		},
 	};
+	return joined;
 };
 
 const getClosestAroundOrContaining = <
@@ -2013,6 +2047,7 @@ const getClosestAroundOrContaining = <
 export const getAdjecentSameOwner = async <R extends "u32" | "u64">(
 	peers: Index<ReplicationRangeIndexable<R>>,
 	range: {
+		id?: Uint8Array;
 		idString?: string;
 		start1: NumberFromType<R>;
 		end2: NumberFromType<R>;
@@ -2031,6 +2066,7 @@ export const getAdjecentSameOwner = async <R extends "u32" | "u64">(
 		numbers,
 		{
 			hash: range.hash,
+			excludeId: range.id,
 		},
 	);
 	const closestBelow = await closestBelowIterator.next(1);
@@ -2043,21 +2079,21 @@ export const getAdjecentSameOwner = async <R extends "u32" | "u64">(
 		numbers,
 		{
 			hash: range.hash,
+			excludeId: range.id,
 		},
 	);
 	const closestAbove = await closestAboveIterator.next(1);
 	closestAboveIterator.close();
-	return {
-		below:
-			range.idString === closestBelow[0]?.value.idString
-				? undefined
-				: closestBelow[0]?.value,
-		above:
-			closestBelow[0]?.id.primitive === closestAbove[0]?.id.primitive ||
-			range.idString === closestBelow[0]?.value.idString
-				? undefined
-				: closestAbove[0]?.value,
-	};
+	const below =
+		range.idString === closestBelow[0]?.value.idString
+			? undefined
+			: closestBelow[0]?.value;
+	const above =
+		range.idString === closestAbove[0]?.value.idString ||
+		below?.idString === closestAbove[0]?.value.idString
+			? undefined
+			: closestAbove[0]?.value;
+	return { below, above };
 };
 
 export const getAllMergeCandiates = async <R extends "u32" | "u64">(

--- a/packages/programs/data/shared-log/test/ranges.spec.ts
+++ b/packages/programs/data/shared-log/test/ranges.spec.ts
@@ -6,7 +6,7 @@ import {
 	type PublicSignKey,
 	randomBytes,
 } from "@peerbit/crypto";
-import type { Index } from "@peerbit/indexer-interface";
+import { type Index, Sort, StringMatch } from "@peerbit/indexer-interface";
 import { create as createIndices } from "@peerbit/indexer-sqlite3";
 import { LamportClock, Meta, ShallowMeta } from "@peerbit/log";
 import { expect } from "chai";
@@ -32,6 +32,7 @@ import {
 	getCoverSet as getCoverSetGeneric,
 	getDistance,
 	getSamples as getSamplesMap,
+	joinIterator,
 	mergeRanges,
 	mergeReplicationChanges,
 	toRebalance,
@@ -1028,6 +1029,28 @@ resolutions.forEach((resolution) => {
 							expect(adjecent.below?.idString).to.eq(below.idString);
 							expect(adjecent.above?.idString).to.eq(above.idString);
 						});
+
+						it("excludes a full-width range from its own adjacency", async () => {
+							const from = createReplicationRangeFromNormalized({
+								publicKey: a,
+								width: 1,
+								offset: (0.25 + rotation) % 1,
+								timestamp: 0n,
+							});
+							const neighbor = createReplicationRangeFromNormalized({
+								publicKey: a,
+								width: 0.1,
+								offset: (0.6 + rotation) % 1,
+								timestamp: 0n,
+							});
+							await create(from, neighbor);
+
+							const adjecent = await getAdjecentSameOwner(peers, from, numbers);
+							const ids = [adjecent.below, adjecent.above]
+								.filter((candidate) => candidate != null)
+								.map((candidate) => candidate.idString);
+							expect(ids).to.deep.equal([neighbor.idString]);
+						});
 					});
 				});
 			});
@@ -1614,6 +1637,40 @@ resolutions.forEach((resolution) => {
 				});
 
 				describe("maturity", () => {
+					it("drains prefetched fallback rows before reporting done", async () => {
+						const point = 1000;
+						const ranges: ReplicationRangeIndexable<R>[] = [];
+						for (let distance = 1; distance <= 75; distance++) {
+							const timestamp =
+								distance === 75 ? 0n : BigInt(Date.now() + 60_000);
+							for (const [side, offset] of [
+								[0, point - distance - 1],
+								[1, point + distance],
+							] as const) {
+								ranges.push(
+									createReplicationRange({
+										id: new Uint8Array([side, distance]),
+										publicKey: distance === 75 ? a : b,
+										offset,
+										width: 1,
+										timestamp,
+									}),
+								);
+							}
+						}
+						await create(...ranges);
+
+						const leaders = await getSamplesMap(
+							[coerceNumber(point)],
+							peers,
+							1000,
+							numbers,
+						);
+						expect([...leaders.entries()]).to.deep.equal([
+							[a.hashcode(), { intersecting: false }],
+						]);
+					});
+
 					it("counts mature evidence for an existing owner in any input order", async () => {
 						for (const immatureFirst of [true, false]) {
 							const immature = createReplicationRange({
@@ -1791,6 +1848,13 @@ resolutions.forEach((resolution) => {
 			});
 
 			describe("getDistance", () => {
+				it("returns a typed zero for equality in every direction", () => {
+					for (const direction of ["above", "below", "closest"] as const) {
+						expect(getDistance(5, 5, direction, 10)).to.equal(0);
+						expect(getDistance(5n, 5n, direction, 10n)).to.equal(0n);
+					}
+				});
+
 				describe("above", () => {
 					it("immediate", () => {
 						expect(getDistance(0.5, 0.4, "above", 1)).to.be.closeTo(
@@ -1844,6 +1908,65 @@ resolutions.forEach((resolution) => {
 							0.0001,
 						);
 					});
+				});
+			});
+
+			describe("joinIterator", () => {
+				it("preserves buffered merge order across next then all", async () => {
+					const aNear = createReplicationRange({
+						id: new Uint8Array([10]),
+						publicKey: a,
+						offset: 10,
+						width: 1,
+						timestamp: 0n,
+					});
+					const aFar = createReplicationRange({
+						id: new Uint8Array([40]),
+						publicKey: a,
+						offset: 40,
+						width: 1,
+						timestamp: 0n,
+					});
+					const bNear = createReplicationRange({
+						id: new Uint8Array([20]),
+						publicKey: b,
+						offset: 20,
+						width: 1,
+						timestamp: 0n,
+					});
+					const bMiddle = createReplicationRange({
+						id: new Uint8Array([30]),
+						publicKey: b,
+						offset: 30,
+						width: 1,
+						timestamp: 0n,
+					});
+					await create(aNear, aFar, bNear, bMiddle);
+
+					const byOwner = (hash: string) =>
+						peers.iterate({
+							query: [new StringMatch({ key: "hash", value: hash })],
+							sort: [new Sort({ key: "start1", direction: "asc" })],
+						});
+					const iterator = joinIterator(
+						[byOwner(a.hashcode()), byOwner(b.hashcode())],
+						numbers.zero,
+						"above",
+						numbers,
+					);
+					try {
+						const first = await iterator.next(1);
+						const remaining = await iterator.all();
+						expect(
+							[...first, ...remaining].map((result) => result.value.idString),
+						).to.deep.equal(
+							[aNear, bNear, bMiddle, aFar].map((range) => range.idString),
+						);
+						expect(iterator.done()).to.be.true;
+						expect(await iterator.pending()).to.equal(0);
+					} finally {
+						await iterator.close();
+					}
 				});
 			});
 


### PR DESCRIPTION
Stacked on #1298. Review only commit `e44dc425e` for this slice.

## What this changes

- Replaces the native fallback planner repeated restart-and-skip search with four stateful cyclic endpoint streams.
- Bounds native fallback endpoint advances to at most four passes over the fallback index per cursor, changing the adversarial path from quadratic to linear in the indexed range facts.
- Stores endpoint metadata in coordinate-keyed ordered sets, preserving deterministic distance, timestamp, owner, and range-id ordering without materializing tie groups.
- Removes the synthetic maximum-string sentinel and correctly merges maximum-timestamp/high-Unicode identifiers and circularly aliased zero/MAX endpoints.
- Makes the TypeScript fallback phases disjoint and monotone, treats exact directional equality as zero distance, and excludes the current full-width range from adjacency lookup.
- Fixes the joined iterator lifecycle so prefetched rows count as pending, prevent premature done, remain ordered through `all()`, and are released on close.

## Evidence

- shared-log Rust: 42 passing
- TypeScript/native parity: 136 passing, including seeded u32/u64 sweeps
- full shared-log ranges suite: 1,518 passing
- native-backbone Rust: 58 passing
- changeset guard: 52 passing
- package builds, changed-file ESLint, Rust formatting, Prettier, and diff checks pass

The 16,384-range adversarial test records exactly four endpoint-index advances per range for one cursor. The prefetched-tail regression uses 150 disjoint fallback rows and proves a mature owner beyond batch 100 is not truncated.

## Compatibility note

This intentionally corrects rare fallback ordering at exact endpoints, zero/MAX aliases, and maximum-timestamp/high-Unicode metadata. Mixed-version peers can therefore choose different fallback owners for those boundary/tie cases until the stack is upgraded. Ordinary intersecting ownership is unchanged.

## Scope boundary

This does not make the generic TypeScript Index backend scan-bounded, remove its existing `.all()` materialization paths, bound startup hydration, or add transfer receipts, custody pins, concurrent-write capture, or prune authority. It is a prerequisite for a deterministic bounded owner planner over a capped frozen placement view.

Because this PR is stacked on #1298, master-only ancestry and changeset checks are expected to remain red until the stack is rebased or merged.