### PR TITLE
feat(shared-log): snapshot native placement ranges

### DIFF
--- a/.changeset/bounded-native-range-snapshots.md
+++ b/.changeset/bounded-native-range-snapshots.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/shared-log-rust": patch
+"@peerbit/native-backbone": patch
+---
+
+Add complete-or-overflow bounded snapshots of resident native shared-log range
+geometry and unauthenticated owner hashes, including native-backbone forwarding.

--- a/packages/programs/data/shared-log/rust/src/error.rs
+++ b/packages/programs/data/shared-log/rust/src/error.rs
@@ -20,6 +20,11 @@ pub enum SharedLogError {
     ExpectedLeaderIntersectingBool,
     MismatchedInputLengths(&'static str),
     MissingCompactAppendFacts,
+    InvalidRangeSnapshotLimit(&'static str),
+    RangeSnapshotIndexInconsistent,
+    RangeSnapshotResolutionMismatch,
+    RangeSnapshotInvalidRange,
+    RangeSnapshotAccountingOverflow,
     InvalidRebalanceCollisionBucketLimit(&'static str),
     RebalanceCollisionBucketIndexInconsistent,
     RebalanceCollisionBucketResolutionMismatch,
@@ -57,6 +62,21 @@ impl std::fmt::Display for SharedLogError {
             }
             SharedLogError::MissingCompactAppendFacts => {
                 f.write_str("Missing compact append facts")
+            }
+            SharedLogError::InvalidRangeSnapshotLimit(label) => {
+                write!(f, "Invalid native range snapshot limit: {label}")
+            }
+            SharedLogError::RangeSnapshotIndexInconsistent => {
+                f.write_str("Native range snapshot index is inconsistent")
+            }
+            SharedLogError::RangeSnapshotResolutionMismatch => {
+                f.write_str("Native range snapshot value exceeds its resolution")
+            }
+            SharedLogError::RangeSnapshotInvalidRange => {
+                f.write_str("Native range snapshot contains an invalid range")
+            }
+            SharedLogError::RangeSnapshotAccountingOverflow => {
+                f.write_str("Native range snapshot accounting overflow")
             }
             SharedLogError::InvalidRebalanceCollisionBucketLimit(label) => {
                 write!(

--- a/packages/programs/data/shared-log/rust/src/index.ts
+++ b/packages/programs/data/shared-log/rust/src/index.ts
@@ -1,5 +1,76 @@
 export type RangeResolution = "u32" | "u64";
 
+export type NativeRangeSnapshotLimits = Readonly<{
+	maxOwners: number;
+	maxRanges: number;
+	maxRangesPerOwner: number;
+	/** UTF-8 bytes of the native runtime id string (normally padded base64). */
+	maxRangeIdBytes: number;
+	/** UTF-8 bytes of the owner hash. This is not a public-key byte limit. */
+	maxOwnerHashBytes: number;
+	/**
+	 * Logical binary accounting: two u32 counts, then per range two u32 UTF-8
+	 * lengths and strings, one u64 timestamp, five resolution-width coordinates,
+	 * and one u8 mode. This is not the decimal-string/array allocation used by
+	 * the WASM bridge; row and string caps bound that allocation.
+	 */
+	maxBytes: number;
+}>;
+
+export const MAX_NATIVE_RANGE_SNAPSHOT_LIMITS: NativeRangeSnapshotLimits =
+	Object.freeze({
+		maxOwners: 4096,
+		maxRanges: 16_384,
+		maxRangesPerOwner: 4096,
+		maxRangeIdBytes: 684,
+		maxOwnerHashBytes: 512,
+		maxBytes: 4 * 1024 * 1024,
+	});
+
+export type NativeRangeSnapshotOverflowCode =
+	| "owners"
+	| "ranges"
+	| "ranges-per-owner"
+	| "range-id"
+	| "owner-hash"
+	| "bytes";
+
+export class NativeRangeSnapshotOverflowError extends Error {
+	constructor(readonly code: NativeRangeSnapshotOverflowCode) {
+		super(`Native range snapshot exceeded ${code}`);
+		this.name = "NativeRangeSnapshotOverflowError";
+	}
+}
+
+export type NativeRangeSnapshotRangeFor<R extends RangeResolution> = Readonly<{
+	idString: string;
+	/** Unauthenticated owner hash copied from the local native range mirror. */
+	ownerHash: string;
+	timestamp: bigint;
+	start1: R extends "u64" ? bigint : number;
+	end1: R extends "u64" ? bigint : number;
+	start2: R extends "u64" ? bigint : number;
+	end2: R extends "u64" ? bigint : number;
+	width: R extends "u64" ? bigint : number;
+	mode: 0 | 1;
+}>;
+
+export type NativeRangeSnapshotResultFor<R extends RangeResolution> = Readonly<{
+	resolution: R;
+	complete: true;
+	ownerCount: number;
+	rangeCount: number;
+	/** Logical binary bytes represented by this complete snapshot (see limits). */
+	bytes: number;
+	rangeIdBytes: number;
+	ownerHashBytes: number;
+	ranges: ReadonlyArray<NativeRangeSnapshotRangeFor<R>>;
+}>;
+
+export type NativeRangeSnapshotResult =
+	| NativeRangeSnapshotResultFor<"u32">
+	| NativeRangeSnapshotResultFor<"u64">;
+
 export type NativeRebalanceCollisionBucketLimits = Readonly<{
 	maxRows: number;
 	maxIdentifierBytes: number;
@@ -230,6 +301,14 @@ type NativeRangePlannerHandle = {
 	free: () => void;
 	len: () => number;
 	clear: () => void;
+	read_range_snapshot: (
+		maxOwners: number,
+		maxRanges: number,
+		maxRangesPerOwner: number,
+		maxRangeIdBytes: number,
+		maxOwnerHashBytes: number,
+		maxBytes: number,
+	) => unknown[];
 	put: (
 		id: string,
 		hash: string,
@@ -380,6 +459,7 @@ type NativeRangePlannerHandle = {
 type NativeSharedLogStateHandle = {
 	len: () => number;
 	clear: () => void;
+	read_range_snapshot: NativeRangePlannerHandle["read_range_snapshot"];
 	/** @internal */
 	full_replica_candidates_for: (
 		minReplicas: number,
@@ -709,6 +789,318 @@ const asIntegerString = (value: bigint | number | string) =>
 const MAX_NATIVE_REBALANCE_U32 = 0xffff_ffffn;
 const MAX_NATIVE_REBALANCE_U64 = 0xffff_ffff_ffff_ffffn;
 const canonicalUnsignedInteger = /^(0|[1-9][0-9]*)$/;
+const nativeRangeSnapshotEncoder = new TextEncoder();
+
+const rangeSnapshotLimits = (
+	limits: NativeRangeSnapshotLimits,
+): NativeRangeSnapshotLimits => {
+	if (!limits || typeof limits !== "object") {
+		throw new Error("Invalid native range snapshot limits");
+	}
+	const out = {} as Record<keyof NativeRangeSnapshotLimits, number>;
+	for (const name of Object.keys(MAX_NATIVE_RANGE_SNAPSHOT_LIMITS) as Array<
+		keyof NativeRangeSnapshotLimits
+	>) {
+		const value = limits[name];
+		if (
+			!Number.isSafeInteger(value) ||
+			value <= 0 ||
+			value > MAX_NATIVE_RANGE_SNAPSHOT_LIMITS[name]
+		) {
+			throw new Error(`Invalid native range snapshot limit: ${name}`);
+		}
+		out[name] = value;
+	}
+	return Object.freeze(out) as NativeRangeSnapshotLimits;
+};
+
+const rangeSnapshotOverflowCodes = new Set<NativeRangeSnapshotOverflowCode>([
+	"owners",
+	"ranges",
+	"ranges-per-owner",
+	"range-id",
+	"owner-hash",
+	"bytes",
+]);
+
+const rangeSnapshotCount = (value: unknown): number => {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return value as number;
+};
+
+const rangeSnapshotString = (
+	value: unknown,
+	maximumBytes: number,
+): { value: string; encoded: Uint8Array } => {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > maximumBytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const encoded = nativeRangeSnapshotEncoder.encode(value);
+	if (encoded.byteLength > maximumBytes) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return { value, encoded };
+};
+
+const rangeSnapshotUnsigned = (value: unknown): bigint => {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > 20 ||
+		!canonicalUnsignedInteger.test(value)
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const parsed = BigInt(value);
+	if (parsed > MAX_NATIVE_REBALANCE_U64) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return parsed;
+};
+
+type ParsedNativeRangeSnapshotRow = {
+	idString: string;
+	ownerHash: string;
+	timestamp: bigint;
+	start1: bigint;
+	end1: bigint;
+	start2: bigint;
+	end2: bigint;
+	width: bigint;
+	mode: 0 | 1;
+	idBytes: number;
+	ownerHashBytes: number;
+	idOrderBytes: Uint8Array;
+	ownerHashOrderBytes: Uint8Array;
+};
+
+const compareNativeRangeSnapshotBytes = (
+	left: Uint8Array,
+	right: Uint8Array,
+): number => {
+	const length = Math.min(left.byteLength, right.byteLength);
+	for (let index = 0; index < length; index++) {
+		if (left[index]! < right[index]!) return -1;
+		if (left[index]! > right[index]!) return 1;
+	}
+	return left.byteLength - right.byteLength;
+};
+
+const compareNativeRangeSnapshotRows = (
+	left: ParsedNativeRangeSnapshotRow,
+	right: ParsedNativeRangeSnapshotRow,
+): number => {
+	const ownerOrder = compareNativeRangeSnapshotBytes(
+		left.ownerHashOrderBytes,
+		right.ownerHashOrderBytes,
+	);
+	if (ownerOrder !== 0) return ownerOrder;
+	const idOrder = compareNativeRangeSnapshotBytes(
+		left.idOrderBytes,
+		right.idOrderBytes,
+	);
+	if (idOrder !== 0) return idOrder;
+	for (const [a, b] of [
+		[left.timestamp, right.timestamp],
+		[left.start1, right.start1],
+		[left.end1, right.end1],
+		[left.start2, right.start2],
+		[left.end2, right.end2],
+		[left.width, right.width],
+	] as const) {
+		if (a < b) return -1;
+		if (a > b) return 1;
+	}
+	return left.mode - right.mode;
+};
+
+const nativeRangeSnapshotGeometryIsValid = (
+	resolution: RangeResolution,
+	range: ParsedNativeRangeSnapshotRow,
+): boolean => {
+	const maximum =
+		resolution === "u32" ? MAX_NATIVE_REBALANCE_U32 : MAX_NATIVE_REBALANCE_U64;
+	if (
+		[range.start1, range.end1, range.start2, range.end2, range.width].some(
+			(value) => value > maximum,
+		)
+	) {
+		return false;
+	}
+	const unscaledEnd = range.start1 + range.width;
+	const expectedEnd1 = unscaledEnd < maximum ? unscaledEnd : maximum;
+	const [expectedStart2, expectedEnd2] =
+		unscaledEnd > maximum
+			? [
+					0n,
+					range.width === maximum
+						? range.start1 % maximum
+						: unscaledEnd % maximum,
+				]
+			: [range.start1, expectedEnd1];
+	if (
+		range.end1 !== expectedEnd1 ||
+		range.start2 !== expectedStart2 ||
+		range.end2 !== expectedEnd2
+	) {
+		return false;
+	}
+	const reconstructedWidth =
+		range.end1 -
+		range.start1 +
+		(range.end2 < range.end1 ? range.end2 - range.start2 : 0n);
+	return reconstructedWidth === range.width;
+};
+
+const rangeSnapshotFromRow = (
+	resolution: RangeResolution,
+	rowValue: unknown,
+	limits: NativeRangeSnapshotLimits,
+): NativeRangeSnapshotResult => {
+	if (!Array.isArray(rowValue)) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	if (rowValue[0] === 2) {
+		if (rowValue.length !== 2) {
+			throw new Error("Invalid native range snapshot overflow");
+		}
+		const code = rowValue[1] as NativeRangeSnapshotOverflowCode;
+		if (!rangeSnapshotOverflowCodes.has(code)) {
+			throw new Error("Invalid native range snapshot overflow");
+		}
+		throw new NativeRangeSnapshotOverflowError(code);
+	}
+	if (rowValue.length !== 7 || rowValue[0] !== 1) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const ownerCount = rangeSnapshotCount(rowValue[1]);
+	const rangeCount = rangeSnapshotCount(rowValue[2]);
+	const bytes = rangeSnapshotCount(rowValue[3]);
+	const expectedRangeIdBytes = rangeSnapshotCount(rowValue[4]);
+	const expectedOwnerHashBytes = rangeSnapshotCount(rowValue[5]);
+	const rows = rowValue[6];
+	if (
+		!Array.isArray(rows) ||
+		rows.length !== rangeCount ||
+		ownerCount > limits.maxOwners ||
+		rangeCount > limits.maxRanges ||
+		bytes > limits.maxBytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+
+	const parsed: ParsedNativeRangeSnapshotRow[] = [];
+	const ids = new Set<string>();
+	const ownerCounts = new Map<string, number>();
+	let rangeIdBytes = 0;
+	let ownerHashBytes = 0;
+	let logicalBytes = 8;
+	const coordinateWidth = resolution === "u32" ? 4 : 8;
+	const fixedRangeBytes = 4 + 4 + 8 + 5 * coordinateWidth + 1;
+	for (let index = 0; index < rangeCount; index++) {
+		if (!Object.prototype.hasOwnProperty.call(rows, index)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const row = rows[index];
+		if (!Array.isArray(row) || row.length !== 9) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const id = rangeSnapshotString(row[0], limits.maxRangeIdBytes);
+		const owner = rangeSnapshotString(row[1], limits.maxOwnerHashBytes);
+		if (ids.has(id.value)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		ids.add(id.value);
+		const mode = row[8];
+		if (mode !== 0 && mode !== 1) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const item: ParsedNativeRangeSnapshotRow = {
+			idString: id.value,
+			ownerHash: owner.value,
+			timestamp: rangeSnapshotUnsigned(row[2]),
+			start1: rangeSnapshotUnsigned(row[3]),
+			end1: rangeSnapshotUnsigned(row[4]),
+			start2: rangeSnapshotUnsigned(row[5]),
+			end2: rangeSnapshotUnsigned(row[6]),
+			width: rangeSnapshotUnsigned(row[7]),
+			mode,
+			idBytes: id.encoded.byteLength,
+			ownerHashBytes: owner.encoded.byteLength,
+			idOrderBytes: id.encoded,
+			ownerHashOrderBytes: owner.encoded,
+		};
+		if (!nativeRangeSnapshotGeometryIsValid(resolution, item)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const ownerRangeCount = (ownerCounts.get(item.ownerHash) ?? 0) + 1;
+		if (ownerRangeCount > limits.maxRangesPerOwner) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		ownerCounts.set(item.ownerHash, ownerRangeCount);
+		if (ownerCounts.size > limits.maxOwners) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		rangeIdBytes += item.idBytes;
+		ownerHashBytes += item.ownerHashBytes;
+		logicalBytes += fixedRangeBytes + item.idBytes + item.ownerHashBytes;
+		if (
+			!Number.isSafeInteger(rangeIdBytes) ||
+			!Number.isSafeInteger(ownerHashBytes) ||
+			!Number.isSafeInteger(logicalBytes) ||
+			logicalBytes > limits.maxBytes
+		) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		if (
+			parsed.length > 0 &&
+			compareNativeRangeSnapshotRows(parsed[parsed.length - 1]!, item) >= 0
+		) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		parsed.push(item);
+	}
+	if (
+		ownerCounts.size !== ownerCount ||
+		rangeIdBytes !== expectedRangeIdBytes ||
+		ownerHashBytes !== expectedOwnerHashBytes ||
+		logicalBytes !== bytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+
+	const ranges = Object.freeze(
+		parsed.map((range) =>
+			Object.freeze({
+				idString: range.idString,
+				ownerHash: range.ownerHash,
+				timestamp: range.timestamp,
+				start1: resolution === "u32" ? Number(range.start1) : range.start1,
+				end1: resolution === "u32" ? Number(range.end1) : range.end1,
+				start2: resolution === "u32" ? Number(range.start2) : range.start2,
+				end2: resolution === "u32" ? Number(range.end2) : range.end2,
+				width: resolution === "u32" ? Number(range.width) : range.width,
+				mode: range.mode,
+			}),
+		),
+	);
+	return Object.freeze({
+		resolution,
+		complete: true,
+		ownerCount,
+		rangeCount,
+		bytes,
+		rangeIdBytes,
+		ownerHashBytes,
+		ranges,
+	}) as NativeRangeSnapshotResult;
+};
 
 const rebalanceCollisionBucketCursor = (
 	resolution: RangeResolution,
@@ -990,6 +1382,29 @@ export class SharedLogRangePlanner {
 
 	clear(): void {
 		this.handle().clear();
+	}
+
+	/**
+	 * Copies every resident range only after the complete set passes native and
+	 * wrapper caps. Owner hashes are local facts, not authenticated identities.
+	 */
+	readRangeSnapshot(
+		limits: NativeRangeSnapshotLimits,
+	): NativeRangeSnapshotResult {
+		const native = this.handle();
+		const bounded = rangeSnapshotLimits(limits);
+		return rangeSnapshotFromRow(
+			this.resolution,
+			native.read_range_snapshot(
+				bounded.maxOwners,
+				bounded.maxRanges,
+				bounded.maxRangesPerOwner,
+				bounded.maxRangeIdBytes,
+				bounded.maxOwnerHashBytes,
+				bounded.maxBytes,
+			),
+			bounded,
+		);
 	}
 
 	put(range: NativeReplicationRange): void {
@@ -1295,6 +1710,25 @@ export class SharedLogNativeState {
 
 	clear(): void {
 		this.native.clear();
+	}
+
+	/** Complete-or-overflow copy of unauthenticated native range facts. */
+	readRangeSnapshot(
+		limits: NativeRangeSnapshotLimits,
+	): NativeRangeSnapshotResult {
+		const bounded = rangeSnapshotLimits(limits);
+		return rangeSnapshotFromRow(
+			this.resolution,
+			this.native.read_range_snapshot(
+				bounded.maxOwners,
+				bounded.maxRanges,
+				bounded.maxRangesPerOwner,
+				bounded.maxRangeIdBytes,
+				bounded.maxOwnerHashBytes,
+				bounded.maxBytes,
+			),
+			bounded,
+		);
 	}
 
 	/** @internal */

--- a/packages/programs/data/shared-log/rust/src/lib.rs
+++ b/packages/programs/data/shared-log/rust/src/lib.rs
@@ -24,6 +24,14 @@ const MAX_CONTAINMENT_BUCKETS_PER_RANGE: usize = 8;
 // before another compaction.
 const CONTAINMENT_RETAINED_CAPACITY_RATIO: usize = 2;
 const CONTAINMENT_RETAINED_CAPACITY_SLACK: usize = 8;
+const MAX_RANGE_SNAPSHOT_OWNERS: usize = 4096;
+const MAX_RANGE_SNAPSHOT_RANGES: usize = 16_384;
+const MAX_RANGE_SNAPSHOT_RANGES_PER_OWNER: usize = 4096;
+// Local placement views admit at most 512 raw id bytes. Runtime ids use
+// padded standard base64, whose largest encoding for 512 bytes is 684 bytes.
+const MAX_RANGE_SNAPSHOT_RANGE_ID_BYTES: usize = 684;
+const MAX_RANGE_SNAPSHOT_OWNER_HASH_BYTES: usize = 512;
+const MAX_RANGE_SNAPSHOT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_REBALANCE_COLLISION_BUCKET_ROWS: usize = 1024;
 const MAX_REBALANCE_COLLISION_BUCKET_IDENTIFIER_BYTES: usize = 512;
 const MAX_REBALANCE_COLLISION_BUCKET_COORDINATE_VALUES: usize = 1024 * 100;
@@ -434,6 +442,54 @@ struct PeerRangeStats {
     non_strict: BTreeSet<PeerRangeKey>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RangeSnapshotLimits {
+    max_owners: usize,
+    max_ranges: usize,
+    max_ranges_per_owner: usize,
+    max_range_id_bytes: usize,
+    max_owner_hash_bytes: usize,
+    max_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RangeSnapshotOverflow {
+    Owners,
+    Ranges,
+    RangesPerOwner,
+    RangeId,
+    OwnerHash,
+    Bytes,
+}
+
+impl RangeSnapshotOverflow {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Owners => "owners",
+            Self::Ranges => "ranges",
+            Self::RangesPerOwner => "ranges-per-owner",
+            Self::RangeId => "range-id",
+            Self::OwnerHash => "owner-hash",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RangeSnapshot<'a> {
+    owners: usize,
+    range_id_bytes: usize,
+    owner_hash_bytes: usize,
+    bytes: usize,
+    ranges: Vec<&'a ReplicationRange>,
+}
+
+#[derive(Debug)]
+enum RangeSnapshotPreflight<'a> {
+    Overflow(RangeSnapshotOverflow),
+    Snapshot(RangeSnapshot<'a>),
+}
+
 impl PeerRangeStats {
     fn insert(&mut self, range: &ReplicationRange) {
         let key = PeerRangeKey::from_range(range);
@@ -503,6 +559,214 @@ impl RangePlanner {
         self.wide_containment_ranges = IndexSet::new();
         self.containment_put_order = IndexSet::new();
         self.peer_ranges.clear();
+    }
+
+    fn preflight_range_snapshot(
+        &self,
+        limits: RangeSnapshotLimits,
+    ) -> Result<RangeSnapshotPreflight<'_>, SharedLogError> {
+        validate_range_snapshot_limits(limits)?;
+
+        // These two cardinality gates are O(1). An accidentally global or
+        // corrupt planner is rejected before any range-sized scan or output
+        // allocation. Every check below therefore visits at most the caller's
+        // bounded maximum number of native rows.
+        if self.ranges.len() > limits.max_ranges {
+            return Ok(RangeSnapshotPreflight::Overflow(
+                RangeSnapshotOverflow::Ranges,
+            ));
+        }
+        if self.peer_ranges.len() > limits.max_owners {
+            return Ok(RangeSnapshotPreflight::Overflow(
+                RangeSnapshotOverflow::Owners,
+            ));
+        }
+
+        let coordinate_width = match self.resolution {
+            Resolution::U32 => 4usize,
+            Resolution::U64 => 8usize,
+        };
+        // Canonical logical binary bytes: owner/range counts, a u32 byte length
+        // before both strings, the UTF-8 strings, timestamp, five coordinates,
+        // and mode. This is deliberately not an estimate of decimal-string and
+        // array allocation across the WASM bridge; cardinality/string caps bound
+        // that allocation independently.
+        let fixed_range_bytes = 4usize
+            .checked_add(4)
+            .and_then(|value| value.checked_add(8))
+            .and_then(|value| value.checked_add(5 * coordinate_width))
+            .and_then(|value| value.checked_add(1))
+            .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+        let mut bytes = 8usize;
+        if bytes > limits.max_bytes {
+            return Ok(RangeSnapshotPreflight::Overflow(
+                RangeSnapshotOverflow::Bytes,
+            ));
+        }
+        let mut range_id_bytes = 0usize;
+        let mut owner_hash_bytes = 0usize;
+        let mut owner_counts: HashMap<&str, (usize, usize)> = HashMap::new();
+        let mut ranges = Vec::with_capacity(self.ranges.len());
+
+        for (map_id, range) in &self.ranges {
+            if map_id != &range.id {
+                return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+            }
+            if range.id.is_empty() || range.hash.is_empty() || range.mode > 1 {
+                return Err(SharedLogError::RangeSnapshotInvalidRange);
+            }
+            if !self.range_geometry_is_valid(range) {
+                return Err(match self.resolution {
+                    Resolution::U32
+                        if [
+                            range.start1,
+                            range.end1,
+                            range.start2,
+                            range.end2,
+                            range.width,
+                        ]
+                        .iter()
+                        .any(|value| *value > MAX_U32) =>
+                    {
+                        SharedLogError::RangeSnapshotResolutionMismatch
+                    }
+                    _ => SharedLogError::RangeSnapshotInvalidRange,
+                });
+            }
+            if range.id.len() > limits.max_range_id_bytes {
+                return Ok(RangeSnapshotPreflight::Overflow(
+                    RangeSnapshotOverflow::RangeId,
+                ));
+            }
+            if range.hash.len() > limits.max_owner_hash_bytes {
+                return Ok(RangeSnapshotPreflight::Overflow(
+                    RangeSnapshotOverflow::OwnerHash,
+                ));
+            }
+
+            let counts = owner_counts.entry(range.hash.as_str()).or_default();
+            counts.0 = counts
+                .0
+                .checked_add(1)
+                .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+            if range.mode == MODE_NON_STRICT {
+                counts.1 = counts
+                    .1
+                    .checked_add(1)
+                    .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+            }
+            if counts.0 > limits.max_ranges_per_owner {
+                return Ok(RangeSnapshotPreflight::Overflow(
+                    RangeSnapshotOverflow::RangesPerOwner,
+                ));
+            }
+            if owner_counts.len() > limits.max_owners {
+                return Ok(RangeSnapshotPreflight::Overflow(
+                    RangeSnapshotOverflow::Owners,
+                ));
+            }
+
+            range_id_bytes = range_id_bytes
+                .checked_add(range.id.len())
+                .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+            owner_hash_bytes = owner_hash_bytes
+                .checked_add(range.hash.len())
+                .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+            bytes = bytes
+                .checked_add(fixed_range_bytes)
+                .and_then(|value| value.checked_add(range.id.len()))
+                .and_then(|value| value.checked_add(range.hash.len()))
+                .ok_or(SharedLogError::RangeSnapshotAccountingOverflow)?;
+            if bytes > limits.max_bytes {
+                return Ok(RangeSnapshotPreflight::Overflow(
+                    RangeSnapshotOverflow::Bytes,
+                ));
+            }
+
+            let Some(stats) = self.peer_ranges.get(&range.hash) else {
+                return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+            };
+            let key = PeerRangeKey::from_range(range);
+            if !stats.all.contains(&key)
+                || stats.non_strict.contains(&key) != (range.mode == MODE_NON_STRICT)
+            {
+                return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+            }
+            ranges.push(range);
+        }
+
+        if owner_counts.len() != self.peer_ranges.len() {
+            return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+        }
+        for (hash, stats) in &self.peer_ranges {
+            let Some((all, non_strict)) = owner_counts.get(hash.as_str()) else {
+                return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+            };
+            if stats.all.len() != *all || stats.non_strict.len() != *non_strict {
+                return Err(SharedLogError::RangeSnapshotIndexInconsistent);
+            }
+        }
+
+        ranges.sort_unstable_by(|left, right| {
+            left.hash
+                .cmp(&right.hash)
+                .then_with(|| left.id.cmp(&right.id))
+                .then_with(|| left.timestamp.cmp(&right.timestamp))
+                .then_with(|| left.start1.cmp(&right.start1))
+                .then_with(|| left.end1.cmp(&right.end1))
+                .then_with(|| left.start2.cmp(&right.start2))
+                .then_with(|| left.end2.cmp(&right.end2))
+                .then_with(|| left.width.cmp(&right.width))
+                .then_with(|| left.mode.cmp(&right.mode))
+        });
+        Ok(RangeSnapshotPreflight::Snapshot(RangeSnapshot {
+            owners: owner_counts.len(),
+            range_id_bytes,
+            owner_hash_bytes,
+            bytes,
+            ranges,
+        }))
+    }
+
+    fn range_geometry_is_valid(&self, range: &ReplicationRange) -> bool {
+        let maximum = self.resolution.max_value();
+        if [
+            range.start1,
+            range.end1,
+            range.start2,
+            range.end2,
+            range.width,
+        ]
+        .iter()
+        .any(|value| *value > maximum)
+        {
+            return false;
+        }
+        let unscaled_end = range.start1 as u128 + range.width as u128;
+        let expected_end1 = unscaled_end.min(maximum as u128) as u64;
+        let (expected_start2, expected_end2) = if unscaled_end > maximum as u128 {
+            let end2 = if range.width == maximum {
+                range.start1 % maximum
+            } else {
+                (unscaled_end % maximum as u128) as u64
+            };
+            (0, end2)
+        } else {
+            (range.start1, expected_end1)
+        };
+        if range.end1 != expected_end1
+            || range.start2 != expected_start2
+            || range.end2 != expected_end2
+        {
+            return false;
+        }
+        let reconstructed_width = (range.end1 - range.start1)
+            + if range.end2 < range.end1 {
+                range.end2 - range.start2
+            } else {
+                0
+            };
+        range.width == reconstructed_width
     }
 
     pub fn put(&mut self, range: ReplicationRange) {
@@ -1114,6 +1378,73 @@ impl RangePlanner {
         }
         Some(range)
     }
+}
+
+fn validate_range_snapshot_limits(limits: RangeSnapshotLimits) -> Result<(), SharedLogError> {
+    let valid = [
+        (limits.max_owners, MAX_RANGE_SNAPSHOT_OWNERS, "maxOwners"),
+        (limits.max_ranges, MAX_RANGE_SNAPSHOT_RANGES, "maxRanges"),
+        (
+            limits.max_ranges_per_owner,
+            MAX_RANGE_SNAPSHOT_RANGES_PER_OWNER,
+            "maxRangesPerOwner",
+        ),
+        (
+            limits.max_range_id_bytes,
+            MAX_RANGE_SNAPSHOT_RANGE_ID_BYTES,
+            "maxRangeIdBytes",
+        ),
+        (
+            limits.max_owner_hash_bytes,
+            MAX_RANGE_SNAPSHOT_OWNER_HASH_BYTES,
+            "maxOwnerHashBytes",
+        ),
+        (limits.max_bytes, MAX_RANGE_SNAPSHOT_BYTES, "maxBytes"),
+    ];
+    for (value, maximum, label) in valid {
+        if value == 0 || value > maximum {
+            return Err(SharedLogError::InvalidRangeSnapshotLimit(label));
+        }
+    }
+    Ok(())
+}
+
+fn range_snapshot_to_rows(
+    planner: &RangePlanner,
+    limits: RangeSnapshotLimits,
+) -> Result<Array, JsValue> {
+    let preflight = planner.preflight_range_snapshot(limits)?;
+    let out = Array::new();
+    match preflight {
+        RangeSnapshotPreflight::Overflow(overflow) => {
+            out.push(&JsValue::from_f64(2.0));
+            out.push(&JsValue::from_str(overflow.code()));
+        }
+        RangeSnapshotPreflight::Snapshot(snapshot) => {
+            let rows = Array::new();
+            for range in snapshot.ranges {
+                let row = Array::new();
+                row.push(&JsValue::from_str(&range.id));
+                row.push(&JsValue::from_str(&range.hash));
+                row.push(&JsValue::from_str(&range.timestamp.to_string()));
+                row.push(&JsValue::from_str(&range.start1.to_string()));
+                row.push(&JsValue::from_str(&range.end1.to_string()));
+                row.push(&JsValue::from_str(&range.start2.to_string()));
+                row.push(&JsValue::from_str(&range.end2.to_string()));
+                row.push(&JsValue::from_str(&range.width.to_string()));
+                row.push(&JsValue::from_f64(range.mode as f64));
+                rows.push(&row);
+            }
+            out.push(&JsValue::from_f64(1.0));
+            out.push(&JsValue::from_f64(snapshot.owners as f64));
+            out.push(&JsValue::from_f64(rows.length() as f64));
+            out.push(&JsValue::from_f64(snapshot.bytes as f64));
+            out.push(&JsValue::from_f64(snapshot.range_id_bytes as f64));
+            out.push(&JsValue::from_f64(snapshot.owner_hash_bytes as f64));
+            out.push(&rows);
+        }
+    }
+    Ok(out)
 }
 
 fn compare_closest(
@@ -2146,6 +2477,31 @@ impl NativeRangePlanner {
         self.inner.clear();
     }
 
+    /// Return either every resident range or one overflow code. Cardinality
+    /// and byte limits are checked before any range row is exposed to JS.
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_range_snapshot(
+        &self,
+        max_owners: usize,
+        max_ranges: usize,
+        max_ranges_per_owner: usize,
+        max_range_id_bytes: usize,
+        max_owner_hash_bytes: usize,
+        max_bytes: usize,
+    ) -> Result<Array, JsValue> {
+        range_snapshot_to_rows(
+            &self.inner,
+            RangeSnapshotLimits {
+                max_owners,
+                max_ranges,
+                max_ranges_per_owner,
+                max_range_id_bytes,
+                max_owner_hash_bytes,
+                max_bytes,
+            },
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn put(
         &mut self,
@@ -2771,6 +3127,31 @@ impl NativeSharedLogState {
 
     pub fn clear(&mut self) {
         self.inner.clear_all();
+    }
+
+    /// Return either every resident range or one overflow code. This snapshots
+    /// only placement geometry and owner hashes; it authenticates no identity.
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_range_snapshot(
+        &self,
+        max_owners: usize,
+        max_ranges: usize,
+        max_ranges_per_owner: usize,
+        max_range_id_bytes: usize,
+        max_owner_hash_bytes: usize,
+        max_bytes: usize,
+    ) -> Result<Array, JsValue> {
+        range_snapshot_to_rows(
+            &self.inner.range_planner,
+            RangeSnapshotLimits {
+                max_owners,
+                max_ranges,
+                max_ranges_per_owner,
+                max_range_id_bytes,
+                max_owner_hash_bytes,
+                max_bytes,
+            },
+        )
     }
 
     pub fn full_replica_candidates_for(&self, min_replicas: usize, self_hash: String) -> Array {
@@ -4811,11 +5192,14 @@ mod tests {
     use super::{
         compare_closest, find_leaders_with_prepared_options, ContainmentIndexLocation,
         EntryCoordinateState, FallbackCandidateStreams, FallbackKeyStream, LeaderSample,
-        NativeSharedLogState, RangePlanner, RebalanceCollisionBucketLimits,
-        RebalanceCollisionBucketOverflow, RebalanceCollisionBucketPreflight, ReplicationRange,
-        SampleOptions, SharedLogError, CONTAINMENT_BUCKETS, CONTAINMENT_RETAINED_CAPACITY_RATIO,
-        CONTAINMENT_RETAINED_CAPACITY_SLACK, MAX_CONTAINMENT_BUCKETS_PER_RANGE, MAX_U32, MAX_U64,
-        MODE_NON_STRICT,
+        NativeSharedLogState, RangePlanner, RangeSnapshotLimits, RangeSnapshotOverflow,
+        RangeSnapshotPreflight, RebalanceCollisionBucketLimits, RebalanceCollisionBucketOverflow,
+        RebalanceCollisionBucketPreflight, ReplicationRange, SampleOptions, SharedLogError,
+        CONTAINMENT_BUCKETS, CONTAINMENT_RETAINED_CAPACITY_RATIO,
+        CONTAINMENT_RETAINED_CAPACITY_SLACK, MAX_CONTAINMENT_BUCKETS_PER_RANGE,
+        MAX_RANGE_SNAPSHOT_BYTES, MAX_RANGE_SNAPSHOT_OWNERS, MAX_RANGE_SNAPSHOT_OWNER_HASH_BYTES,
+        MAX_RANGE_SNAPSHOT_RANGES, MAX_RANGE_SNAPSHOT_RANGES_PER_OWNER,
+        MAX_RANGE_SNAPSHOT_RANGE_ID_BYTES, MAX_U32, MAX_U64, MODE_NON_STRICT,
     };
     use indexmap::IndexSet;
     use std::collections::HashSet;
@@ -4829,6 +5213,31 @@ mod tests {
             max_coordinate_bytes: 4 * 1024 * 1024,
             max_bytes: 4 * 1024 * 1024,
         }
+    }
+
+    fn range_snapshot_limits() -> RangeSnapshotLimits {
+        RangeSnapshotLimits {
+            max_owners: MAX_RANGE_SNAPSHOT_OWNERS,
+            max_ranges: MAX_RANGE_SNAPSHOT_RANGES,
+            max_ranges_per_owner: MAX_RANGE_SNAPSHOT_RANGES_PER_OWNER,
+            max_range_id_bytes: MAX_RANGE_SNAPSHOT_RANGE_ID_BYTES,
+            max_owner_hash_bytes: MAX_RANGE_SNAPSHOT_OWNER_HASH_BYTES,
+            max_bytes: MAX_RANGE_SNAPSHOT_BYTES,
+        }
+    }
+
+    fn snapshot_range(id: &str, hash: &str, start: u64, width: u64) -> ReplicationRange {
+        ReplicationRange::new(
+            id,
+            hash,
+            0,
+            start,
+            start + width,
+            start,
+            start + width,
+            width,
+            MODE_NON_STRICT,
+        )
     }
 
     fn intersecting_options() -> SampleOptions {
@@ -4908,6 +5317,257 @@ mod tests {
         *state ^= *state >> 7;
         *state ^= *state << 17;
         *state
+    }
+
+    #[test]
+    fn range_snapshot_is_complete_sorted_and_exactly_accounted() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(snapshot_range("z", "owner-b", 20, 5));
+        planner.put(snapshot_range("b", "owner-a", 10, 5));
+        planner.put(snapshot_range("a", "owner-a", 0, 5));
+
+        let RangeSnapshotPreflight::Snapshot(snapshot) = planner
+            .preflight_range_snapshot(range_snapshot_limits())
+            .unwrap()
+        else {
+            panic!("expected complete snapshot");
+        };
+        assert_eq!(snapshot.owners, 2);
+        assert_eq!(snapshot.ranges.len(), 3);
+        assert_eq!(
+            snapshot
+                .ranges
+                .iter()
+                .map(|range| range.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "z"]
+        );
+        assert_eq!(snapshot.range_id_bytes, 3);
+        assert_eq!(snapshot.owner_hash_bytes, 21);
+        // Header 8 + three u32 rows * 37 fixed bytes + string bytes.
+        assert_eq!(snapshot.bytes, 8 + 3 * 37 + 3 + 21);
+    }
+
+    #[test]
+    fn range_snapshot_accepts_exact_empty_header_cap() {
+        let planner = RangePlanner::new("u64");
+        let mut limits = range_snapshot_limits();
+        limits.max_bytes = 7;
+        assert!(matches!(
+            planner.preflight_range_snapshot(limits).unwrap(),
+            RangeSnapshotPreflight::Overflow(RangeSnapshotOverflow::Bytes)
+        ));
+        limits.max_bytes = 8;
+        let RangeSnapshotPreflight::Snapshot(snapshot) =
+            planner.preflight_range_snapshot(limits).unwrap()
+        else {
+            panic!("expected exact-cap empty snapshot");
+        };
+        assert_eq!(snapshot.bytes, 8);
+        assert!(snapshot.ranges.is_empty());
+    }
+
+    #[test]
+    fn range_snapshot_accepts_valid_edge_geometry_for_both_resolutions() {
+        for (resolution, maximum) in [("u32", MAX_U32), ("u64", MAX_U64)] {
+            let mut planner = RangePlanner::new(resolution);
+            planner.put(ReplicationRange::new(
+                "nonwrapped",
+                "owner",
+                0,
+                10,
+                15,
+                10,
+                15,
+                5,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                "wrapped",
+                "owner",
+                0,
+                maximum - 2,
+                maximum,
+                0,
+                3,
+                5,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                "full-width",
+                "owner",
+                0,
+                10,
+                maximum,
+                0,
+                10,
+                maximum,
+                MODE_NON_STRICT,
+            ));
+            planner.put(ReplicationRange::new(
+                "maximum-edge",
+                "owner",
+                0,
+                maximum - 1,
+                maximum,
+                maximum - 1,
+                maximum,
+                1,
+                MODE_NON_STRICT,
+            ));
+
+            let RangeSnapshotPreflight::Snapshot(snapshot) = planner
+                .preflight_range_snapshot(range_snapshot_limits())
+                .unwrap()
+            else {
+                panic!("expected valid {resolution} edge snapshot");
+            };
+            assert_eq!(snapshot.ranges.len(), 4);
+        }
+    }
+
+    #[test]
+    fn range_snapshot_rejects_every_cap_without_a_partial_prefix() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(snapshot_range("aa", "owner-a", 0, 5));
+        planner.put(snapshot_range("b", "owner-a", 10, 5));
+        planner.put(snapshot_range("c", "owner-b", 20, 5));
+
+        let cases = [
+            (
+                RangeSnapshotLimits {
+                    max_owners: 1,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::Owners,
+            ),
+            (
+                RangeSnapshotLimits {
+                    max_ranges: 2,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::Ranges,
+            ),
+            (
+                RangeSnapshotLimits {
+                    max_ranges_per_owner: 1,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::RangesPerOwner,
+            ),
+            (
+                RangeSnapshotLimits {
+                    max_range_id_bytes: 1,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::RangeId,
+            ),
+            (
+                RangeSnapshotLimits {
+                    max_owner_hash_bytes: 6,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::OwnerHash,
+            ),
+            (
+                RangeSnapshotLimits {
+                    max_bytes: 10,
+                    ..range_snapshot_limits()
+                },
+                RangeSnapshotOverflow::Bytes,
+            ),
+        ];
+        for (limits, expected) in cases {
+            assert!(matches!(
+                planner.preflight_range_snapshot(limits).unwrap(),
+                RangeSnapshotPreflight::Overflow(actual) if actual == expected
+            ));
+        }
+        let RangeSnapshotPreflight::Snapshot(retry) = planner
+            .preflight_range_snapshot(range_snapshot_limits())
+            .unwrap()
+        else {
+            panic!("expected complete retry");
+        };
+        assert_eq!(retry.ranges.len(), 3);
+    }
+
+    #[test]
+    fn range_snapshot_cardinality_gate_precedes_row_validation() {
+        let mut planner = RangePlanner::new("u32");
+        planner.put(ReplicationRange::new("bad", "owner-a", 0, 0, 1, 0, 1, 1, 9));
+        planner.put(snapshot_range("good", "owner-b", 10, 1));
+        let limits = RangeSnapshotLimits {
+            max_ranges: 1,
+            ..range_snapshot_limits()
+        };
+        assert!(matches!(
+            planner.preflight_range_snapshot(limits).unwrap(),
+            RangeSnapshotPreflight::Overflow(RangeSnapshotOverflow::Ranges)
+        ));
+    }
+
+    #[test]
+    fn range_snapshot_detects_corrupt_geometry_resolution_and_owner_index() {
+        let mut invalid_mode = RangePlanner::new("u32");
+        invalid_mode.put(ReplicationRange::new("a", "owner", 0, 0, 1, 0, 1, 1, 2));
+        assert_eq!(
+            invalid_mode
+                .preflight_range_snapshot(range_snapshot_limits())
+                .unwrap_err(),
+            SharedLogError::RangeSnapshotInvalidRange
+        );
+
+        let mut invalid_geometry = RangePlanner::new("u32");
+        invalid_geometry.put(ReplicationRange::new("a", "owner", 0, 0, 2, 0, 2, 1, 0));
+        assert_eq!(
+            invalid_geometry
+                .preflight_range_snapshot(range_snapshot_limits())
+                .unwrap_err(),
+            SharedLogError::RangeSnapshotInvalidRange
+        );
+
+        let mut wrong_resolution = RangePlanner::new("u32");
+        wrong_resolution.put(ReplicationRange::new(
+            "a",
+            "owner",
+            0,
+            MAX_U32 + 1,
+            MAX_U32 + 1,
+            MAX_U32 + 1,
+            MAX_U32 + 1,
+            0,
+            0,
+        ));
+        assert_eq!(
+            wrong_resolution
+                .preflight_range_snapshot(range_snapshot_limits())
+                .unwrap_err(),
+            SharedLogError::RangeSnapshotResolutionMismatch
+        );
+
+        let mut inconsistent = RangePlanner::new("u32");
+        inconsistent.put(snapshot_range("a", "owner", 0, 1));
+        inconsistent.peer_ranges.clear();
+        assert_eq!(
+            inconsistent
+                .preflight_range_snapshot(range_snapshot_limits())
+                .unwrap_err(),
+            SharedLogError::RangeSnapshotIndexInconsistent
+        );
+    }
+
+    #[test]
+    fn range_snapshot_rejects_invalid_public_limits() {
+        let planner = RangePlanner::new("u32");
+        let limits = RangeSnapshotLimits {
+            max_owners: 0,
+            ..range_snapshot_limits()
+        };
+        assert_eq!(
+            planner.preflight_range_snapshot(limits).unwrap_err(),
+            SharedLogError::InvalidRangeSnapshotLimit("maxOwners")
+        );
     }
 
     #[test]

--- a/packages/programs/data/shared-log/rust/test/index.spec.ts
+++ b/packages/programs/data/shared-log/rust/test/index.spec.ts
@@ -1,11 +1,35 @@
 import { expect } from "chai";
 import {
+	MAX_NATIVE_RANGE_SNAPSHOT_LIMITS,
 	MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
+	type NativeRangeSnapshotLimits,
+	NativeRangeSnapshotOverflowError,
 	type NativeRebalanceCollisionBucketLimits,
 	NativeRebalanceCollisionBucketOverflowError,
 	createRangePlanner,
 	createSharedLogState,
 } from "../src/index.js";
+
+const rangeSnapshotLimits = (
+	overrides?: Partial<NativeRangeSnapshotLimits>,
+): NativeRangeSnapshotLimits => ({
+	...MAX_NATIVE_RANGE_SNAPSHOT_LIMITS,
+	...overrides,
+});
+
+const expectRangeSnapshotOverflow = (
+	read: () => unknown,
+	code: NativeRangeSnapshotOverflowError["code"],
+) => {
+	let failure: unknown;
+	try {
+		read();
+	} catch (error) {
+		failure = error;
+	}
+	expect(failure).to.be.instanceOf(NativeRangeSnapshotOverflowError);
+	expect((failure as NativeRangeSnapshotOverflowError).code).to.equal(code);
+};
 
 const rebalanceBucketLimits = (
 	overrides?: Partial<NativeRebalanceCollisionBucketLimits>,
@@ -75,6 +99,237 @@ describe("native shared-log range planner", () => {
 			"SharedLogRangePlanner is closed",
 		);
 		expect(consumed).to.equal(false);
+	});
+
+	it("reads one complete deterministic snapshot from the planner and shared state", async () => {
+		const planner = await createRangePlanner("u32");
+		const state = await createSharedLogState("u32");
+		// Rust strings sort by UTF-8 bytes. JavaScript UTF-16 ordering puts the
+		// supplementary character first, so this pair guards the ABI comparator.
+		const rows = [
+			range({
+				id: "supplementary",
+				hash: "\u{10000}",
+				start1: 20,
+				end1: 25,
+				timestamp: 9n,
+				mode: 1,
+			}),
+			range({
+				id: "bmp",
+				hash: "\u{e000}",
+				start1: 10,
+				end1: 15,
+				timestamp: 7n,
+			}),
+		];
+		for (const row of rows) {
+			planner.put(row);
+			state.put(row);
+		}
+
+		const plannerSnapshot = planner.readRangeSnapshot(rangeSnapshotLimits());
+		const stateSnapshot = state.readRangeSnapshot(rangeSnapshotLimits());
+		expect(stateSnapshot).to.deep.equal(plannerSnapshot);
+		expect(plannerSnapshot).to.deep.include({
+			resolution: "u32",
+			complete: true,
+			ownerCount: 2,
+			rangeCount: 2,
+		});
+		expect(plannerSnapshot.ranges.map((row) => row.ownerHash)).to.deep.equal([
+			"\u{e000}",
+			"\u{10000}",
+		]);
+		expect(plannerSnapshot.rangeIdBytes).to.equal(
+			new TextEncoder().encode("supplementarybmp").byteLength,
+		);
+		expect(plannerSnapshot.ownerHashBytes).to.equal(7);
+		expect(Object.isFrozen(plannerSnapshot)).to.equal(true);
+		expect(Object.isFrozen(plannerSnapshot.ranges)).to.equal(true);
+		expect(Object.isFrozen(plannerSnapshot.ranges[0])).to.equal(true);
+	});
+
+	it("preserves u64 snapshot values without Number coercion", async () => {
+		const state = await createSharedLogState("u64");
+		const maximum = 0xffff_ffff_ffff_ffffn;
+		for (const row of [
+			{
+				id: "edge",
+				hash: "owner-u64",
+				timestamp: maximum,
+				start1: maximum - 10n,
+				end1: maximum,
+				start2: maximum - 10n,
+				end2: maximum,
+				width: 10n,
+				mode: 1,
+			},
+			{
+				id: "wrapped",
+				hash: "owner-u64",
+				timestamp: 1n,
+				start1: maximum - 2n,
+				end1: maximum,
+				start2: 0n,
+				end2: 3n,
+				width: 5n,
+				mode: 0,
+			},
+			{
+				id: "full-width",
+				hash: "owner-u64",
+				timestamp: 2n,
+				start1: 10n,
+				end1: maximum,
+				start2: 0n,
+				end2: 10n,
+				width: maximum,
+				mode: 0,
+			},
+		]) {
+			state.put(row);
+		}
+
+		const snapshot = state.readRangeSnapshot(rangeSnapshotLimits());
+		expect(snapshot.resolution).to.equal("u64");
+		expect(snapshot.rangeCount).to.equal(3);
+		const edge = snapshot.ranges.find((row) => row.idString === "edge");
+		expect(edge).to.deep.include({
+			timestamp: maximum,
+			start1: maximum - 10n,
+			end1: maximum,
+			width: 10n,
+		});
+		expect(
+			snapshot.ranges.find((row) => row.idString === "wrapped"),
+		).to.deep.include({
+			start1: maximum - 2n,
+			end1: maximum,
+			start2: 0n,
+			end2: 3n,
+			width: 5n,
+		});
+		expect(
+			snapshot.ranges.find((row) => row.idString === "full-width"),
+		).to.deep.include({
+			start1: 10n,
+			end1: maximum,
+			start2: 0n,
+			end2: 10n,
+			width: maximum,
+		});
+		for (const value of [edge?.start1, edge?.end1, edge?.width]) {
+			expect(typeof value).to.equal("bigint");
+		}
+	});
+
+	it("accepts exact logical byte caps including the empty header", async () => {
+		const empty = await createRangePlanner("u32");
+		expectRangeSnapshotOverflow(
+			() => empty.readRangeSnapshot(rangeSnapshotLimits({ maxBytes: 7 })),
+			"bytes",
+		);
+		expect(
+			empty.readRangeSnapshot(rangeSnapshotLimits({ maxBytes: 8 })),
+		).to.deep.include({ bytes: 8, ownerCount: 0, rangeCount: 0 });
+
+		const one = await createRangePlanner("u32");
+		one.put(range({ id: "a", hash: "b", start1: 1, end1: 2 }));
+		expectRangeSnapshotOverflow(
+			() => one.readRangeSnapshot(rangeSnapshotLimits({ maxBytes: 46 })),
+			"bytes",
+		);
+		expect(
+			one.readRangeSnapshot(rangeSnapshotLimits({ maxBytes: 47 })),
+		).to.deep.include({
+			bytes: 47,
+			ownerCount: 1,
+			rangeCount: 1,
+			rangeIdBytes: 1,
+			ownerHashBytes: 1,
+		});
+	});
+
+	it("rejects every snapshot cap without exposing a partial prefix", async () => {
+		const planner = await createRangePlanner("u32");
+		for (const row of [
+			range({ id: "aa", hash: "owner-a", start1: 0, end1: 5 }),
+			range({ id: "b", hash: "owner-a", start1: 10, end1: 15 }),
+			range({ id: "c", hash: "owner-b", start1: 20, end1: 25 }),
+		]) {
+			planner.put(row);
+		}
+		const complete = planner.readRangeSnapshot(rangeSnapshotLimits());
+		const cases: Array<
+			readonly [
+				Partial<NativeRangeSnapshotLimits>,
+				NativeRangeSnapshotOverflowError["code"],
+			]
+		> = [
+			[{ maxOwners: 1 }, "owners"],
+			[{ maxRanges: 2 }, "ranges"],
+			[{ maxRangesPerOwner: 1 }, "ranges-per-owner"],
+			[{ maxRangeIdBytes: 1 }, "range-id"],
+			[{ maxOwnerHashBytes: 6 }, "owner-hash"],
+			[{ maxBytes: complete.bytes - 1 }, "bytes"],
+		];
+		for (const [overrides, code] of cases) {
+			expectRangeSnapshotOverflow(
+				() => planner.readRangeSnapshot(rangeSnapshotLimits(overrides)),
+				code,
+			);
+		}
+		expect(planner.readRangeSnapshot(rangeSnapshotLimits())).to.deep.equal(
+			complete,
+		);
+	});
+
+	it("rejects invalid snapshot limits and closes before reading them", async () => {
+		const planner = await createRangePlanner("u32");
+		for (const name of Object.keys(MAX_NATIVE_RANGE_SNAPSHOT_LIMITS) as Array<
+			keyof NativeRangeSnapshotLimits
+		>) {
+			for (const value of [
+				0,
+				1.5,
+				MAX_NATIVE_RANGE_SNAPSHOT_LIMITS[name] + 1,
+			]) {
+				expect(() =>
+					planner.readRangeSnapshot(rangeSnapshotLimits({ [name]: value })),
+				).to.throw(`Invalid native range snapshot limit: ${name}`);
+			}
+		}
+
+		planner.close();
+		let limitsRead = false;
+		const unreadLimits = Object.defineProperty({}, "maxOwners", {
+			get() {
+				limitsRead = true;
+				return 1;
+			},
+		}) as NativeRangeSnapshotLimits;
+		expect(() => planner.readRangeSnapshot(unreadLimits)).to.throw(
+			"SharedLogRangePlanner is closed",
+		);
+		expect(limitsRead).to.equal(false);
+	});
+
+	it("fails closed when locally mirrored range geometry is corrupt", async () => {
+		const planner = await createRangePlanner("u32");
+		planner.put({
+			...range({ id: "bad", hash: "owner", start1: 0, end1: 2 }),
+			width: 1,
+		});
+		let failure: unknown;
+		try {
+			planner.readRangeSnapshot(rangeSnapshotLimits());
+		} catch (error) {
+			failure = error;
+		}
+		expect(String(failure)).to.contain(
+			"Native range snapshot contains an invalid range",
+		);
 	});
 
 	it("returns intersecting leaders", async () => {

--- a/packages/utils/native-backbone/src/index.ts
+++ b/packages/utils/native-backbone/src/index.ts
@@ -9,6 +9,77 @@ export * from "./durability/storage.js";
 
 export type RangeResolution = "u32" | "u64";
 
+export type NativeRangeSnapshotLimits = Readonly<{
+	maxOwners: number;
+	maxRanges: number;
+	maxRangesPerOwner: number;
+	/** UTF-8 bytes of the native runtime id string (normally padded base64). */
+	maxRangeIdBytes: number;
+	/** UTF-8 bytes of the owner hash. This is not a public-key byte limit. */
+	maxOwnerHashBytes: number;
+	/**
+	 * Logical binary accounting: two u32 counts, then per range two u32 UTF-8
+	 * lengths and strings, one u64 timestamp, five resolution-width coordinates,
+	 * and one u8 mode. This is not the decimal-string/array allocation used by
+	 * the WASM bridge; row and string caps bound that allocation.
+	 */
+	maxBytes: number;
+}>;
+
+export const MAX_NATIVE_RANGE_SNAPSHOT_LIMITS: NativeRangeSnapshotLimits =
+	Object.freeze({
+		maxOwners: 4096,
+		maxRanges: 16_384,
+		maxRangesPerOwner: 4096,
+		maxRangeIdBytes: 684,
+		maxOwnerHashBytes: 512,
+		maxBytes: 4 * 1024 * 1024,
+	});
+
+export type NativeRangeSnapshotOverflowCode =
+	| "owners"
+	| "ranges"
+	| "ranges-per-owner"
+	| "range-id"
+	| "owner-hash"
+	| "bytes";
+
+export class NativeRangeSnapshotOverflowError extends Error {
+	constructor(readonly code: NativeRangeSnapshotOverflowCode) {
+		super(`Native range snapshot exceeded ${code}`);
+		this.name = "NativeRangeSnapshotOverflowError";
+	}
+}
+
+export type NativeRangeSnapshotRangeFor<R extends RangeResolution> = Readonly<{
+	idString: string;
+	/** Unauthenticated owner hash copied from the local native range mirror. */
+	ownerHash: string;
+	timestamp: bigint;
+	start1: R extends "u64" ? bigint : number;
+	end1: R extends "u64" ? bigint : number;
+	start2: R extends "u64" ? bigint : number;
+	end2: R extends "u64" ? bigint : number;
+	width: R extends "u64" ? bigint : number;
+	mode: 0 | 1;
+}>;
+
+export type NativeRangeSnapshotResultFor<R extends RangeResolution> = Readonly<{
+	resolution: R;
+	complete: true;
+	ownerCount: number;
+	rangeCount: number;
+	/** Logical binary bytes represented by this complete snapshot (see limits). */
+	bytes: number;
+	rangeIdBytes: number;
+	ownerHashBytes: number;
+	ranges: ReadonlyArray<NativeRangeSnapshotRangeFor<R>>;
+}>;
+
+export type NativeRangeSnapshotResult =
+	| NativeRangeSnapshotResultFor<"u32">
+	| NativeRangeSnapshotResultFor<"u64">;
+
 export type NativeRebalanceCollisionBucketLimits = Readonly<{
 	maxRows: number;
 	maxIdentifierBytes: number;
@@ -137,6 +208,14 @@ type NativePeerbitBackboneHandle = {
 		maxIdentifierBytesTotal: number,
 		maxCoordinateValues: number,
 		maxCoordinateBytes: number,
+		maxBytes: number,
+	) => unknown[];
+	read_range_snapshot: (
+		maxOwners: number,
+		maxRanges: number,
+		maxRangesPerOwner: number,
+		maxRangeIdBytes: number,
+		maxOwnerHashBytes: number,
 		maxBytes: number,
 	) => unknown[];
 	count_entry_coordinates_in_ranges: (
@@ -5853,6 +5932,318 @@ const integerString = (value: bigint | number | string): string =>
 const MAX_NATIVE_REBALANCE_U32 = 0xffff_ffffn;
 const MAX_NATIVE_REBALANCE_U64 = 0xffff_ffff_ffff_ffffn;
 const canonicalUnsignedInteger = /^(0|[1-9][0-9]*)$/;
+const nativeRangeSnapshotEncoder = new TextEncoder();
+
+const rangeSnapshotLimits = (
+	limits: NativeRangeSnapshotLimits,
+): NativeRangeSnapshotLimits => {
+	if (!limits || typeof limits !== "object") {
+		throw new Error("Invalid native range snapshot limits");
+	}
+	const out = {} as Record<keyof NativeRangeSnapshotLimits, number>;
+	for (const name of Object.keys(MAX_NATIVE_RANGE_SNAPSHOT_LIMITS) as Array<
+		keyof NativeRangeSnapshotLimits
+	>) {
+		const value = limits[name];
+		if (
+			!Number.isSafeInteger(value) ||
+			value <= 0 ||
+			value > MAX_NATIVE_RANGE_SNAPSHOT_LIMITS[name]
+		) {
+			throw new Error(`Invalid native range snapshot limit: ${name}`);
+		}
+		out[name] = value;
+	}
+	return Object.freeze(out) as NativeRangeSnapshotLimits;
+};
+
+const rangeSnapshotOverflowCodes = new Set<NativeRangeSnapshotOverflowCode>([
+	"owners",
+	"ranges",
+	"ranges-per-owner",
+	"range-id",
+	"owner-hash",
+	"bytes",
+]);
+
+const rangeSnapshotCount = (value: unknown): number => {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return value as number;
+};
+
+const rangeSnapshotString = (
+	value: unknown,
+	maximumBytes: number,
+): { value: string; encoded: Uint8Array } => {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > maximumBytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const encoded = nativeRangeSnapshotEncoder.encode(value);
+	if (encoded.byteLength > maximumBytes) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return { value, encoded };
+};
+
+const rangeSnapshotUnsigned = (value: unknown): bigint => {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > 20 ||
+		!canonicalUnsignedInteger.test(value)
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const parsed = BigInt(value);
+	if (parsed > MAX_NATIVE_REBALANCE_U64) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	return parsed;
+};
+
+type ParsedNativeRangeSnapshotRow = {
+	idString: string;
+	ownerHash: string;
+	timestamp: bigint;
+	start1: bigint;
+	end1: bigint;
+	start2: bigint;
+	end2: bigint;
+	width: bigint;
+	mode: 0 | 1;
+	idBytes: number;
+	ownerHashBytes: number;
+	idOrderBytes: Uint8Array;
+	ownerHashOrderBytes: Uint8Array;
+};
+
+const compareNativeRangeSnapshotBytes = (
+	left: Uint8Array,
+	right: Uint8Array,
+): number => {
+	const length = Math.min(left.byteLength, right.byteLength);
+	for (let index = 0; index < length; index++) {
+		if (left[index]! < right[index]!) return -1;
+		if (left[index]! > right[index]!) return 1;
+	}
+	return left.byteLength - right.byteLength;
+};
+
+const compareNativeRangeSnapshotRows = (
+	left: ParsedNativeRangeSnapshotRow,
+	right: ParsedNativeRangeSnapshotRow,
+): number => {
+	const ownerOrder = compareNativeRangeSnapshotBytes(
+		left.ownerHashOrderBytes,
+		right.ownerHashOrderBytes,
+	);
+	if (ownerOrder !== 0) return ownerOrder;
+	const idOrder = compareNativeRangeSnapshotBytes(
+		left.idOrderBytes,
+		right.idOrderBytes,
+	);
+	if (idOrder !== 0) return idOrder;
+	for (const [a, b] of [
+		[left.timestamp, right.timestamp],
+		[left.start1, right.start1],
+		[left.end1, right.end1],
+		[left.start2, right.start2],
+		[left.end2, right.end2],
+		[left.width, right.width],
+	] as const) {
+		if (a < b) return -1;
+		if (a > b) return 1;
+	}
+	return left.mode - right.mode;
+};
+
+const nativeRangeSnapshotGeometryIsValid = (
+	resolution: RangeResolution,
+	range: ParsedNativeRangeSnapshotRow,
+): boolean => {
+	const maximum =
+		resolution === "u32" ? MAX_NATIVE_REBALANCE_U32 : MAX_NATIVE_REBALANCE_U64;
+	if (
+		[range.start1, range.end1, range.start2, range.end2, range.width].some(
+			(value) => value > maximum,
+		)
+	) {
+		return false;
+	}
+	const unscaledEnd = range.start1 + range.width;
+	const expectedEnd1 = unscaledEnd < maximum ? unscaledEnd : maximum;
+	const [expectedStart2, expectedEnd2] =
+		unscaledEnd > maximum
+			? [
+					0n,
+					range.width === maximum
+						? range.start1 % maximum
+						: unscaledEnd % maximum,
+				]
+			: [range.start1, expectedEnd1];
+	if (
+		range.end1 !== expectedEnd1 ||
+		range.start2 !== expectedStart2 ||
+		range.end2 !== expectedEnd2
+	) {
+		return false;
+	}
+	const reconstructedWidth =
+		range.end1 -
+		range.start1 +
+		(range.end2 < range.end1 ? range.end2 - range.start2 : 0n);
+	return reconstructedWidth === range.width;
+};
+
+const rangeSnapshotFromRow = (
+	resolution: RangeResolution,
+	rowValue: unknown,
+	limits: NativeRangeSnapshotLimits,
+): NativeRangeSnapshotResult => {
+	if (!Array.isArray(rowValue)) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	if (rowValue[0] === 2) {
+		if (rowValue.length !== 2) {
+			throw new Error("Invalid native range snapshot overflow");
+		}
+		const code = rowValue[1] as NativeRangeSnapshotOverflowCode;
+		if (!rangeSnapshotOverflowCodes.has(code)) {
+			throw new Error("Invalid native range snapshot overflow");
+		}
+		throw new NativeRangeSnapshotOverflowError(code);
+	}
+	if (rowValue.length !== 7 || rowValue[0] !== 1) {
+		throw new Error("Invalid native range snapshot result");
+	}
+	const ownerCount = rangeSnapshotCount(rowValue[1]);
+	const rangeCount = rangeSnapshotCount(rowValue[2]);
+	const bytes = rangeSnapshotCount(rowValue[3]);
+	const expectedRangeIdBytes = rangeSnapshotCount(rowValue[4]);
+	const expectedOwnerHashBytes = rangeSnapshotCount(rowValue[5]);
+	const rows = rowValue[6];
+	if (
+		!Array.isArray(rows) ||
+		rows.length !== rangeCount ||
+		ownerCount > limits.maxOwners ||
+		rangeCount > limits.maxRanges ||
+		bytes > limits.maxBytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+
+	const parsed: ParsedNativeRangeSnapshotRow[] = [];
+	const ids = new Set<string>();
+	const ownerCounts = new Map<string, number>();
+	let rangeIdBytes = 0;
+	let ownerHashBytes = 0;
+	let logicalBytes = 8;
+	const coordinateWidth = resolution === "u32" ? 4 : 8;
+	const fixedRangeBytes = 4 + 4 + 8 + 5 * coordinateWidth + 1;
+	for (let index = 0; index < rangeCount; index++) {
+		if (!Object.prototype.hasOwnProperty.call(rows, index)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const row = rows[index];
+		if (!Array.isArray(row) || row.length !== 9) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const id = rangeSnapshotString(row[0], limits.maxRangeIdBytes);
+		const owner = rangeSnapshotString(row[1], limits.maxOwnerHashBytes);
+		if (ids.has(id.value)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		ids.add(id.value);
+		const mode = row[8];
+		if (mode !== 0 && mode !== 1) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const item: ParsedNativeRangeSnapshotRow = {
+			idString: id.value,
+			ownerHash: owner.value,
+			timestamp: rangeSnapshotUnsigned(row[2]),
+			start1: rangeSnapshotUnsigned(row[3]),
+			end1: rangeSnapshotUnsigned(row[4]),
+			start2: rangeSnapshotUnsigned(row[5]),
+			end2: rangeSnapshotUnsigned(row[6]),
+			width: rangeSnapshotUnsigned(row[7]),
+			mode,
+			idBytes: id.encoded.byteLength,
+			ownerHashBytes: owner.encoded.byteLength,
+			idOrderBytes: id.encoded,
+			ownerHashOrderBytes: owner.encoded,
+		};
+		if (!nativeRangeSnapshotGeometryIsValid(resolution, item)) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		const ownerRangeCount = (ownerCounts.get(item.ownerHash) ?? 0) + 1;
+		if (ownerRangeCount > limits.maxRangesPerOwner) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		ownerCounts.set(item.ownerHash, ownerRangeCount);
+		if (ownerCounts.size > limits.maxOwners) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		rangeIdBytes += item.idBytes;
+		ownerHashBytes += item.ownerHashBytes;
+		logicalBytes += fixedRangeBytes + item.idBytes + item.ownerHashBytes;
+		if (
+			!Number.isSafeInteger(rangeIdBytes) ||
+			!Number.isSafeInteger(ownerHashBytes) ||
+			!Number.isSafeInteger(logicalBytes) ||
+			logicalBytes > limits.maxBytes
+		) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		if (
+			parsed.length > 0 &&
+			compareNativeRangeSnapshotRows(parsed[parsed.length - 1]!, item) >= 0
+		) {
+			throw new Error("Invalid native range snapshot result");
+		}
+		parsed.push(item);
+	}
+	if (
+		ownerCounts.size !== ownerCount ||
+		rangeIdBytes !== expectedRangeIdBytes ||
+		ownerHashBytes !== expectedOwnerHashBytes ||
+		logicalBytes !== bytes
+	) {
+		throw new Error("Invalid native range snapshot result");
+	}
+
+	const ranges = Object.freeze(
+		parsed.map((range) =>
+			Object.freeze({
+				idString: range.idString,
+				ownerHash: range.ownerHash,
+				timestamp: range.timestamp,
+				start1: resolution === "u32" ? Number(range.start1) : range.start1,
+				end1: resolution === "u32" ? Number(range.end1) : range.end1,
+				start2: resolution === "u32" ? Number(range.start2) : range.start2,
+				end2: resolution === "u32" ? Number(range.end2) : range.end2,
+				width: resolution === "u32" ? Number(range.width) : range.width,
+				mode: range.mode,
+			}),
+		),
+	);
+	return Object.freeze({
+		resolution,
+		complete: true,
+		ownerCount,
+		rangeCount,
+		bytes,
+		rangeIdBytes,
+		ownerHashBytes,
+		ranges,
+	}) as NativeRangeSnapshotResult;
+};
 
 const rebalanceCollisionBucketCursor = (
 	resolution: RangeResolution,
@@ -6547,6 +6938,28 @@ export class NativePeerbitBackbone {
 		return coordinates
 			? rowsToNumbers(this.resolution, coordinates)
 			: undefined;
+	}
+
+	/**
+	 * Complete-or-overflow copy of resident range geometry and owner hashes.
+	 * The result authenticates no identity and grants no transfer/prune right.
+	 */
+	readRangeSnapshot(
+		limits: NativeRangeSnapshotLimits,
+	): NativeRangeSnapshotResult {
+		const bounded = rangeSnapshotLimits(limits);
+		return rangeSnapshotFromRow(
+			this.resolution,
+			this.native.read_range_snapshot(
+				bounded.maxOwners,
+				bounded.maxRanges,
+				bounded.maxRangesPerOwner,
+				bounded.maxRangeIdBytes,
+				bounded.maxOwnerHashBytes,
+				bounded.maxBytes,
+			),
+			bounded,
+		);
 	}
 
 	/**

--- a/packages/utils/native-backbone/src/shared_log_plan.rs
+++ b/packages/utils/native-backbone/src/shared_log_plan.rs
@@ -326,6 +326,28 @@ impl NativePeerbitBackbone {
         )
     }
 
+    /// Thin forwarding surface for the shared-log core's complete-or-overflow
+    /// range snapshot. The rows contain owner hashes, never authenticated keys.
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_range_snapshot(
+        &self,
+        max_owners: usize,
+        max_ranges: usize,
+        max_ranges_per_owner: usize,
+        max_range_id_bytes: usize,
+        max_owner_hash_bytes: usize,
+        max_bytes: usize,
+    ) -> Result<Array, JsValue> {
+        self.shared_log.read_range_snapshot(
+            max_owners,
+            max_ranges,
+            max_ranges_per_owner,
+            max_range_id_bytes,
+            max_owner_hash_bytes,
+            max_bytes,
+        )
+    }
+
     pub fn entry_hash_numbers_in_range(
         &self,
         start1: String,

--- a/packages/utils/native-backbone/test/index.spec.ts
+++ b/packages/utils/native-backbone/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { benchmarkPlainCommittedNoNextStorageAppendTransactionLoop } from "../src/benchmark.js";
 import {
+	MAX_NATIVE_RANGE_SNAPSHOT_LIMITS,
 	MAX_NATIVE_REBALANCE_COLLISION_BUCKET_LIMITS,
 	NativeBackboneBufferedCoordinatePersistenceStore,
 	NativeBackboneCoordinatePersistence,
@@ -11,6 +12,8 @@ import {
 	NativeBackboneNodeCoordinatePersistenceStore,
 	NativeBackboneOPFSCoordinatePersistenceStore,
 	type NativeBackboneOPFSDirectoryHandle,
+	type NativeRangeSnapshotLimits,
+	NativeRangeSnapshotOverflowError,
 	type NativeRebalanceCollisionBucketLimits,
 	NativeRebalanceCollisionBucketOverflowError,
 	createBufferedNativeBackboneCoordinatePersistence,
@@ -19,6 +22,27 @@ import {
 	createNativePeerbitBackbone,
 	defaultNativeBackboneCoordinateFlushMaxPendingBytes,
 } from "../src/index.js";
+
+const rangeSnapshotLimits = (
+	overrides?: Partial<NativeRangeSnapshotLimits>,
+): NativeRangeSnapshotLimits => ({
+	...MAX_NATIVE_RANGE_SNAPSHOT_LIMITS,
+	...overrides,
+});
+
+const expectRangeSnapshotOverflow = (
+	read: () => unknown,
+	code: NativeRangeSnapshotOverflowError["code"],
+) => {
+	let failure: unknown;
+	try {
+		read();
+	} catch (error) {
+		failure = error;
+	}
+	expect(failure).to.be.instanceOf(NativeRangeSnapshotOverflowError);
+	expect((failure as NativeRangeSnapshotOverflowError).code).to.equal(code);
+};
 
 const rebalanceBucketLimits = (
 	overrides?: Partial<NativeRebalanceCollisionBucketLimits>,
@@ -324,6 +348,67 @@ class FakeOPFSDirectoryHandle implements NativeBackboneOPFSDirectoryHandle {
 }
 
 describe("native peerbit backbone", () => {
+	it("forwards complete bounded range snapshots without changing precision or order", async () => {
+		const maximum = 0xffff_ffff_ffff_ffffn;
+		const backbone = await createNativePeerbitBackbone({
+			clockId: publicKey,
+			privateKey,
+			publicKey,
+			resolution: "u64",
+		});
+		backbone.putRange({
+			id: "supplementary",
+			hash: "\u{10000}",
+			timestamp: maximum,
+			start1: maximum - 10n,
+			end1: maximum,
+			start2: maximum - 10n,
+			end2: maximum,
+			width: 10n,
+			mode: 1,
+		});
+		backbone.putRange({
+			id: "bmp",
+			hash: "\u{e000}",
+			timestamp: 7,
+			start1: 10,
+			end1: 15,
+			start2: 10,
+			end2: 15,
+			width: 5,
+			mode: 0,
+		});
+
+		const complete = backbone.readRangeSnapshot(rangeSnapshotLimits());
+		expect(complete).to.deep.include({
+			resolution: "u64",
+			complete: true,
+			ownerCount: 2,
+			rangeCount: 2,
+			ownerHashBytes: 7,
+		});
+		expect(complete.ranges.map((row) => row.ownerHash)).to.deep.equal([
+			"\u{e000}",
+			"\u{10000}",
+		]);
+		expect(complete.ranges[1]).to.deep.include({
+			timestamp: maximum,
+			start1: maximum - 10n,
+			end1: maximum,
+			width: 10n,
+		});
+		expect(typeof complete.ranges[1]?.start1).to.equal("bigint");
+		expect(Object.isFrozen(complete.ranges)).to.equal(true);
+
+		expectRangeSnapshotOverflow(
+			() => backbone.readRangeSnapshot(rangeSnapshotLimits({ maxOwners: 1 })),
+			"owners",
+		);
+		expect(backbone.readRangeSnapshot(rangeSnapshotLimits())).to.deep.equal(
+			complete,
+		);
+	});
+
 	it("samples intersecting strict ranges excluded from full replica fallback", async () => {
 		const maxU64 = (1n << 64n) - 1n;
 		const liveRangeEnd = 86_400_000_000_000_000n;


### PR DESCRIPTION
## Summary

- add complete-or-overflow native snapshots of resident replication-range geometry and owner hashes
- enforce fixed owner, range, per-owner, identifier, and logical-byte ceilings before exposing any row to JavaScript
- validate deterministic UTF-8 ordering, exact u32/u64 geometry/accounting, and secondary owner-index consistency
- expose the same bounded primitive through standalone range planners, shared native state, and native-backbone

## Safety boundary

This is an unwired resident-state primitive only. It does not query an `Index`, authenticate owner hashes, create a placement epoch, transfer entries, issue custody receipts, or authorize pruning. Runtime capture still requires current V2 owner provenance and the global ownership-mutation lane. Native hydration and concurrent-write/outbox coverage remain separate follow-up work.

Stacked on #1300.

## Verification

- shared-log Rust: 49/49
- native-backbone Rust: 58/58
- shared-log Node/WASM: 143/143
- native-backbone Node/WASM: 123/123
- both package builds and lints
- `cargo fmt --check`
- changeset guard tests: 52/52
- `git diff --check`
- two independent safety reviews: no blockers