### PR TITLE
feat(shared-log): plan owners from frozen placement views

### DIFF
--- a/.changeset/pure-local-owner-plans.md
+++ b/.changeset/pure-local-owner-plans.md
@@ -1,0 +1,9 @@
+---
+"@peerbit/shared-log": patch
+"@peerbit/shared-log-rust": patch
+---
+
+Add an internal, issued-view-only owner planner that hydrates the native range
+planner once and returns canonical bounded decisions without querying an Index.
+Give standalone native range planners an explicit idempotent close/free
+lifecycle and reject every operation after release.

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -227,6 +227,7 @@ type ResidentRepairDispatchPlanInput = Omit<
 type RepairDispatchPlan = Map<string, Map<string, string[]>>;
 
 type NativeRangePlannerHandle = {
+	free: () => void;
 	len: () => number;
 	clear: () => void;
 	put: (
@@ -959,10 +960,19 @@ const appendDeliveryPlanFromRow = (
 });
 
 export class SharedLogRangePlanner {
+	private closed = false;
+
 	private constructor(
 		private readonly native: NativeRangePlannerHandle,
 		private readonly resolution: RangeResolution,
 	) {}
+
+	private handle(): NativeRangePlannerHandle {
+		if (this.closed) {
+			throw new Error("SharedLogRangePlanner is closed");
+		}
+		return this.native;
+	}
 
 	static async create(
 		resolution: RangeResolution,
@@ -975,15 +985,15 @@ export class SharedLogRangePlanner {
 	}
 
 	get length(): number {
-		return this.native.len();
+		return this.handle().len();
 	}
 
 	clear(): void {
-		this.native.clear();
+		this.handle().clear();
 	}
 
 	put(range: NativeReplicationRange): void {
-		this.native.put(
+		this.handle().put(
 			range.id,
 			range.hash,
 			asIntegerString(range.timestamp),
@@ -997,14 +1007,14 @@ export class SharedLogRangePlanner {
 	}
 
 	delete(id: string): boolean {
-		return this.native.delete(id);
+		return this.handle().delete(id);
 	}
 
 	getSamples(
 		cursors: Iterable<bigint | number | string>,
 		options?: SampleOptions,
 	): Map<string, LeaderSample> {
-		const rows = this.native.get_samples(
+		const rows = this.handle().get_samples(
 			[...cursors].map(asIntegerString),
 			options?.roleAge ?? 0,
 			asIntegerString(options?.now ?? Date.now()),
@@ -1020,7 +1030,7 @@ export class SharedLogRangePlanner {
 		replicas: number,
 		options?: FindLeaderOptions,
 	): Map<string, LeaderSample> {
-		const rows = this.native.find_leaders(
+		const rows = this.handle().find_leaders(
 			[...cursors].map(asIntegerString),
 			replicas,
 			...findLeaderArguments(options),
@@ -1032,6 +1042,7 @@ export class SharedLogRangePlanner {
 		items: Iterable<LeaderBatchInput>,
 		options?: FindLeaderOptions,
 	): Array<Map<string, LeaderSample>> {
+		const native = this.handle();
 		const cursorBatches: string[][] = [];
 		const replicaCounts: number[] = [];
 		for (const item of items) {
@@ -1039,7 +1050,7 @@ export class SharedLogRangePlanner {
 			replicaCounts.push(item.replicas);
 		}
 
-		const rows = this.native.find_leaders_batch(
+		const rows = native.find_leaders_batch(
 			cursorBatches,
 			replicaCounts,
 			...findLeaderArguments(options),
@@ -1052,7 +1063,7 @@ export class SharedLogRangePlanner {
 		replicas: number,
 		options?: FindLeaderOptions,
 	): Map<string, LeaderSample> {
-		const rows = this.native.find_leaders_for_gid(
+		const rows = this.handle().find_leaders_for_gid(
 			gid,
 			replicas,
 			...findLeaderArguments(options),
@@ -1065,7 +1076,7 @@ export class SharedLogRangePlanner {
 		replicas: number,
 		options?: FindLeaderOptions,
 	): LeaderPlan {
-		const [coordinateRows, leaderRows] = this.native.plan_leaders_for_gid(
+		const [coordinateRows, leaderRows] = this.handle().plan_leaders_for_gid(
 			gid,
 			replicas,
 			...findLeaderArguments(options),
@@ -1080,6 +1091,7 @@ export class SharedLogRangePlanner {
 		items: Iterable<LeaderGidBatchInput>,
 		options?: FindLeaderOptions,
 	): LeaderPlan[] {
+		const native = this.handle();
 		const gids: string[] = [];
 		const replicaCounts: number[] = [];
 		for (const item of items) {
@@ -1087,7 +1099,7 @@ export class SharedLogRangePlanner {
 			replicaCounts.push(item.replicas);
 		}
 
-		const rows = this.native.plan_leaders_for_gids_batch(
+		const rows = native.plan_leaders_for_gids_batch(
 			gids,
 			replicaCounts,
 			...findLeaderArguments(options),
@@ -1105,7 +1117,8 @@ export class SharedLogRangePlanner {
 		items: Iterable<LeaderGidHashBatchInput>,
 		options?: FindLeaderOptions,
 	): Set<string> | undefined {
-		if (!this.native.plan_local_leaders_for_gids_batch) {
+		const native = this.handle();
+		if (!native.plan_local_leaders_for_gids_batch) {
 			return undefined;
 		}
 		const hashes: string[] = [];
@@ -1117,7 +1130,7 @@ export class SharedLogRangePlanner {
 			replicaCounts.push(item.replicas);
 		}
 		return new Set(
-			this.native.plan_local_leaders_for_gids_batch(
+			native.plan_local_leaders_for_gids_batch(
 				hashes,
 				gids,
 				replicaCounts,
@@ -1127,9 +1140,10 @@ export class SharedLogRangePlanner {
 	}
 
 	planRepairDispatchBatch(input: RepairDispatchPlanInput): RepairDispatchPlan {
+		const native = this.handle();
 		const entries = [...input.entries];
 		const pendingModes = [...input.pendingModes];
-		const rows = this.native.plan_repair_dispatch(
+		const rows = native.plan_repair_dispatch(
 			entries.map((entry) => entry.hash),
 			entries.map((entry) => entry.gid),
 			entries.map((entry) => entry.requestedReplicas),
@@ -1164,9 +1178,10 @@ export class SharedLogRangePlanner {
 		input: RepairDispatchEntryPlanInput,
 		options?: FindLeaderOptions,
 	): RepairDispatchPlan {
+		const native = this.handle();
 		const entries = [...input.entries];
 		const pendingModes = [...input.pendingModes];
-		const rows = this.native.plan_repair_dispatch_for_entries(
+		const rows = native.plan_repair_dispatch_for_entries(
 			entries.map((entry) => entry.hash),
 			entries.map((entry) => entry.gid),
 			entries.map((entry) => entry.requestedReplicas),
@@ -1204,7 +1219,7 @@ export class SharedLogRangePlanner {
 		replicas: number,
 		options?: FullReplicaLeaderOptions,
 	): Map<string, LeaderSample> | undefined {
-		const rows = this.native.get_full_replica_leaders(
+		const rows = this.handle().get_full_replica_leaders(
 			replicas,
 			options?.roleAge ?? 0,
 			asIntegerString(options?.now ?? Date.now()),
@@ -1219,7 +1234,7 @@ export class SharedLogRangePlanner {
 		replicas: number,
 		options: MaturedPeerOptions,
 	): Set<string> | undefined {
-		const peers = this.native.include_matured_peers(
+		const peers = this.handle().include_matured_peers(
 			peerFilter ? [...peerFilter] : undefined,
 			replicas,
 			options.roleAge ?? 0,
@@ -1236,15 +1251,27 @@ export class SharedLogRangePlanner {
 	): Array<number | bigint> {
 		return rowsToNumbers(
 			this.resolution,
-			this.native.get_grid(asIntegerString(from), count),
+			this.handle().get_grid(asIntegerString(from), count),
 		);
 	}
 
 	getGidCoordinates(gid: string, count: number): Array<number | bigint> {
 		return rowsToNumbers(
 			this.resolution,
-			this.native.get_gid_coordinates(gid, count),
+			this.handle().get_gid_coordinates(gid, count),
 		);
+	}
+
+	/** Release the owned wasm allocation. Safe to call more than once. */
+	close(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.native.free();
+	}
+
+	/** wasm-style alias for callers that own this planner directly. */
+	free(): void {
+		this.close();
 	}
 }
 

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -56,6 +56,27 @@ const range = (properties: {
 };
 
 describe("native shared-log range planner", () => {
+	it("closes idempotently and rejects before consuming caller iterables", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.close();
+		planner.close();
+		planner.free();
+
+		expect(() => planner.length).to.throw("SharedLogRangePlanner is closed");
+		expect(() => planner.clear()).to.throw("SharedLogRangePlanner is closed");
+		let consumed = false;
+		const items: Iterable<{ cursors: number[]; replicas: number }> = {
+			*[Symbol.iterator]() {
+				consumed = true;
+				yield { cursors: [1], replicas: 1 };
+			},
+		};
+		expect(() => planner.findLeadersBatch(items)).to.throw(
+			"SharedLogRangePlanner is closed",
+		);
+		expect(consumed).to.equal(false);
+	});
+
 	it("returns intersecting leaders", async () => {
 		const planner = await createRangePlanner("u32");
 		planner.put(range({ id: "a", hash: "peer-a", start1: 10, end1: 20 }));

--- a/packages/programs/data/shared-log/src/local-placement-owner-planner.ts
+++ b/packages/programs/data/shared-log/src/local-placement-owner-planner.ts
@@ -1,0 +1,459 @@
+import {
+	fromHexString,
+	sha256Sync,
+	toBase64,
+	toHexString,
+} from "@peerbit/crypto";
+import type {
+	NativeReplicationRange,
+	SharedLogRangePlanner,
+} from "@peerbit/shared-log-rust";
+import { MAX_U32, MAX_U64 } from "./integers.js";
+import {
+	type CanonicalLocalPlacementView,
+	assertIssuedCanonicalLocalPlacementView,
+} from "./local-placement-view.js";
+
+const BUILT_IN_PLANNER_ID = "peerbit-built-in-owner-planner" as const;
+const BUILT_IN_PLANNER_VERSION = 1 as const;
+const PLAN_FORMAT = "peerbit-shared-log-local-placement-owner-plan" as const;
+const PLAN_VERSION = 1 as const;
+const MAX_REPLICAS = 100;
+const MAX_PLAN_ID_BYTES = 4 * 1024 * 1024;
+const encoder = new TextEncoder();
+
+type Resolution = "u32" | "u64";
+
+type CoordinateInput<R extends Resolution> = R extends "u32"
+	? readonly number[]
+	: readonly bigint[];
+
+export type LocalPlacementOwnerPlanInput<R extends Resolution = Resolution> =
+	Readonly<{
+		resolution: R;
+		coordinates: CoordinateInput<R>;
+		requestedReplicas: number;
+	}>;
+
+export type LocalPlacementOwnerRow = Readonly<{
+	ownerHash: string;
+	/** Canonical lower-case hex encoding of the authenticated public-key bytes. */
+	publicKey: string;
+	intersecting: boolean;
+}>;
+
+export type LocalPlacementOwnerPlanFor<R extends Resolution> = Readonly<{
+	format: typeof PLAN_FORMAT;
+	version: typeof PLAN_VERSION;
+	/** Ownership-decision identity only; never custody or pruning authority. */
+	planId: string;
+	viewId: string;
+	resolution: R;
+	coordinates: CoordinateInput<R>;
+	requestedReplicas: number;
+	effectiveReplicas: number;
+	owners: readonly LocalPlacementOwnerRow[];
+}>;
+
+export type LocalPlacementOwnerPlan =
+	| LocalPlacementOwnerPlanFor<"u32">
+	| LocalPlacementOwnerPlanFor<"u64">;
+
+export type LocalPlacementViewOwnerPlanner = Readonly<{
+	viewId: string;
+	resolution: Resolution;
+	validUntil?: bigint;
+	effectiveReplicas(requestedReplicas: number): number;
+	plan<R extends Resolution>(
+		input: LocalPlacementOwnerPlanInput<R>,
+	): LocalPlacementOwnerPlanFor<R>;
+	close(): void;
+}>;
+
+type NativeOwnerPlanner = Pick<
+	SharedLogRangePlanner,
+	"length" | "put" | "findLeaders" | "close"
+>;
+
+type LocalPlacementOwnerPlannerDependencies = Readonly<{
+	createRangePlanner(resolution: Resolution): Promise<NativeOwnerPlanner>;
+}>;
+
+class BoundedPlanWriter {
+	private value = new Uint8Array(256);
+	private offset = 0;
+
+	private reserve(length: number): number {
+		if (!Number.isSafeInteger(length) || length < 0) {
+			throw new Error("Invalid local placement owner plan encoding length");
+		}
+		const required = this.offset + length;
+		if (required > MAX_PLAN_ID_BYTES) {
+			throw new Error("Local placement owner plan exceeds the byte limit");
+		}
+		if (required > this.value.byteLength) {
+			let capacity = this.value.byteLength;
+			while (capacity < required) {
+				capacity = Math.min(MAX_PLAN_ID_BYTES, capacity * 2);
+			}
+			const next = new Uint8Array(capacity);
+			next.set(this.value.subarray(0, this.offset));
+			this.value = next;
+		}
+		const start = this.offset;
+		this.offset = required;
+		return start;
+	}
+
+	u8(value: number): void {
+		const start = this.reserve(1);
+		this.value[start] = value;
+	}
+
+	u32(value: number): void {
+		const start = this.reserve(4);
+		new DataView(this.value.buffer).setUint32(start, value, true);
+	}
+
+	u64(value: bigint): void {
+		const start = this.reserve(8);
+		new DataView(this.value.buffer).setBigUint64(start, value, true);
+	}
+
+	raw(value: Uint8Array): void {
+		const start = this.reserve(value.byteLength);
+		this.value.set(value, start);
+	}
+
+	bytes(value: Uint8Array): void {
+		this.u32(value.byteLength);
+		this.raw(value);
+	}
+
+	string(value: string): void {
+		this.bytes(encoder.encode(value));
+	}
+
+	finish(): Uint8Array {
+		return this.value.slice(0, this.offset);
+	}
+}
+
+const own = (value: readonly unknown[], index: number) =>
+	Object.prototype.hasOwnProperty.call(value, index);
+
+const compareStrings = (left: string, right: string) =>
+	left < right ? -1 : left > right ? 1 : 0;
+
+const requestedReplicaCount = (value: unknown): number => {
+	if (
+		typeof value !== "number" ||
+		!Number.isSafeInteger(value) ||
+		Object.is(value, -0) ||
+		value < 0 ||
+		value > MAX_REPLICAS
+	) {
+		throw new Error("Invalid local placement owner plan requested replicas");
+	}
+	return value;
+};
+
+const effectiveReplicaCount = (
+	view: CanonicalLocalPlacementView,
+	requestedReplicas: unknown,
+): number => {
+	const requested = requestedReplicaCount(requestedReplicas);
+	const maximum = view.body.policy.maxReplicas ?? MAX_REPLICAS;
+	return Math.max(view.body.policy.minReplicas, Math.min(maximum, requested));
+};
+
+const canonicalCoordinates = <R extends Resolution>(
+	resolution: R,
+	value: unknown,
+	effectiveReplicas: number,
+): CoordinateInput<R> => {
+	if (!Array.isArray(value)) {
+		throw new Error(
+			"Local placement owner plan coordinates must match effective replicas",
+		);
+	}
+	const length = value.length;
+	if (length !== effectiveReplicas) {
+		throw new Error(
+			"Local placement owner plan coordinates must match effective replicas",
+		);
+	}
+	const coordinates: Array<number | bigint> = [];
+	for (let index = 0; index < length; index++) {
+		if (!own(value, index)) {
+			throw new Error("Invalid sparse local placement owner plan coordinates");
+		}
+		const coordinate = value[index];
+		if (resolution === "u32") {
+			if (
+				typeof coordinate !== "number" ||
+				!Number.isInteger(coordinate) ||
+				Object.is(coordinate, -0) ||
+				coordinate < 0 ||
+				coordinate > MAX_U32
+			) {
+				throw new Error("Invalid u32 local placement owner plan coordinate");
+			}
+		} else if (
+			typeof coordinate !== "bigint" ||
+			coordinate < 0n ||
+			coordinate > MAX_U64
+		) {
+			throw new Error("Invalid u64 local placement owner plan coordinate");
+		}
+		coordinates.push(coordinate);
+	}
+	return Object.freeze(coordinates) as CoordinateInput<R>;
+};
+
+const nativeOwnerRows = (
+	value: unknown,
+	ownersByHash: ReadonlyMap<string, string>,
+): readonly LocalPlacementOwnerRow[] => {
+	if (!(value instanceof Map) || value.size > ownersByHash.size) {
+		throw new Error("Invalid native local placement owner plan output");
+	}
+	const rows: LocalPlacementOwnerRow[] = [];
+	for (const [ownerHash, sample] of value) {
+		if (typeof ownerHash !== "string") {
+			throw new Error("Invalid native local placement owner hash");
+		}
+		const publicKey = ownersByHash.get(ownerHash);
+		if (publicKey == null) {
+			throw new Error(`Unknown native local placement owner: ${ownerHash}`);
+		}
+		if (
+			!sample ||
+			typeof sample !== "object" ||
+			Array.isArray(sample) ||
+			!Object.prototype.hasOwnProperty.call(sample, "intersecting") ||
+			typeof (sample as { intersecting?: unknown }).intersecting !==
+				"boolean" ||
+			Object.keys(sample).length !== 1
+		) {
+			throw new Error("Invalid native local placement owner sample");
+		}
+		rows.push(
+			Object.freeze({
+				ownerHash,
+				publicKey,
+				intersecting: (sample as { intersecting: boolean }).intersecting,
+			}),
+		);
+	}
+	rows.sort(
+		(left, right) =>
+			compareStrings(left.ownerHash, right.ownerHash) ||
+			compareStrings(left.publicKey, right.publicKey),
+	);
+	return Object.freeze(rows);
+};
+
+const encodePlanIdentity = (
+	view: CanonicalLocalPlacementView,
+	coordinates: readonly (number | bigint)[],
+	requestedReplicas: number,
+	effectiveReplicas: number,
+	owners: readonly LocalPlacementOwnerRow[],
+): Uint8Array => {
+	const writer = new BoundedPlanWriter();
+	writer.string(PLAN_FORMAT);
+	writer.u32(PLAN_VERSION);
+	writer.raw(fromHexString(view.digest));
+	writer.string(view.body.planner.id);
+	writer.u32(view.body.planner.version);
+	writer.u8(view.body.resolution === "u32" ? 0 : 1);
+	writer.u32(coordinates.length);
+	for (const coordinate of coordinates) {
+		if (view.body.resolution === "u32") writer.u32(Number(coordinate));
+		else writer.u64(BigInt(coordinate));
+	}
+	writer.u32(requestedReplicas);
+	writer.u32(effectiveReplicas);
+	writer.u32(owners.length);
+	for (const owner of owners) {
+		writer.string(owner.ownerHash);
+		writer.u8(owner.intersecting ? 1 : 0);
+	}
+	return writer.finish();
+};
+
+const defaultDependencies: LocalPlacementOwnerPlannerDependencies = {
+	async createRangePlanner(resolution) {
+		const { createRangePlanner } = await import(
+			/* @vite-ignore */ "@peerbit/shared-log-rust"
+		);
+		return createRangePlanner(resolution);
+	},
+};
+
+const closeAfterConstructionFailure = (
+	native: NativeOwnerPlanner | undefined,
+	error: unknown,
+): never => {
+	if (!native || typeof native.close !== "function") throw error;
+	try {
+		native.close();
+	} catch (closeError) {
+		throw new AggregateError(
+			[error, closeError],
+			"Failed to construct and release local placement owner planner",
+		);
+	}
+	throw error;
+};
+
+/**
+ * Hydrate a pure owner planner from one complete, issued local placement view.
+ * The returned object never reads an Index and performs no transfer or pruning.
+ *
+ * @internal
+ */
+const createLocalPlacementViewOwnerPlannerWithDependencies = async (
+	viewValue: unknown,
+	dependencies: LocalPlacementOwnerPlannerDependencies,
+): Promise<LocalPlacementViewOwnerPlanner> => {
+	const view = assertIssuedCanonicalLocalPlacementView(viewValue);
+	if (
+		view.body.planner.id !== BUILT_IN_PLANNER_ID ||
+		view.body.planner.version !== BUILT_IN_PLANNER_VERSION
+	) {
+		throw new Error(
+			`Unsupported local placement owner planner: ${view.body.planner.id}@${view.body.planner.version}`,
+		);
+	}
+	if (!dependencies || typeof dependencies.createRangePlanner !== "function") {
+		throw new Error("Invalid local placement owner planner dependencies");
+	}
+
+	let native: NativeOwnerPlanner | undefined;
+	try {
+		native = await dependencies.createRangePlanner(view.body.resolution);
+		if (
+			!native ||
+			typeof native.put !== "function" ||
+			typeof native.findLeaders !== "function" ||
+			typeof native.close !== "function"
+		) {
+			throw new Error("Invalid native local placement owner planner");
+		}
+		for (const range of view.body.ranges) {
+			const nativeRange: NativeReplicationRange = {
+				id: toBase64(fromHexString(range.id)),
+				hash: range.owner,
+				timestamp: range.timestamp,
+				start1: range.start1,
+				end1: range.end1,
+				start2: range.start2,
+				end2: range.end2,
+				width: range.width,
+				mode: range.mode,
+			};
+			native.put(nativeRange);
+		}
+		if (native.length !== view.body.ranges.length) {
+			throw new Error(
+				"Native local placement owner planner hydration mismatch",
+			);
+		}
+	} catch (error) {
+		return closeAfterConstructionFailure(native, error);
+	}
+
+	const hydratedNative = native;
+	const ownersByHash = new Map(
+		view.body.owners.map((owner) => [owner.hash, owner.publicKey]),
+	);
+	const state = { closed: false };
+	const assertOpen = () => {
+		if (state.closed) {
+			throw new Error("Local placement owner planner is closed");
+		}
+	};
+	const planner: LocalPlacementViewOwnerPlanner = {
+		viewId: view.digest,
+		resolution: view.body.resolution,
+		validUntil: view.validUntilMs,
+		effectiveReplicas(requestedReplicas) {
+			assertOpen();
+			return effectiveReplicaCount(view, requestedReplicas);
+		},
+		plan<R extends Resolution>(
+			input: LocalPlacementOwnerPlanInput<R>,
+		): LocalPlacementOwnerPlanFor<R> {
+			assertOpen();
+			if (!input || typeof input !== "object") {
+				throw new Error("Local placement owner plan resolution mismatch");
+			}
+			const resolution = input.resolution;
+			const requestedReplicasValue = input.requestedReplicas;
+			const coordinatesValue = input.coordinates;
+			if (resolution !== view.body.resolution) {
+				throw new Error("Local placement owner plan resolution mismatch");
+			}
+			const requestedReplicas = requestedReplicaCount(requestedReplicasValue);
+			const effectiveReplicas = effectiveReplicaCount(view, requestedReplicas);
+			const coordinates = canonicalCoordinates(
+				resolution,
+				coordinatesValue,
+				effectiveReplicas,
+			);
+			const nativeRows = hydratedNative.findLeaders(
+				coordinates,
+				effectiveReplicas,
+				{
+					roleAge: Number(view.body.policy.roleAgeMs),
+					now: view.capturedAtMs,
+					peerFilter: view.body.basePeerFilter ?? undefined,
+					expandPeerFilter: view.body.policy.expandPeerFilter,
+					selfHash: view.body.self.owner,
+					selfReplicating: view.body.self.replicating,
+					fullReplicaFallback: view.body.policy.fullReplicaFallback,
+					includeStrictFullReplica: view.body.policy.includeStrictFullReplica,
+				},
+			);
+			const owners = nativeOwnerRows(nativeRows, ownersByHash);
+			const planId = toHexString(
+				sha256Sync(
+					encodePlanIdentity(
+						view,
+						coordinates,
+						requestedReplicas,
+						effectiveReplicas,
+						owners,
+					),
+				),
+			);
+			return Object.freeze({
+				format: PLAN_FORMAT,
+				version: PLAN_VERSION,
+				planId,
+				viewId: view.digest,
+				resolution,
+				coordinates,
+				requestedReplicas,
+				effectiveReplicas,
+				owners,
+			});
+		},
+		close() {
+			if (state.closed) return;
+			state.closed = true;
+			hydratedNative.close();
+		},
+	};
+	return Object.freeze(planner);
+};
+
+export const createLocalPlacementViewOwnerPlanner = (
+	viewValue: unknown,
+): Promise<LocalPlacementViewOwnerPlanner> =>
+	createLocalPlacementViewOwnerPlannerWithDependencies(
+		viewValue,
+		defaultDependencies,
+	);

--- a/packages/programs/data/shared-log/src/local-placement-view.ts
+++ b/packages/programs/data/shared-log/src/local-placement-view.ts
@@ -474,6 +474,30 @@ const assertDigest = (value: unknown, name: string) => {
 };
 
 /**
+ * Admit only canonical views issued by this module in the current JavaScript
+ * realm. Structural lookalikes are deliberately insufficient: the issuer also
+ * binds the mutable byte buffer back to the view digest on every admission.
+ *
+ * @internal
+ */
+export const assertIssuedCanonicalLocalPlacementView = (
+	view: unknown,
+): CanonicalLocalPlacementView => {
+	if (!view || typeof view !== "object" || !issuedCanonicalViews.has(view)) {
+		throw new Error("Invalid issued canonical local placement view");
+	}
+	const candidate = view as CanonicalLocalPlacementView;
+	const viewId = assertDigest(candidate.digest, "issued view id");
+	if (
+		!(candidate.bytes instanceof Uint8Array) ||
+		toHexString(sha256Sync(candidate.bytes)) !== viewId
+	) {
+		throw new Error("Invalid issued canonical local placement view digest");
+	}
+	return candidate;
+};
+
+/**
  * Canonicalize a complete, frozen LOCAL placement snapshot. Authentication and
  * freshness are caller obligations: this codec cannot recover signatures,
  * sender epochs, or V2 sequence provenance from persisted range rows.
@@ -830,17 +854,8 @@ export const createLocalPlacementExecutionFence = (properties: {
 	ownershipRevision: bigint;
 	roleGeneration: number;
 }): LocalPlacementExecutionFence => {
-	const view = properties?.view;
-	if (!view || !issuedCanonicalViews.has(view)) {
-		throw new Error("Invalid local placement view execution fence view");
-	}
-	const viewId = assertDigest(view.digest, "execution fence view id");
-	if (
-		!(view.bytes instanceof Uint8Array) ||
-		toHexString(sha256Sync(view.bytes)) !== viewId
-	) {
-		throw new Error("Invalid local placement view execution fence digest");
-	}
+	const view = assertIssuedCanonicalLocalPlacementView(properties?.view);
+	const viewId = view.digest;
 	const executionEpoch = boundedBytes(
 		properties?.executionEpoch,
 		32,

--- a/packages/programs/data/shared-log/test/local-placement-owner-planner.spec.ts
+++ b/packages/programs/data/shared-log/test/local-placement-owner-planner.spec.ts
@@ -1,0 +1,767 @@
+import {
+	sha256Base64Sync,
+	sha256Sync,
+	toBase64,
+	toHexString,
+} from "@peerbit/crypto";
+import { SharedLogRangePlanner } from "@peerbit/shared-log-rust";
+import { expect } from "chai";
+import { MAX_U32, MAX_U64 } from "../src/integers.js";
+import {
+	type LocalPlacementOwnerPlan,
+	createLocalPlacementViewOwnerPlanner,
+} from "../src/local-placement-owner-planner.js";
+import {
+	type LocalPlacementSnapshotInput,
+	canonicalizeLocalPlacementSnapshotV1,
+} from "../src/local-placement-view.js";
+import {
+	ReplicationIntent,
+	ReplicationRangeIndexableU32,
+	ReplicationRangeIndexableU64,
+} from "../src/ranges.js";
+
+const textEncoder = new TextEncoder();
+const digest = (value: string) =>
+	toHexString(sha256Sync(textEncoder.encode(value)));
+
+type Owner = Readonly<{
+	hash: string;
+	publicKey: Uint8Array;
+}>;
+
+const owner = (value: number): Owner => {
+	const publicKey = Uint8Array.of(value);
+	return { publicKey, hash: sha256Base64Sync(publicKey) };
+};
+
+const u32Range = (
+	ownerValue: Owner,
+	id: number,
+	offset: number,
+	properties?: {
+		width?: number;
+		mode?: ReplicationIntent;
+		timestamp?: bigint;
+	},
+) => {
+	const range = new ReplicationRangeIndexableU32({
+		id: Uint8Array.of(id),
+		publicKeyHash: ownerValue.hash,
+		offset,
+		width: properties?.width ?? 20,
+		timestamp: properties?.timestamp ?? 0n,
+		mode: properties?.mode ?? ReplicationIntent.NonStrict,
+	});
+	return {
+		owner: range.hash,
+		id: range.id,
+		timestamp: range.timestamp,
+		start1: range.start1,
+		end1: range.end1,
+		start2: range.start2,
+		end2: range.end2,
+		width: range.width,
+		mode: range.mode,
+	};
+};
+
+const u64Range = (
+	ownerValue: Owner,
+	id: number,
+	offset: bigint,
+	properties?: { width?: bigint; mode?: ReplicationIntent },
+) => {
+	const range = new ReplicationRangeIndexableU64({
+		id: Uint8Array.of(id),
+		publicKeyHash: ownerValue.hash,
+		offset,
+		width: properties?.width ?? 20n,
+		timestamp: 0n,
+		mode: properties?.mode ?? ReplicationIntent.NonStrict,
+	});
+	return {
+		owner: range.hash,
+		id: range.id,
+		timestamp: range.timestamp,
+		start1: range.start1,
+		end1: range.end1,
+		start2: range.start2,
+		end2: range.end2,
+		width: range.width,
+		mode: range.mode,
+	};
+};
+
+const policy = (properties?: {
+	minReplicas?: number;
+	maxReplicas?: number;
+	expandPeerFilter?: boolean;
+	fullReplicaFallback?: boolean;
+	includeStrictFullReplica?: boolean;
+	roleAgeMs?: number;
+}) => ({
+	id: digest("local-owner-planner-policy-v1"),
+	minReplicas: properties?.minReplicas ?? 1,
+	maxReplicas: properties?.maxReplicas,
+	roleAgeMs: properties?.roleAgeMs ?? 0,
+	expandPeerFilter: properties?.expandPeerFilter ?? false,
+	fullReplicaFallback: properties?.fullReplicaFallback ?? false,
+	includeStrictFullReplica: properties?.includeStrictFullReplica ?? true,
+});
+
+const inputU32 = (properties: {
+	owners: readonly Owner[];
+	ranges: ReturnType<typeof u32Range>[];
+	self?: Owner;
+	selfReplicating?: boolean;
+	basePeerFilter?: readonly string[];
+	planner?: Readonly<{ id: string; version: number }>;
+	policy?: ReturnType<typeof policy>;
+}): LocalPlacementSnapshotInput<"u32"> => ({
+	logId: Uint8Array.of(1, 2, 3),
+	resolution: "u32",
+	planner: properties.planner ?? {
+		id: "peerbit-built-in-owner-planner",
+		version: 1,
+	},
+	domain: { type: "hash", version: 1, configId: digest("u32-domain-v1") },
+	policy: properties.policy ?? policy(),
+	capturedAtMs: 1_000n,
+	self: {
+		owner: (properties.self ?? properties.owners[0]!).hash,
+		replicating: properties.selfReplicating ?? true,
+	},
+	basePeerFilter: properties.basePeerFilter,
+	owners: properties.owners.map((value) => ({ publicKey: value.publicKey })),
+	ranges: properties.ranges,
+});
+
+const inputU64 = (properties: {
+	owners: readonly Owner[];
+	ranges: ReturnType<typeof u64Range>[];
+	policy?: ReturnType<typeof policy>;
+}): LocalPlacementSnapshotInput<"u64"> => ({
+	logId: Uint8Array.of(4, 5, 6),
+	resolution: "u64",
+	planner: { id: "peerbit-built-in-owner-planner", version: 1 },
+	domain: { type: "hash", version: 1, configId: digest("u64-domain-v1") },
+	policy: properties.policy ?? policy(),
+	capturedAtMs: 1_000n,
+	self: { owner: properties.owners[0]!.hash, replicating: true },
+	owners: properties.owners.map((value) => ({ publicKey: value.publicKey })),
+	ranges: properties.ranges,
+});
+
+const hashes = (plan: LocalPlacementOwnerPlan) =>
+	plan.owners.map((value) => value.ownerHash);
+
+describe("local placement view owner planner", () => {
+	it("hydrates real u32 WASM, clamps replicas, freezes output, and is permutation stable", async () => {
+		const owners = [owner(3), owner(1), owner(2)];
+		const ranges = owners.map((value, index) =>
+			u32Range(value, index + 1, index * 100),
+		);
+		const firstView = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners,
+				ranges,
+				policy: policy({ minReplicas: 2, maxReplicas: 3 }),
+			}),
+		);
+		const secondView = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners: [...owners].reverse(),
+				ranges: [...ranges].reverse(),
+				self: owners[0],
+				policy: policy({ minReplicas: 2, maxReplicas: 3 }),
+			}),
+		);
+		expect(secondView.digest).to.equal(firstView.digest);
+
+		const first = await createLocalPlacementViewOwnerPlanner(firstView);
+		const second = await createLocalPlacementViewOwnerPlanner(secondView);
+		try {
+			expect(Object.isFrozen(first)).to.equal(true);
+			expect(first.viewId).to.equal(firstView.digest);
+			expect(first.resolution).to.equal("u32");
+			expect(first.validUntil).to.equal(undefined);
+			expect(first.effectiveReplicas(0)).to.equal(2);
+			expect(first.effectiveReplicas(100)).to.equal(3);
+
+			const inputCoordinates = [5, 105];
+			const firstPlan = first.plan({
+				resolution: "u32",
+				coordinates: inputCoordinates,
+				requestedReplicas: 1,
+			});
+			inputCoordinates[0] = 999;
+			const secondPlan = second.plan({
+				resolution: "u32",
+				coordinates: [5, 105],
+				requestedReplicas: 1,
+			});
+			expect(firstPlan).to.deep.equal(secondPlan);
+			expect(firstPlan.coordinates).to.deep.equal([5, 105]);
+			expect(firstPlan.requestedReplicas).to.equal(1);
+			expect(firstPlan.effectiveReplicas).to.equal(2);
+			expect(new Set(hashes(firstPlan))).to.deep.equal(
+				new Set([owners[0]!.hash, owners[1]!.hash]),
+			);
+			expect(firstPlan.owners.map((value) => value.ownerHash)).to.deep.equal(
+				[...firstPlan.owners].map((value) => value.ownerHash).sort(),
+			);
+			expect(firstPlan.owners.every((value) => value.intersecting)).to.equal(
+				true,
+			);
+			expect(firstPlan.owners[0]!.publicKey).to.match(/^[0-9a-f]+$/);
+			expect(Object.isFrozen(firstPlan)).to.equal(true);
+			expect(Object.isFrozen(firstPlan.coordinates)).to.equal(true);
+			expect(Object.isFrozen(firstPlan.owners)).to.equal(true);
+			expect(firstPlan.owners.every(Object.isFrozen)).to.equal(true);
+			expect(firstPlan.format).to.equal(
+				"peerbit-shared-log-local-placement-owner-plan",
+			);
+			expect(firstPlan.version).to.equal(1);
+			expect(firstPlan.planId).to.match(/^[0-9a-f]{64}$/);
+			expect(firstPlan.planId).to.equal(
+				"2c3a358cb3e8eaa78b000041b01024ac8d8f629cb2610e5ceea415af05f0a3df",
+			);
+
+			const sameEffective = first.plan({
+				resolution: "u32",
+				coordinates: [5, 105],
+				requestedReplicas: 0,
+			});
+			expect(sameEffective.effectiveReplicas).to.equal(
+				firstPlan.effectiveReplicas,
+			);
+			expect(sameEffective.owners).to.deep.equal(firstPlan.owners);
+			expect(sameEffective.planId).to.not.equal(firstPlan.planId);
+			const movedCoordinates = first.plan({
+				resolution: "u32",
+				coordinates: [6, 106],
+				requestedReplicas: 1,
+			});
+			expect(movedCoordinates.owners).to.deep.equal(firstPlan.owners);
+			expect(movedCoordinates.planId).to.not.equal(firstPlan.planId);
+
+			const high = first.plan({
+				resolution: "u32",
+				coordinates: [5, 105, 205],
+				requestedReplicas: 100,
+			});
+			expect(high.effectiveReplicas).to.equal(3);
+		} finally {
+			first.close();
+			second.close();
+		}
+	});
+
+	it("hydrates real u64 WASM and preserves bigint coordinates", async () => {
+		const owners = [owner(4), owner(5)];
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU64({
+				owners,
+				ranges: [u64Range(owners[0]!, 1, 10n), u64Range(owners[1]!, 2, 100n)],
+				policy: policy({ minReplicas: 2, maxReplicas: 2 }),
+			}),
+		);
+		const planner = await createLocalPlacementViewOwnerPlanner(view);
+		try {
+			const plan = planner.plan({
+				resolution: "u64",
+				coordinates: [15n, 105n],
+				requestedReplicas: 2,
+			});
+			expect(plan.resolution).to.equal("u64");
+			expect(plan.coordinates).to.deep.equal([15n, 105n]);
+			expect(hashes(plan)).to.have.members(owners.map((value) => value.hash));
+		} finally {
+			planner.close();
+		}
+	});
+
+	it("binds plan identity to semantic view changes with unchanged owners", async () => {
+		const owners = [owner(19)];
+		const ranges = [u32Range(owners[0]!, 1, 0)];
+		const firstPolicy = policy();
+		const first = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({ owners, ranges, policy: firstPolicy }),
+			),
+		);
+		const second = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({
+					owners,
+					ranges,
+					policy: {
+						...firstPolicy,
+						id: digest("same-semantics-new-policy-revision"),
+					},
+				}),
+			),
+		);
+		try {
+			const input = {
+				resolution: "u32" as const,
+				coordinates: [5],
+				requestedReplicas: 1,
+			};
+			const firstPlan = first.plan(input);
+			const secondPlan = second.plan(input);
+			expect(secondPlan.owners).to.deep.equal(firstPlan.owners);
+			expect(secondPlan.planId).to.not.equal(firstPlan.planId);
+		} finally {
+			first.close();
+			second.close();
+		}
+	});
+
+	it("hydrates runtime-compatible base64 range ids", async () => {
+		const owners = [owner(16)];
+		const rangeId = 0xfa;
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners,
+				ranges: [u32Range(owners[0]!, rangeId, 0)],
+			}),
+		);
+		const originalPut = SharedLogRangePlanner.prototype.put;
+		const ids: string[] = [];
+		SharedLogRangePlanner.prototype.put = function (range) {
+			ids.push(range.id);
+			return originalPut.call(this, range);
+		};
+		let planner: Awaited<
+			ReturnType<typeof createLocalPlacementViewOwnerPlanner>
+		> | null = null;
+		try {
+			planner = await createLocalPlacementViewOwnerPlanner(view);
+			expect(ids).to.deep.equal([toBase64(Uint8Array.of(rangeId))]);
+		} finally {
+			SharedLogRangePlanner.prototype.put = originalPut;
+			planner?.close();
+		}
+	});
+
+	it("uses captured view time and role age for immature intersections", async () => {
+		const owners = [owner(17), owner(18)];
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners,
+				ranges: [
+					u32Range(owners[0]!, 1, 0, { timestamp: 950n }),
+					u32Range(owners[1]!, 2, 100),
+				],
+				policy: policy({ roleAgeMs: 100 }),
+			}),
+		);
+		const planner = await createLocalPlacementViewOwnerPlanner(view);
+		try {
+			expect(planner.validUntil).to.equal(1_050n);
+			const plan = planner.plan({
+				resolution: "u32",
+				coordinates: [5],
+				requestedReplicas: 1,
+			});
+			const rows = new Map(
+				plan.owners.map((value) => [value.ownerHash, value.intersecting]),
+			);
+			expect(rows.size).to.equal(2);
+			expect(rows.get(owners[0]!.hash)).to.equal(true);
+			expect(rows.get(owners[1]!.hash)).to.equal(false);
+		} finally {
+			planner.close();
+		}
+	});
+
+	it("preserves absent versus empty peer filters", async () => {
+		const owners = [owner(6), owner(7)];
+		const ranges = [u32Range(owners[0]!, 1, 0), u32Range(owners[1]!, 2, 100)];
+		const absent = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(inputU32({ owners, ranges })),
+		);
+		const empty = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({ owners, ranges, basePeerFilter: [] }),
+			),
+		);
+		try {
+			expect(
+				hashes(
+					absent.plan({
+						resolution: "u32",
+						coordinates: [5],
+						requestedReplicas: 1,
+					}),
+				),
+			).to.deep.equal([owners[0]!.hash]);
+			expect(
+				empty.plan({
+					resolution: "u32",
+					coordinates: [5],
+					requestedReplicas: 1,
+				}).owners,
+			).to.deep.equal([]);
+		} finally {
+			absent.close();
+			empty.close();
+		}
+	});
+
+	it("pins strict-full fallback and self-filter semantics", async () => {
+		const owners = [owner(8), owner(9)];
+		const strictRanges = [
+			u32Range(owners[0]!, 1, 0),
+			u32Range(owners[1]!, 2, 100, { mode: ReplicationIntent.Strict }),
+		];
+		const withoutStrict = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({
+					owners,
+					ranges: strictRanges,
+					policy: policy({
+						minReplicas: 2,
+						maxReplicas: 2,
+						fullReplicaFallback: true,
+						includeStrictFullReplica: false,
+					}),
+				}),
+			),
+		);
+		const withStrict = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({
+					owners,
+					ranges: strictRanges,
+					policy: policy({
+						minReplicas: 2,
+						maxReplicas: 2,
+						fullReplicaFallback: true,
+						includeStrictFullReplica: true,
+					}),
+				}),
+			),
+		);
+		const selfRanges = [
+			u32Range(owners[0]!, 1, 0),
+			u32Range(owners[1]!, 2, 100),
+		];
+		const selfIncluded = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({
+					owners,
+					ranges: selfRanges,
+					self: owners[1],
+					selfReplicating: true,
+					basePeerFilter: [owners[0]!.hash],
+					policy: policy({
+						minReplicas: 2,
+						maxReplicas: 2,
+						expandPeerFilter: true,
+					}),
+				}),
+			),
+		);
+		const selfExcluded = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({
+					owners,
+					ranges: selfRanges,
+					self: owners[1],
+					selfReplicating: false,
+					basePeerFilter: [owners[0]!.hash],
+					policy: policy({
+						minReplicas: 2,
+						maxReplicas: 2,
+						expandPeerFilter: true,
+					}),
+				}),
+			),
+		);
+		try {
+			const coordinates = [50, 60] as const;
+			expect(
+				hashes(
+					withoutStrict.plan({
+						resolution: "u32",
+						coordinates,
+						requestedReplicas: 2,
+					}),
+				),
+			).to.deep.equal([owners[0]!.hash]);
+			expect(
+				hashes(
+					withStrict.plan({
+						resolution: "u32",
+						coordinates,
+						requestedReplicas: 2,
+					}),
+				),
+			).to.have.members(owners.map((value) => value.hash));
+			expect(
+				hashes(
+					selfIncluded.plan({
+						resolution: "u32",
+						coordinates: [5, 105],
+						requestedReplicas: 2,
+					}),
+				),
+			).to.have.members(owners.map((value) => value.hash));
+			expect(
+				hashes(
+					selfExcluded.plan({
+						resolution: "u32",
+						coordinates: [5, 105],
+						requestedReplicas: 2,
+					}),
+				),
+			).to.deep.equal([owners[0]!.hash]);
+		} finally {
+			withoutStrict.close();
+			withStrict.close();
+			selfIncluded.close();
+			selfExcluded.close();
+		}
+	});
+
+	it("rejects unsupported or forged views before loading WASM", async () => {
+		const owners = [owner(10)];
+		const unknown = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners,
+				ranges: [u32Range(owners[0]!, 1, 0)],
+				planner: { id: "unknown", version: 1 },
+			}),
+		);
+		await expect(
+			createLocalPlacementViewOwnerPlanner(unknown),
+		).to.be.rejectedWith("Unsupported local placement owner planner");
+
+		const issued = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({ owners, ranges: [u32Range(owners[0]!, 1, 0)] }),
+		);
+		await expect(
+			createLocalPlacementViewOwnerPlanner({ ...issued }),
+		).to.be.rejectedWith("Invalid issued canonical local placement view");
+		issued.bytes[0] ^= 1;
+		await expect(
+			createLocalPlacementViewOwnerPlanner(issued),
+		).to.be.rejectedWith(
+			"Invalid issued canonical local placement view digest",
+		);
+	});
+
+	it("validates dense typed coordinates and the 100-replica ceiling", async () => {
+		const owners = [owner(11)];
+		const planner = await createLocalPlacementViewOwnerPlanner(
+			canonicalizeLocalPlacementSnapshotV1(
+				inputU32({ owners, ranges: [u32Range(owners[0]!, 1, 0)] }),
+			),
+		);
+		try {
+			expect(() => planner.effectiveReplicas(101)).to.throw(
+				"Invalid local placement owner plan requested replicas",
+			);
+			expect(() => planner.effectiveReplicas(-0)).to.throw(
+				"Invalid local placement owner plan requested replicas",
+			);
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: [],
+					requestedReplicas: 1,
+				}),
+			).to.throw("coordinates must match effective replicas");
+			const sparse = new Array<number>(1);
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: sparse,
+					requestedReplicas: 1,
+				}),
+			).to.throw("Invalid sparse");
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: [MAX_U32 + 1],
+					requestedReplicas: 1,
+				}),
+			).to.throw("Invalid u32");
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: [-0],
+					requestedReplicas: 1,
+				}),
+			).to.throw("Invalid u32");
+			expect(() =>
+				planner.plan({
+					resolution: "u64",
+					coordinates: [MAX_U64],
+					requestedReplicas: 1,
+				}),
+			).to.throw("resolution mismatch");
+
+			let lengthReads = 0;
+			const boundedProxy = new Proxy([5], {
+				get(target, property, receiver) {
+					if (property === "length") {
+						lengthReads++;
+						return lengthReads === 1 ? 1 : Number.MAX_SAFE_INTEGER;
+					}
+					return Reflect.get(target, property, receiver);
+				},
+			});
+			let resolutionReads = 0;
+			const aliasedInput = new Proxy(
+				{
+					resolution: "u32" as const,
+					coordinates: boundedProxy,
+					requestedReplicas: 1,
+				},
+				{
+					get(target, property, receiver) {
+						if (property === "resolution") {
+							resolutionReads++;
+							return resolutionReads === 1 ? "u32" : "u64";
+						}
+						return Reflect.get(target, property, receiver);
+					},
+				},
+			);
+			const boundedPlan = planner.plan(aliasedInput);
+			expect(boundedPlan.resolution).to.equal("u32");
+			expect(lengthReads).to.equal(1);
+			expect(resolutionReads).to.equal(1);
+		} finally {
+			planner.close();
+		}
+	});
+
+	it("rejects unknown and malformed native owner rows", async () => {
+		const owners = [owner(12)];
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({ owners, ranges: [u32Range(owners[0]!, 1, 0)] }),
+		);
+		const planner = await createLocalPlacementViewOwnerPlanner(view);
+		const original = SharedLogRangePlanner.prototype.findLeaders;
+		try {
+			SharedLogRangePlanner.prototype.findLeaders = (() =>
+				new Map([
+					["unknown-owner", { intersecting: true }],
+				])) as typeof original;
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: [5],
+					requestedReplicas: 1,
+				}),
+			).to.throw("Unknown native local placement owner");
+
+			SharedLogRangePlanner.prototype.findLeaders = (() =>
+				new Map([
+					[owners[0]!.hash, { intersecting: "yes" }],
+				])) as unknown as typeof original;
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates: [5],
+					requestedReplicas: 1,
+				}),
+			).to.throw("Invalid native local placement owner sample");
+		} finally {
+			SharedLogRangePlanner.prototype.findLeaders = original;
+			planner.close();
+		}
+	});
+
+	it("frees partial hydration once and preserves cleanup failure causes", async () => {
+		const owners = [owner(13), owner(14)];
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({
+				owners,
+				ranges: [u32Range(owners[0]!, 1, 0), u32Range(owners[1]!, 2, 100)],
+			}),
+		);
+		const originalPut = SharedLogRangePlanner.prototype.put;
+		const originalClose = SharedLogRangePlanner.prototype.close;
+		let puts = 0;
+		let closes = 0;
+		try {
+			SharedLogRangePlanner.prototype.put = function (...args) {
+				puts++;
+				if (puts === 2) throw new Error("hydrate failed");
+				return originalPut.apply(this, args);
+			};
+			SharedLogRangePlanner.prototype.close = function () {
+				closes++;
+				return originalClose.call(this);
+			};
+			await expect(
+				createLocalPlacementViewOwnerPlanner(view),
+			).to.be.rejectedWith("hydrate failed");
+			expect(closes).to.equal(1);
+
+			puts = 0;
+			closes = 0;
+			SharedLogRangePlanner.prototype.close = function () {
+				closes++;
+				originalClose.call(this);
+				throw new Error("cleanup failed");
+			};
+			let failure: unknown;
+			try {
+				await createLocalPlacementViewOwnerPlanner(view);
+			} catch (error) {
+				failure = error;
+			}
+			expect(failure).to.be.instanceOf(AggregateError);
+			expect((failure as AggregateError).errors).to.have.length(2);
+			expect(closes).to.equal(1);
+		} finally {
+			SharedLogRangePlanner.prototype.put = originalPut;
+			SharedLogRangePlanner.prototype.close = originalClose;
+		}
+	});
+
+	it("is fail-closed and idempotent when native close throws", async () => {
+		const owners = [owner(15)];
+		const view = canonicalizeLocalPlacementSnapshotV1(
+			inputU32({ owners, ranges: [u32Range(owners[0]!, 1, 0)] }),
+		);
+		const planner = await createLocalPlacementViewOwnerPlanner(view);
+		const originalClose = SharedLogRangePlanner.prototype.close;
+		let closes = 0;
+		SharedLogRangePlanner.prototype.close = function () {
+			closes++;
+			originalClose.call(this);
+			throw new Error("close failed");
+		};
+		try {
+			expect(() => planner.close()).to.throw("close failed");
+			expect(() => planner.close()).to.not.throw();
+			expect(closes).to.equal(1);
+			expect(() => planner.effectiveReplicas(1)).to.throw("planner is closed");
+			let consumed = false;
+			const coordinates = new Proxy([5], {
+				get(target, property, receiver) {
+					if (property === "length" || property === "0") consumed = true;
+					return Reflect.get(target, property, receiver);
+				},
+			});
+			expect(() =>
+				planner.plan({
+					resolution: "u32",
+					coordinates,
+					requestedReplicas: 1,
+				}),
+			).to.throw("planner is closed");
+			expect(consumed).to.equal(false);
+		} finally {
+			SharedLogRangePlanner.prototype.close = originalClose;
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Stacked on #1299.

This adds the next non-destructive runtime primitive for the shared-log scaling work: compile one complete, capped, locally authenticated placement view into an isolated native owner planner, then answer deterministic bounded owner queries without reading an Index.

- accept only canonical placement views issued in the current process and revalidate their bytes/digest before native allocation
- hydrate the complete frozen range set once, converting canonical range IDs back to the runtime base64 representation
- expose bounded u32/u64 plans with exact dense coordinates, the protocol's 100-replica ceiling, canonical owner ordering, immutable authenticated key rows, and a versioned `planId`
- pass every captured policy/time/filter/self-role input explicitly; planning never uses `Date.now()` or live runtime state
- give standalone native range planners an explicit idempotent `close()`/`free()` lifecycle and reject work before consuming inputs after release
- close partial hydration exactly once and preserve cleanup failures

## Boundedness

For an issued view, construction is bounded by the existing view ceilings (4,096 owners / 16,384 ranges / 4 MiB). Each plan accepts at most 100 coordinates, validates native output against the issued owner set before materializing rows, and caps canonical plan-identity encoding at 4 MiB.

This module has no Index dependency and no `.all()` path.

## Safety boundary

The view digest and `planId` are local deterministic decision identities only. They are not a global placement epoch, transfer acknowledgement, custody receipt, retention pin, or pruning authority. This PR does not schedule runtime work, transfer entries, or delete data.

Before destructive maintenance is possible, follow-ups still need bounded fresh-view capture with current V2 provenance, a concurrent-write fence/outbox, destination durable custody receipts and pins, a source receipt/prune journal, and a final lane-fenced placement revalidation.

## Tests

- local placement view + owner planner: 25 passing
- pure owner planner: 12 passing (real u32/u64 WASM)
- Rust core: 42 passing
- native planner close/lifecycle: passing
- shared-log and shared-log-rust builds
- changed-file ESLint
- shard coverage guard
- `git diff --check`
