### PR TITLE
feat(shared-log): fence current V2 owner provenance

### DIFF
--- a/.changeset/current-v2-owner-provenance.md
+++ b/.changeset/current-v2-owner-provenance.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-log": patch
+---
+
+Track bounded, current-session V2 remote-owner provenance, invalidate it across lifecycle, session, transport, recovery, and clock fences, and publish it only after ownership mutations fully finalize inside the global mutation lane. This volatile evidence is for future placement capture only and carries no custody or prune authority.

--- a/packages/programs/data/shared-log/src/index.ts
+++ b/packages/programs/data/shared-log/src/index.ts
@@ -2264,6 +2264,7 @@ export class SharedLog<
 	// BEFORE the fresh lifecycle is installed, preserving the legacy
 	// ordering: a synchronous abort listener observes pre-rotation state.
 	private startRepairLifecycle(): AbortController {
+		this._v2Receive?.invalidateCurrentRemoteOwnerProvenance();
 		this._instanceLifecycle?.abortOwnership();
 		this._instanceLifecycle = this.createInstanceLifecycle();
 		this.clearCheckedPruneAuditTimer();
@@ -2271,6 +2272,7 @@ export class SharedLog<
 	}
 
 	private stopRepairLifecycle(): void {
+		this._v2Receive?.invalidateCurrentRemoteOwnerProvenance();
 		this._instanceLifecycle?.abortOwnership();
 	}
 
@@ -3575,6 +3577,13 @@ export class SharedLog<
 	private createReplicationInfoV2ReceiveCoordinator(): ReplicationInfoV2ReceiveCoordinator {
 		return new ReplicationInfoV2ReceiveCoordinator({
 			getSelfKey: () => this.node.identity.publicKey,
+			isOwnershipActive: () => {
+				const lifecycle = this._instanceLifecycle;
+				return (
+					lifecycle !== undefined &&
+					this.isRepairLifecycleActive(lifecycle.ownershipLifecycleController)
+				);
+			},
 			getReceiverTransportSession: () =>
 				BigInt(
 					(this.node.services.pubsub as unknown as { session: number }).session,
@@ -6706,7 +6715,9 @@ export class SharedLog<
 		options?: {
 			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
 			shouldRemove?: () => boolean;
+			onMutationStarted?: () => boolean | void;
 			onDurableRemoveCommitted?: () => boolean | void;
+			onMutationFinalized?: () => boolean | void;
 		},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
 	): Promise<boolean> {
@@ -6725,13 +6736,25 @@ export class SharedLog<
 		options?: {
 			onRemoved?: (ranges: ReplicationRangeIndexable<R>[]) => void;
 			shouldRemove?: () => boolean;
+			onMutationStarted?: () => boolean | void;
 			onDurableRemoveCommitted?: () => boolean | void;
+			onMutationFinalized?: () => boolean | void;
 		},
 	): Promise<boolean> {
-		if (ranges.length === 0) {
+		if (options?.shouldRemove && !options.shouldRemove()) {
 			return false;
 		}
-		if (options?.shouldRemove && !options.shouldRemove()) {
+		if (options?.onMutationStarted?.() === false) {
+			return false;
+		}
+		const finalizeNoop = () => {
+			if (options?.onDurableRemoveCommitted?.() === false) {
+				return false;
+			}
+			return options?.onMutationFinalized?.() !== false;
+		};
+		if (ranges.length === 0) {
+			finalizeNoop();
 			return false;
 		}
 		const expectedRangeById = new Map(
@@ -6771,10 +6794,11 @@ export class SharedLog<
 			}
 		}
 		ranges = refreshedRanges;
-		if (
-			ranges.length === 0 ||
-			(options?.shouldRemove && !options.shouldRemove())
-		) {
+		if (options?.shouldRemove && !options.shouldRemove()) {
+			return false;
+		}
+		if (ranges.length === 0) {
+			finalizeNoop();
 			return false;
 		}
 		const deletion = await this.deleteReplicationRangesCoherently(
@@ -6815,6 +6839,7 @@ export class SharedLog<
 			}
 			throw deletion.error;
 		}
+		options?.onMutationFinalized?.();
 		return ranges.length > 0;
 	}
 
@@ -6874,7 +6899,9 @@ export class SharedLog<
 			timestamp?: number;
 			allowOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			onMutationStarted?: () => boolean | void;
 			onDurableApplyCommitted?: () => boolean | void;
+			onMutationFinalized?: () => boolean | void;
 			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -6916,7 +6943,9 @@ export class SharedLog<
 			rebalance,
 			allowOrderedReplacementPairs,
 			onConfirmedDurableStateChanged,
+			onMutationStarted,
 			onDurableApplyCommitted,
+			onMutationFinalized,
 			shouldApply,
 		}: {
 			reset?: boolean;
@@ -6925,7 +6954,9 @@ export class SharedLog<
 			timestamp?: number;
 			allowOrderedReplacementPairs?: boolean;
 			onConfirmedDurableStateChanged?: () => void;
+			onMutationStarted?: () => boolean | void;
 			onDurableApplyCommitted?: () => boolean | void;
+			onMutationFinalized?: () => boolean | void;
 			shouldApply?: () => boolean;
 		} = {},
 		replicationOwnershipLifecycleController = this.captureReplicationOwnershipLifecycle(),
@@ -6938,6 +6969,9 @@ export class SharedLog<
 		// An adaptive update delayed by authorization must not commit after a newer
 		// full unreplication already completed in that lane.
 		if (shouldApply && !shouldApply()) {
+			return [];
+		}
+		if (onMutationStarted?.() === false) {
 			return [];
 		}
 		const applySuperseded = Symbol("replication-range-apply-superseded");
@@ -7498,6 +7532,7 @@ export class SharedLog<
 				}),
 			);
 		}
+		onMutationFinalized?.();
 		return diffs;
 	}
 
@@ -12943,9 +12978,7 @@ export class SharedLog<
 		}
 		// Success seam: `rollbackBatch` has exactly one call site (the catch
 		// above), and everything from here on escapes without any rollback.
-		this._coordinates.settleResidentCoordinateSnapshot(
-			batchCoordinateRollback,
-		);
+		this._coordinates.settleResidentCoordinateSnapshot(batchCoordinateRollback);
 
 		this.throwIfReplicationOwnershipLifecycleInactive(
 			ownershipLifecycleController,
@@ -15710,13 +15743,12 @@ export class SharedLog<
 			this.topic,
 		);
 		// We do this here, because these calls requires this.closed == false
-		void this.pruneOfflineReplicators()
-			.catch((error) => {
-				if (isNotStartedError(error as Error)) {
-					return;
-				}
-				logger.error(error);
-			});
+		void this.pruneOfflineReplicators().catch((error) => {
+			if (isNotStartedError(error as Error)) {
+				return;
+			}
+			logger.error(error);
+		});
 
 		this._liveness.startReplicatorLivenessSweep();
 
@@ -19253,24 +19285,30 @@ export class SharedLog<
 								);
 							}
 							if (syncProfile) {
-								emitSyncProfileDuration(syncProfile, coordinatePersistStartedAt, {
-									name: "sharedLog.receive.coordinatePersist",
-									component: "shared-log",
-									entries: entriesToPersist.length,
-									messages: 1,
-									details: {
-										reusedLeaderPlans: reusableCoordinatePersistItemCount,
-										nativeBackboneOnly:
-											nativeBackboneOnlyPersistedHashes?.size ?? 0,
+								emitSyncProfileDuration(
+									syncProfile,
+									coordinatePersistStartedAt,
+									{
+										name: "sharedLog.receive.coordinatePersist",
+										component: "shared-log",
+										entries: entriesToPersist.length,
+										messages: 1,
+										details: {
+											reusedLeaderPlans: reusableCoordinatePersistItemCount,
+											nativeBackboneOnly:
+												nativeBackboneOnlyPersistedHashes?.size ?? 0,
+										},
 									},
-								});
+								);
 							}
 							for (const hash of admittedHashes) {
 								confirmedHashes.add(hash);
 							}
 							const checkedPruneStartedAt = syncProfileStart(syncProfile);
 							const ownershipChangedDuringReceive =
-								!this.isReceiveOwnershipSnapshotStable(receiveOwnershipRevision);
+								!this.isReceiveOwnershipSnapshotStable(
+									receiveOwnershipRevision,
+								);
 							if (ownershipChangedDuringReceive) {
 								const freshAuditRevision =
 									this._instanceLifecycle?._receiveOwnershipRevision ?? 0;
@@ -19836,6 +19874,34 @@ export class SharedLog<
 				const exactGate = () =>
 					hostGate() && this._v2Receive.isAdmissionCurrent(admission);
 				let durableCommitted = false;
+				let provenanceMutationStarted = false;
+				let provenancePublished = false;
+				const beginProvenanceMutation = () => {
+					if (
+						!exactGate() ||
+						!this._v2Receive.beginRemoteOwnerProvenanceMutation(admission)
+					) {
+						return false;
+					}
+					provenanceMutationStarted = true;
+					return true;
+				};
+				const publishProvenance = () => {
+					if (
+						!durableCommitted ||
+						!exactGate() ||
+						!this._v2Receive.publishRemoteOwnerProvenance(admission)
+					) {
+						return false;
+					}
+					provenancePublished = true;
+					return true;
+				};
+				const failClosedIfPublicationMissing = () => {
+					if (durableCommitted && !provenancePublished) {
+						this._v2Receive.requireFullAfterFailure(admission);
+					}
+				};
 
 				try {
 					if (
@@ -19860,6 +19926,7 @@ export class SharedLog<
 									mutationGateAdmitted = exactGate();
 									return mutationGateAdmitted;
 								},
+								onMutationStarted: beginProvenanceMutation,
 								onDurableApplyCommitted: () => {
 									if (!exactGate() || !this._v2Receive.commit(admission)) {
 										return false;
@@ -19867,14 +19934,24 @@ export class SharedLog<
 									durableCommitted = true;
 									return true;
 								},
+								onMutationFinalized: publishProvenance,
 							},
 							lane.ownershipLifecycleController,
 						);
+						if (result === undefined) {
+							// Authorization is evaluated before the ownership lane. A fresh
+							// rejection must revoke any previously published provenance for
+							// this owner; persisted rows alone are never current authority.
+							this._v2Receive.requireFullAfterFailure(admission);
+							return;
+						}
+						failClosedIfPublicationMissing();
 						if (
-							result === undefined ||
 							!mutationGateChecked ||
 							!mutationGateAdmitted ||
+							!provenanceMutationStarted ||
 							!durableCommitted ||
+							!provenancePublished ||
 							!exactGate()
 						) {
 							return;
@@ -19892,8 +19969,7 @@ export class SharedLog<
 							return;
 						}
 						let mutationGateAdmitted = true;
-						const removedRanges: ReplicationRangeIndexable<R>[] = [];
-						const removed = await this.removeReplicationRanges(
+						await this.removeReplicationRanges(
 							rangesToRemove,
 							from,
 							{
@@ -19901,6 +19977,7 @@ export class SharedLog<
 									mutationGateAdmitted = exactGate();
 									return mutationGateAdmitted;
 								},
+								onMutationStarted: beginProvenanceMutation,
 								onDurableRemoveCommitted: () => {
 									if (!exactGate() || !this._v2Receive.commit(admission)) {
 										return false;
@@ -19908,35 +19985,39 @@ export class SharedLog<
 									durableCommitted = true;
 									return true;
 								},
-								onRemoved: (ranges) => removedRanges.push(...ranges),
+								onRemoved: (ranges) => {
+									if (
+										!this._instanceLifecycle!.isMembershipActiveFor(
+											lane.lifecycleController,
+										) ||
+										!this.isRepairLifecycleActive(
+											lane.ownershipLifecycleController,
+										)
+									) {
+										return;
+									}
+									const timestamp = BigInt(Date.now());
+									for (const range of ranges) {
+										this.replicationChangeDebounceFn.add({
+											range,
+											type: "removed",
+											timestamp,
+										});
+									}
+								},
+								onMutationFinalized: publishProvenance,
 							},
 							lane.ownershipLifecycleController,
 						);
-						if (!durableCommitted) {
-							if (
-								!mutationGateAdmitted ||
-								!exactGate() ||
-								removed ||
-								!this._v2Receive.commit(admission)
-							) {
-								return;
-							}
-							durableCommitted = true;
-						}
+						failClosedIfPublicationMissing();
 						if (
-							this._instanceLifecycle!.isMembershipActiveFor(
-								lane.lifecycleController,
-							) &&
-							this.isRepairLifecycleActive(lane.ownershipLifecycleController)
+							!mutationGateAdmitted ||
+							!provenanceMutationStarted ||
+							!durableCommitted ||
+							!provenancePublished ||
+							!exactGate()
 						) {
-							const timestamp = BigInt(Date.now());
-							for (const range of removedRanges) {
-								this.replicationChangeDebounceFn.add({
-									range,
-									type: "removed",
-									timestamp,
-								});
-							}
+							return;
 						}
 					}
 				} catch (error) {
@@ -19944,10 +20025,12 @@ export class SharedLog<
 					throw error;
 				}
 
-				if (!durableCommitted) {
-					if (!exactGate() || !this._v2Receive.commit(admission)) {
-						return;
-					}
+				if (
+					!provenanceMutationStarted ||
+					!durableCommitted ||
+					!provenancePublished
+				) {
+					return;
 				}
 				if (!hostGate()) {
 					return;

--- a/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
+++ b/packages/programs/data/shared-log/src/replication-info-v2-receive.ts
@@ -1,5 +1,11 @@
 import { serialize } from "@dao-xyz/borsh";
-import { type PublicSignKey, randomBytes, sha256Sync } from "@peerbit/crypto";
+import {
+	type PublicSignKey,
+	randomBytes,
+	sha256Base64Sync,
+	sha256Sync,
+	toHexString,
+} from "@peerbit/crypto";
 import {
 	SYNC_CAPABILITY_REPLICATION_INFO_V2_DECODE,
 	SYNC_CAPABILITY_REPLICATION_INFO_V2_SEND,
@@ -25,6 +31,86 @@ const DEFAULT_MAX_REQUEST_RETRY_MS = 30_000;
 const DEFAULT_REQUEST_MAX_ATTEMPTS = 7;
 const MAX_U64 = (1n << 64n) - 1n;
 const MAX_BACKOFF_EXPONENT = 20;
+
+export const MAX_REPLICATION_INFO_V2_CURRENT_OWNER_BATCH = 4096;
+export const MAX_REPLICATION_INFO_V2_CURRENT_OWNER_KEY_BYTES = 512;
+export const MAX_REPLICATION_INFO_V2_CURRENT_OWNER_HASH_BYTES = 512;
+export const DEFAULT_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS = 60_000;
+export const MAX_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS = 5 * 60_000;
+
+const utf8 = new TextEncoder();
+
+/**
+ * Volatile evidence that one authenticated V2 update was applied under the
+ * current receiver grant. It is not consensus, custody, transfer, or prune
+ * authority. It deliberately does not freeze the host's custom replicator
+ * policy; any later placement capture must re-evaluate current authorization.
+ */
+export type ReplicationInfoV2CurrentRemoteOwnerToken = Readonly<{
+	peerHash: string;
+	/** Canonical bytes of the authenticated sender key, copied and hex encoded. */
+	publicKeyHex: string;
+	senderTransportSession: bigint;
+	receiverTransportSession: bigint;
+	/** The capability-bound receiver binding carried by admitted V2 frames. */
+	receiverBindingHex: string;
+	senderEpochHex: string;
+	sequence: bigint;
+}>;
+
+export type ReplicationInfoV2CurrentRemoteOwner = Readonly<{
+	revision: bigint;
+	/** Conservative wall-clock projection of a monotonic local deadline. */
+	freshUntilMs: bigint;
+	token: ReplicationInfoV2CurrentRemoteOwnerToken;
+}>;
+
+export type ReplicationInfoV2CurrentRemoteOwnerCapture = Readonly<{
+	revision: bigint;
+	/** Minimum conservative wall deadline across every returned token. */
+	freshUntilMs?: bigint;
+	tokens: ReadonlyArray<ReplicationInfoV2CurrentRemoteOwnerToken>;
+}>;
+
+type ReplicationInfoV2RemoteOwnerGrant = {
+	generation: object;
+	openGeneration: object;
+	receiveEpoch: object | null;
+	senderTransportSession: bigint;
+	receiverTransportSession: bigint;
+	receiverRequestChallenge: Uint8Array;
+	receiverBinding: Uint8Array;
+	deadlineMonotonicMs: number;
+	fullFinalized: boolean;
+};
+
+type ReplicationInfoV2CurrentRemoteOwnerEntry = {
+	openGeneration: object;
+	state: ReplicationInfoV2ReceiveState;
+	peerSession: object;
+	receiveEpoch: object | null;
+	grantGeneration: object;
+	senderTransportSession: bigint;
+	receiverTransportSession: bigint;
+	receiverRequestChallenge: Uint8Array;
+	receiverBinding: Uint8Array;
+	senderEpoch: Uint8Array;
+	sequence: bigint;
+	deadlineMonotonicMs: number;
+	token: ReplicationInfoV2CurrentRemoteOwnerToken;
+};
+
+type ReplicationInfoV2CurrentRemoteOwnerCaptureEntry = {
+	openGeneration: object;
+	revision: bigint;
+	deadlineMonotonicMs?: number;
+};
+
+type ReplicationInfoV2RemoteOwnerMutationFence = {
+	openGeneration: object;
+	state: ReplicationInfoV2ReceiveState;
+	grantGeneration: object;
+};
 
 const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
 	if (left.byteLength !== right.byteLength) {
@@ -138,6 +224,8 @@ export type ReplicationInfoV2ReceiveState = {
 	requestParked: boolean;
 	capabilityRefreshRequired: boolean;
 	reservedAdmission?: ReplicationInfoV2ReceiveAdmission;
+	/** Local-only freshness for the exact currently bound receiver grant. */
+	remoteOwnerGrant?: ReplicationInfoV2RemoteOwnerGrant;
 };
 
 export type ReplicationInfoV2ReceiveAdmission = {
@@ -156,6 +244,8 @@ export type ReplicationInfoV2ReceiveDeps = {
 	getSelfKey: () => PublicSignKey;
 	getReceiverTransportSession: () => bigint;
 	isClosed: () => boolean;
+	/** Exact current SharedLog ownership lifecycle, including poison/rotation. */
+	isOwnershipActive: () => boolean;
 	isPeerSessionCurrent: (peerHash: string, peerSession: object) => boolean;
 	isReceiveEpochCurrent: (
 		peerHash: string,
@@ -185,6 +275,11 @@ export type ReplicationInfoV2ReceiveDeps = {
 	onRequestError?: (error: unknown) => void;
 	onLocalCapabilityError?: (error: unknown) => void;
 	now?: () => number;
+	/** Receiver-local monotonic clock; remote/wall timestamps never grant freshness. */
+	monotonicNow?: () => number;
+	/** Wall clock used only to project a diagnostic/capture deadline. */
+	wallNow?: () => number;
+	currentRemoteOwnerTtlMs?: number;
 	requestRetryMs?: number;
 	maxRequestRetryMs?: number;
 	requestMaxAttempts?: number;
@@ -216,14 +311,49 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		ReplicationInfoV2LocalCapabilityAdvertisement
 	>;
 	_reservedAdmissionsByPeer!: Map<string, ReplicationInfoV2ReceiveAdmission>;
+	_currentRemoteOwnerByPeer!: Map<
+		string,
+		ReplicationInfoV2CurrentRemoteOwnerEntry
+	>;
+	_currentRemoteOwnerOpenGeneration!: object;
+	_currentRemoteOwnerRevision!: bigint;
+	_currentRemoteOwnerTokens!: WeakSet<object>;
+	_currentRemoteOwnerCaptures!: WeakMap<
+		object,
+		ReplicationInfoV2CurrentRemoteOwnerCaptureEntry
+	>;
+	_currentRemoteOwnerMutationFences!: WeakMap<
+		object,
+		ReplicationInfoV2RemoteOwnerMutationFence
+	>;
 
 	private readonly now: () => number;
+	private readonly monotonicNow: () => number;
+	private readonly wallNow: () => number;
+	private readonly currentRemoteOwnerTtlMs: number;
+	private lastMonotonicNow = 0;
+	private monotonicNowInitialized = false;
 	private readonly requestRetryMs: number;
 	private readonly maxRequestRetryMs: number;
 	private readonly requestMaxAttempts: number;
 
 	constructor(private readonly deps: ReplicationInfoV2ReceiveDeps) {
 		this.now = deps.now ?? Date.now;
+		this.monotonicNow =
+			deps.monotonicNow ??
+			(() => globalThis.performance?.now?.() ?? Date.now());
+		this.wallNow = deps.wallNow ?? Date.now;
+		const currentRemoteOwnerTtlMs =
+			deps.currentRemoteOwnerTtlMs ??
+			DEFAULT_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS;
+		if (
+			!Number.isSafeInteger(currentRemoteOwnerTtlMs) ||
+			currentRemoteOwnerTtlMs <= 0 ||
+			currentRemoteOwnerTtlMs > MAX_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS
+		) {
+			throw new Error("Invalid replication-info V2 current-owner TTL");
+		}
+		this.currentRemoteOwnerTtlMs = currentRemoteOwnerTtlMs;
 		this.requestRetryMs = Math.max(
 			1,
 			deps.requestRetryMs ?? DEFAULT_REQUEST_RETRY_MS,
@@ -242,6 +372,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		this._localCapabilityContextBySession = new WeakMap();
 		this._localCapabilityAdvertisementsByPeer = new Map();
 		this._reservedAdmissionsByPeer = new Map();
+		this.resetCurrentRemoteOwnerProvenance();
 	}
 
 	resetForOpen(): void {
@@ -252,9 +383,11 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		this._localCapabilityContextBySession = new WeakMap();
 		this._localCapabilityAdvertisementsByPeer = new Map();
 		this._reservedAdmissionsByPeer = new Map();
+		this.resetCurrentRemoteOwnerProvenance();
 	}
 
 	clearForClose(): void {
+		this.clearCurrentRemoteOwnerProvenance();
 		for (const advertisement of [
 			...(this._localCapabilityAdvertisementsByPeer?.values() ?? []),
 		]) {
@@ -291,12 +424,17 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			this._localCapabilityContextBySession.delete(expectedSession);
 			this._cutoverPeerSessions.delete(expectedSession);
 		}
+		const current = this._currentRemoteOwnerByPeer.get(peerHash);
+		if (!expectedSession || current?.peerSession === expectedSession) {
+			this.invalidateCurrentRemoteOwner(peerHash);
+		}
 	}
 
 	/** Revoke an unauthenticated or downgraded capability generation. */
 	revokePeerCapability(peerHash: string): void {
 		const state = this._receiveStates.get(peerHash);
 		if (!state) {
+			this.invalidateCurrentRemoteOwner(peerHash);
 			return;
 		}
 		this.clearState(state);
@@ -308,6 +446,8 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	}
 
 	private clearState(state: ReplicationInfoV2ReceiveState): void {
+		this.invalidateCurrentRemoteOwner(state.peerHash, state);
+		state.remoteOwnerGrant = undefined;
 		if (state.requestTimer) {
 			clearTimeout(state.requestTimer);
 			state.requestTimer = undefined;
@@ -317,6 +457,591 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (this._receiveStates.get(state.peerHash) === state) {
 			this._receiveStates.delete(state.peerHash);
 		}
+	}
+
+	private resetCurrentRemoteOwnerProvenance(): void {
+		this._currentRemoteOwnerByPeer = new Map();
+		this._currentRemoteOwnerOpenGeneration = {};
+		this._currentRemoteOwnerRevision = 0n;
+		this._currentRemoteOwnerTokens = new WeakSet();
+		this._currentRemoteOwnerCaptures = new WeakMap();
+		this._currentRemoteOwnerMutationFences = new WeakMap();
+		this.lastMonotonicNow = 0;
+		this.monotonicNowInitialized = false;
+	}
+
+	private clearCurrentRemoteOwnerProvenance(): void {
+		if (this._currentRemoteOwnerByPeer?.size > 0) {
+			this._currentRemoteOwnerRevision++;
+		}
+		this._currentRemoteOwnerByPeer = new Map();
+		// Tokens from a closed open-generation must fail before consulting any
+		// caller-visible diagnostic field.
+		this._currentRemoteOwnerTokens = new WeakSet();
+		this._currentRemoteOwnerCaptures = new WeakMap();
+		this._currentRemoteOwnerMutationFences = new WeakMap();
+		this._currentRemoteOwnerOpenGeneration = {};
+	}
+
+	private currentMonotonicNow(): number | undefined {
+		let sampled: number;
+		try {
+			sampled = this.monotonicNow();
+		} catch {
+			this.clearCurrentRemoteOwnerProvenance();
+			return undefined;
+		}
+		if (
+			!Number.isFinite(sampled) ||
+			sampled < 0 ||
+			(this.monotonicNowInitialized && sampled < this.lastMonotonicNow)
+		) {
+			// An unmeasured interval can never be repaired by a later clock sample.
+			// Rotate the authority generation so every already-bound grant fails
+			// closed until the capability worker binds a fresh challenge.
+			this.clearCurrentRemoteOwnerProvenance();
+			return undefined;
+		}
+		this.monotonicNowInitialized = true;
+		this.lastMonotonicNow = sampled;
+		return this.lastMonotonicNow;
+	}
+
+	/** O(1) host lifecycle fence; protocol ordering state is intentionally kept. */
+	invalidateCurrentRemoteOwnerProvenance(): void {
+		this.clearCurrentRemoteOwnerProvenance();
+	}
+
+	private hasCurrentOwnershipAuthority(): boolean {
+		let active = false;
+		try {
+			active = !this.deps.isClosed() && this.deps.isOwnershipActive();
+		} catch {
+			active = false;
+		}
+		if (!active && this._currentRemoteOwnerByPeer) {
+			// Observing a poisoned/rotated host generation is itself a permanent
+			// fence: old empty captures must not become current if the predicate
+			// later flips back without a coordinator open reset.
+			this.clearCurrentRemoteOwnerProvenance();
+		}
+		return active;
+	}
+
+	private isRemoteOwnerGrantCurrent(
+		state: ReplicationInfoV2ReceiveState,
+		grant: ReplicationInfoV2RemoteOwnerGrant,
+	): boolean {
+		return (
+			grant.openGeneration === this._currentRemoteOwnerOpenGeneration &&
+			grant.receiveEpoch === state.receiveEpoch &&
+			grant.senderTransportSession === state.senderTransportSession &&
+			state.receiverTransportSession !== undefined &&
+			grant.receiverTransportSession === state.receiverTransportSession &&
+			state.receiverBinding !== undefined &&
+			bytesEqual(
+				grant.receiverRequestChallenge,
+				state.receiverRequestChallenge,
+			) &&
+			bytesEqual(grant.receiverBinding, state.receiverBinding)
+		);
+	}
+
+	private boundedCurrentRemoteOwnerPeerHash(
+		value: unknown,
+	): string | undefined {
+		if (
+			typeof value !== "string" ||
+			value.length === 0 ||
+			value.length > MAX_REPLICATION_INFO_V2_CURRENT_OWNER_HASH_BYTES
+		) {
+			return undefined;
+		}
+		return utf8.encode(value).byteLength <=
+			MAX_REPLICATION_INFO_V2_CURRENT_OWNER_HASH_BYTES
+			? value
+			: undefined;
+	}
+
+	private currentRemoteOwnerKeyFacts(
+		state: ReplicationInfoV2ReceiveState,
+	): { peerHash: string; publicKeyHex: string } | undefined {
+		const bytes = state.target.bytes;
+		if (
+			!(bytes instanceof Uint8Array) ||
+			bytes.byteLength === 0 ||
+			bytes.byteLength > MAX_REPLICATION_INFO_V2_CURRENT_OWNER_KEY_BYTES
+		) {
+			return undefined;
+		}
+		const copied = bytes.slice();
+		const peerHash = sha256Base64Sync(copied);
+		if (peerHash !== state.peerHash) {
+			return undefined;
+		}
+		return { peerHash, publicKeyHex: toHexString(copied) };
+	}
+
+	private invalidateCurrentRemoteOwner(
+		peerHash: string,
+		expectedState?: ReplicationInfoV2ReceiveState,
+	): boolean {
+		const current = this._currentRemoteOwnerByPeer?.get(peerHash);
+		if (!current || (expectedState && current.state !== expectedState)) {
+			return false;
+		}
+		this._currentRemoteOwnerByPeer.delete(peerHash);
+		this._currentRemoteOwnerRevision++;
+		return true;
+	}
+
+	private expireCurrentRemoteOwner(
+		entry: ReplicationInfoV2CurrentRemoteOwnerEntry,
+	): void {
+		this.invalidateCurrentRemoteOwner(entry.token.peerHash, entry.state);
+		const { state } = entry;
+		if (
+			this._receiveStates.get(state.peerHash) === state &&
+			state.remoteOwnerGrant?.generation === entry.grantGeneration &&
+			this.isStateCurrent(state)
+		) {
+			this.transitionToResync(state, {
+				force: true,
+				refreshCapability: true,
+			});
+		}
+	}
+
+	private expireCurrentRemoteOwnerGrantIfNeeded(
+		peerHash: string,
+		now: number,
+	): void {
+		const state = this._receiveStates.get(peerHash);
+		const grant = state?.remoteOwnerGrant;
+		if (
+			state &&
+			grant &&
+			now >= grant.deadlineMonotonicMs &&
+			this.isStateCurrent(state)
+		) {
+			this.transitionToResync(state, {
+				force: true,
+				refreshCapability: true,
+			});
+		}
+	}
+
+	private isCurrentRemoteOwnerEntry(
+		entry: ReplicationInfoV2CurrentRemoteOwnerEntry,
+		now: number,
+	): boolean {
+		const { state, token } = entry;
+		const grant = state.remoteOwnerGrant;
+		if (
+			!this.hasCurrentOwnershipAuthority() ||
+			this._currentRemoteOwnerByPeer.get(token.peerHash) !== entry ||
+			entry.openGeneration !== this._currentRemoteOwnerOpenGeneration ||
+			entry.peerSession !== state.peerSession ||
+			entry.receiveEpoch !== state.receiveEpoch ||
+			entry.senderTransportSession !== state.senderTransportSession ||
+			entry.receiverTransportSession !== state.receiverTransportSession ||
+			state.phase !== "active" ||
+			state.senderEpoch === undefined ||
+			state.lastSequence !== entry.sequence ||
+			!bytesEqual(state.senderEpoch, entry.senderEpoch) ||
+			state.receiverBinding === undefined ||
+			!bytesEqual(state.receiverBinding, entry.receiverBinding) ||
+			grant === undefined ||
+			!this.isRemoteOwnerGrantCurrent(state, grant) ||
+			grant.generation !== entry.grantGeneration ||
+			grant.receiveEpoch !== entry.receiveEpoch ||
+			grant.senderTransportSession !== entry.senderTransportSession ||
+			grant.receiverTransportSession !== entry.receiverTransportSession ||
+			!bytesEqual(
+				grant.receiverRequestChallenge,
+				entry.receiverRequestChallenge,
+			) ||
+			!bytesEqual(
+				state.receiverRequestChallenge,
+				entry.receiverRequestChallenge,
+			) ||
+			grant.deadlineMonotonicMs !== entry.deadlineMonotonicMs ||
+			!grant.fullFinalized ||
+			!bytesEqual(grant.receiverBinding, entry.receiverBinding) ||
+			!this.isStateCurrent(state)
+		) {
+			this.invalidateCurrentRemoteOwner(token.peerHash, state);
+			return false;
+		}
+		if (now >= entry.deadlineMonotonicMs) {
+			this.expireCurrentRemoteOwner(entry);
+			return false;
+		}
+		const key = this.currentRemoteOwnerKeyFacts(state);
+		if (
+			!key ||
+			key.peerHash !== token.peerHash ||
+			key.publicKeyHex !== token.publicKeyHex ||
+			toHexString(state.senderEpoch) !== token.senderEpochHex ||
+			toHexString(state.receiverBinding) !== token.receiverBindingHex
+		) {
+			this.invalidateCurrentRemoteOwner(token.peerHash, state);
+			return false;
+		}
+		return true;
+	}
+
+	private currentRemoteOwnerFreshUntil(
+		deadlineMonotonicMs: number,
+		nowMonotonicMs: number,
+	): bigint | undefined {
+		let wallNow: number;
+		try {
+			wallNow = this.wallNow();
+		} catch {
+			return undefined;
+		}
+		if (!Number.isSafeInteger(wallNow) || wallNow < 0) {
+			return undefined;
+		}
+		const projected = Math.floor(
+			wallNow + Math.max(0, deadlineMonotonicMs - nowMonotonicMs),
+		);
+		return Number.isSafeInteger(projected) && projected > wallNow
+			? BigInt(projected)
+			: undefined;
+	}
+
+	/** Read one exact current token. It conveys no transfer or prune authority. */
+	currentRemoteOwnerProvenance(
+		peerHash: string,
+	): ReplicationInfoV2CurrentRemoteOwner | undefined {
+		const bounded = this.boundedCurrentRemoteOwnerPeerHash(peerHash);
+		const now = this.currentMonotonicNow();
+		if (!bounded || now === undefined || !this.hasCurrentOwnershipAuthority()) {
+			return undefined;
+		}
+		const entry = this._currentRemoteOwnerByPeer.get(bounded);
+		if (!entry || !this.isCurrentRemoteOwnerEntry(entry, now)) {
+			if (!entry) {
+				this.expireCurrentRemoteOwnerGrantIfNeeded(bounded, now);
+			}
+			return undefined;
+		}
+		const freshUntilMs = this.currentRemoteOwnerFreshUntil(
+			entry.deadlineMonotonicMs,
+			now,
+		);
+		return freshUntilMs === undefined
+			? undefined
+			: Object.freeze({
+					revision: this._currentRemoteOwnerRevision,
+					freshUntilMs,
+					token: entry.token,
+				});
+	}
+
+	/** Validate exact token identity against the complete current V2 state. */
+	isCurrentRemoteOwnerProvenance(
+		token: ReplicationInfoV2CurrentRemoteOwnerToken,
+	): boolean {
+		if (
+			!token ||
+			typeof token !== "object" ||
+			!this._currentRemoteOwnerTokens.has(token) ||
+			!this.hasCurrentOwnershipAuthority()
+		) {
+			return false;
+		}
+		const now = this.currentMonotonicNow();
+		if (now === undefined) {
+			return false;
+		}
+		const entry = this._currentRemoteOwnerByPeer.get(token.peerHash);
+		if (!entry) {
+			this.expireCurrentRemoteOwnerGrantIfNeeded(token.peerHash, now);
+		}
+		return (
+			entry !== undefined &&
+			entry.token === token &&
+			this.isCurrentRemoteOwnerEntry(entry, now)
+		);
+	}
+
+	/**
+	 * Capture a dense unique peer set at one revision and monotonic instant.
+	 * Missing or expired peers fail the whole capture; no prefix is returned.
+	 */
+	captureCurrentRemoteOwnerProvenance(
+		peerHashes: readonly string[],
+	): ReplicationInfoV2CurrentRemoteOwnerCapture | undefined {
+		if (!Array.isArray(peerHashes)) {
+			throw new Error("Invalid replication-info V2 current-owner batch");
+		}
+		const length = peerHashes.length;
+		if (
+			!Number.isSafeInteger(length) ||
+			length < 0 ||
+			length > MAX_REPLICATION_INFO_V2_CURRENT_OWNER_BATCH
+		) {
+			throw new Error("Invalid replication-info V2 current-owner batch");
+		}
+		const bounded: string[] = [];
+		const unique = new Set<string>();
+		for (let index = 0; index < length; index++) {
+			if (!Object.prototype.hasOwnProperty.call(peerHashes, index)) {
+				throw new Error("Invalid replication-info V2 current-owner batch");
+			}
+			const peerHash = this.boundedCurrentRemoteOwnerPeerHash(
+				peerHashes[index],
+			);
+			if (!peerHash || unique.has(peerHash)) {
+				throw new Error("Invalid replication-info V2 current-owner batch");
+			}
+			unique.add(peerHash);
+			bounded.push(peerHash);
+		}
+
+		const now = this.currentMonotonicNow();
+		if (now === undefined || !this.hasCurrentOwnershipAuthority()) {
+			return undefined;
+		}
+		const entries: ReplicationInfoV2CurrentRemoteOwnerEntry[] = [];
+		let deadline = Number.POSITIVE_INFINITY;
+		for (let index = 0; index < bounded.length; index++) {
+			const entry = this._currentRemoteOwnerByPeer.get(bounded[index]!);
+			if (!entry || !this.isCurrentRemoteOwnerEntry(entry, now)) {
+				if (!entry) {
+					this.expireCurrentRemoteOwnerGrantIfNeeded(bounded[index]!, now);
+				}
+				return undefined;
+			}
+			entries.push(entry);
+			deadline = Math.min(deadline, entry.deadlineMonotonicMs);
+		}
+		const freshUntilMs =
+			entries.length === 0
+				? undefined
+				: this.currentRemoteOwnerFreshUntil(deadline, now);
+		if (entries.length > 0 && freshUntilMs === undefined) {
+			return undefined;
+		}
+		const tokens = Object.freeze(entries.map((entry) => entry.token));
+		const capture = Object.freeze({
+			revision: this._currentRemoteOwnerRevision,
+			freshUntilMs,
+			tokens,
+		});
+		this._currentRemoteOwnerCaptures.set(capture, {
+			openGeneration: this._currentRemoteOwnerOpenGeneration,
+			revision: this._currentRemoteOwnerRevision,
+			deadlineMonotonicMs: entries.length === 0 ? undefined : deadline,
+		});
+		return capture;
+	}
+
+	/**
+	 * Revalidate a complete batch, including an empty self-only capture, against
+	 * the exact open generation and every intervening registry mutation.
+	 */
+	isCurrentRemoteOwnerProvenanceCapture(
+		capture: ReplicationInfoV2CurrentRemoteOwnerCapture,
+	): boolean {
+		if (
+			!capture ||
+			typeof capture !== "object" ||
+			!this.hasCurrentOwnershipAuthority()
+		) {
+			return false;
+		}
+		const retained = this._currentRemoteOwnerCaptures.get(capture);
+		if (
+			!retained ||
+			retained.openGeneration !== this._currentRemoteOwnerOpenGeneration ||
+			retained.revision !== this._currentRemoteOwnerRevision
+		) {
+			return false;
+		}
+		const now = this.currentMonotonicNow();
+		if (now === undefined) {
+			return false;
+		}
+		for (let index = 0; index < capture.tokens.length; index++) {
+			const token = capture.tokens[index]!;
+			if (!this._currentRemoteOwnerTokens.has(token)) {
+				return false;
+			}
+			const entry = this._currentRemoteOwnerByPeer.get(token.peerHash);
+			if (
+				!entry ||
+				entry.token !== token ||
+				!this.isCurrentRemoteOwnerEntry(entry, now)
+			) {
+				return false;
+			}
+		}
+		return (
+			retained.openGeneration === this._currentRemoteOwnerOpenGeneration &&
+			retained.revision === this._currentRemoteOwnerRevision
+		);
+	}
+
+	/** Invalidate at the exact-gated ownership-lane mutation start. */
+	beginRemoteOwnerProvenanceMutation(
+		admission: ReplicationInfoV2ReceiveAdmission,
+	): boolean {
+		const existing = this._currentRemoteOwnerMutationFences.get(admission);
+		if (existing) {
+			return (
+				!admission.committed &&
+				existing.openGeneration === this._currentRemoteOwnerOpenGeneration &&
+				existing.state === admission.state &&
+				existing.grantGeneration ===
+					admission.state.remoteOwnerGrant?.generation &&
+				this.hasCurrentOwnershipAuthority() &&
+				this.isAdmissionCurrent(admission)
+			);
+		}
+		const grant = admission.state.remoteOwnerGrant;
+		const now = this.currentMonotonicNow();
+		if (
+			admission.committed ||
+			!this.hasCurrentOwnershipAuthority() ||
+			!this.isAdmissionCurrent(admission) ||
+			!grant ||
+			!this.isRemoteOwnerGrantCurrent(admission.state, grant) ||
+			now === undefined ||
+			now >= grant.deadlineMonotonicMs
+		) {
+			if (
+				grant &&
+				now !== undefined &&
+				now >= grant.deadlineMonotonicMs &&
+				this.isAdmissionCurrent(admission)
+			) {
+				this.transitionToResync(admission.state, {
+					force: true,
+					refreshCapability: true,
+				});
+			}
+			return false;
+		}
+		const invalidated = this.invalidateCurrentRemoteOwner(
+			admission.state.peerHash,
+			admission.state,
+		);
+		if (!invalidated) {
+			// Even a first Full with no previous token invalidates a previously
+			// captured empty/self-only view while its range mutation is in flight.
+			this._currentRemoteOwnerRevision++;
+		}
+		this._currentRemoteOwnerMutationFences.set(admission, {
+			openGeneration: this._currentRemoteOwnerOpenGeneration,
+			state: admission.state,
+			grantGeneration: grant.generation,
+		});
+		return true;
+	}
+
+	/**
+	 * Publish only after protocol commit and all fallible ownership bookkeeping.
+	 * Full enables the bound grant; deltas can only replace an enabled token.
+	 */
+	publishRemoteOwnerProvenance(
+		admission: ReplicationInfoV2ReceiveAdmission,
+	): boolean {
+		const mutationFence = this._currentRemoteOwnerMutationFences.get(admission);
+		if (
+			!admission.committed ||
+			!this.hasCurrentOwnershipAuthority() ||
+			!this.isAdmissionCurrent(admission) ||
+			!mutationFence ||
+			mutationFence.openGeneration !== this._currentRemoteOwnerOpenGeneration ||
+			mutationFence.state !== admission.state
+		) {
+			return false;
+		}
+		const { state, message } = admission;
+		const grant = state.remoteOwnerGrant;
+		const now = this.currentMonotonicNow();
+		if (
+			now === undefined ||
+			state.phase !== "active" ||
+			state.lastSequence !== message.sequence ||
+			state.senderEpoch === undefined ||
+			!bytesEqual(state.senderEpoch, message.senderEpoch) ||
+			state.receiverBinding === undefined ||
+			grant === undefined ||
+			mutationFence.grantGeneration !== grant.generation ||
+			!this.isRemoteOwnerGrantCurrent(state, grant) ||
+			grant.receiveEpoch !== state.receiveEpoch ||
+			grant.senderTransportSession !== state.senderTransportSession ||
+			grant.receiverTransportSession !== state.receiverTransportSession ||
+			!bytesEqual(grant.receiverBinding, state.receiverBinding)
+		) {
+			return false;
+		}
+		if (now >= grant.deadlineMonotonicMs) {
+			const existing = this._currentRemoteOwnerByPeer.get(state.peerHash);
+			if (existing) {
+				this.expireCurrentRemoteOwner(existing);
+			} else {
+				this.transitionToResync(state, {
+					force: true,
+					refreshCapability: true,
+				});
+			}
+			return false;
+		}
+		if (admission.kind !== "full" && !grant.fullFinalized) {
+			return false;
+		}
+		const key = this.currentRemoteOwnerKeyFacts(state);
+		if (!key) {
+			return false;
+		}
+		const existing = this._currentRemoteOwnerByPeer.get(state.peerHash);
+		if (
+			existing?.state === state &&
+			existing.grantGeneration === grant.generation &&
+			existing.sequence === message.sequence &&
+			this.isCurrentRemoteOwnerEntry(existing, now)
+		) {
+			return true;
+		}
+
+		const token = Object.freeze({
+			peerHash: key.peerHash,
+			publicKeyHex: key.publicKeyHex,
+			senderTransportSession: state.senderTransportSession,
+			receiverTransportSession: state.receiverTransportSession!,
+			receiverBindingHex: toHexString(state.receiverBinding),
+			senderEpochHex: toHexString(state.senderEpoch),
+			sequence: message.sequence,
+		});
+		const entry: ReplicationInfoV2CurrentRemoteOwnerEntry = {
+			openGeneration: this._currentRemoteOwnerOpenGeneration,
+			state,
+			peerSession: state.peerSession,
+			receiveEpoch: state.receiveEpoch,
+			grantGeneration: grant.generation,
+			senderTransportSession: state.senderTransportSession,
+			receiverTransportSession: state.receiverTransportSession!,
+			receiverRequestChallenge: state.receiverRequestChallenge.slice(),
+			receiverBinding: state.receiverBinding.slice(),
+			senderEpoch: state.senderEpoch.slice(),
+			sequence: message.sequence,
+			deadlineMonotonicMs: grant.deadlineMonotonicMs,
+			token,
+		};
+		if (admission.kind === "full") {
+			grant.fullFinalized = true;
+		}
+		this._currentRemoteOwnerByPeer.set(state.peerHash, entry);
+		this._currentRemoteOwnerTokens.add(token);
+		this._currentRemoteOwnerRevision++;
+		this._currentRemoteOwnerMutationFences.delete(admission);
+		return true;
 	}
 
 	private clearLocalCapabilityAdvertisement(
@@ -896,13 +1621,53 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		ready: LocalCapabilityReady,
 	): void {
 		state.receiverTransportSession = ready.receiverTransportSession;
-		state.receiverBinding = deriveReplicationInfoV2ReceiverBinding({
+		const receiverBinding = deriveReplicationInfoV2ReceiverBinding({
 			receiverChallenge: state.receiverRequestChallenge,
 			receiver: this.deps.getSelfKey(),
 			receiverTransportSession: ready.receiverTransportSession,
 			sender: state.target,
 			senderTransportSession: state.senderTransportSession,
 		});
+		state.receiverBinding = receiverBinding;
+		const current = state.remoteOwnerGrant;
+		if (
+			current &&
+			current.receiveEpoch === state.receiveEpoch &&
+			current.senderTransportSession === state.senderTransportSession &&
+			current.receiverTransportSession === ready.receiverTransportSession &&
+			bytesEqual(
+				current.receiverRequestChallenge,
+				state.receiverRequestChallenge,
+			) &&
+			bytesEqual(current.receiverBinding, receiverBinding)
+		) {
+			// Replayed readiness for the same exact binding must not manufacture a
+			// later freshness deadline.
+			return;
+		}
+		this.invalidateCurrentRemoteOwner(state.peerHash, state);
+		const boundAt = this.currentMonotonicNow();
+		const deadline =
+			boundAt === undefined
+				? undefined
+				: boundAt + this.currentRemoteOwnerTtlMs;
+		state.remoteOwnerGrant =
+			boundAt === undefined ||
+			deadline === undefined ||
+			!Number.isFinite(deadline) ||
+			deadline <= boundAt
+				? undefined
+				: {
+						generation: {},
+						openGeneration: this._currentRemoteOwnerOpenGeneration,
+						receiveEpoch: state.receiveEpoch,
+						senderTransportSession: state.senderTransportSession,
+						receiverTransportSession: ready.receiverTransportSession,
+						receiverRequestChallenge: state.receiverRequestChallenge.slice(),
+						receiverBinding: receiverBinding.slice(),
+						deadlineMonotonicMs: deadline,
+						fullFinalized: false,
+					};
 	}
 
 	/** Require a fresh capability-bound grant and authoritative Full. */
@@ -1004,6 +1769,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		state: ReplicationInfoV2ReceiveState,
 		options?: { force?: boolean; refreshCapability?: boolean },
 	): void {
+		this.invalidateCurrentRemoteOwner(state.peerHash, state);
 		const shouldRestart =
 			state.phase !== "resync" ||
 			options?.force === true ||
@@ -1014,6 +1780,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		}
 		if (options?.refreshCapability) {
 			state.capabilityRefreshRequired = true;
+			state.remoteOwnerGrant = undefined;
 		}
 		if (shouldRestart) {
 			state.requestAttempts = 0;
@@ -1047,6 +1814,23 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		) {
 			return undefined;
 		}
+		if (!this.hasCurrentOwnershipAuthority()) {
+			return undefined;
+		}
+		const grantNow = this.currentMonotonicNow();
+		const grant = state.remoteOwnerGrant;
+		if (
+			grantNow === undefined ||
+			grant === undefined ||
+			!this.isRemoteOwnerGrantCurrent(state, grant) ||
+			grantNow >= grant.deadlineMonotonicMs
+		) {
+			this.transitionToResync(state, {
+				force: true,
+				refreshCapability: true,
+			});
+			return undefined;
+		}
 
 		const kind =
 			message instanceof FullReplicationInfoV2Message
@@ -1059,7 +1843,6 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		if (!kind) {
 			return undefined;
 		}
-
 		if (state.senderEpoch === undefined) {
 			if (kind !== "full") {
 				return undefined;
@@ -1232,6 +2015,23 @@ export class ReplicationInfoV2ReceiveCoordinator {
 			this.release(admission);
 			return false;
 		}
+		const mutationFence = this._currentRemoteOwnerMutationFences.get(admission);
+		if (
+			!mutationFence ||
+			mutationFence.openGeneration !== this._currentRemoteOwnerOpenGeneration ||
+			mutationFence.state !== state ||
+			mutationFence.grantGeneration !== state.remoteOwnerGrant?.generation
+		) {
+			const invalidated = this.invalidateCurrentRemoteOwner(
+				state.peerHash,
+				state,
+			);
+			if (!invalidated) {
+				// Direct protocol users do not participate in the host ownership lane,
+				// but their successful state advance must still stale empty captures.
+				this._currentRemoteOwnerRevision++;
+			}
+		}
 		state.lastSequence = message.sequence;
 		state.phase = "active";
 		state.requestAttempts = 0;
@@ -1253,6 +2053,7 @@ export class ReplicationInfoV2ReceiveCoordinator {
 	requireFullAfterFailure(
 		admission: ReplicationInfoV2ReceiveAdmission,
 	): boolean {
+		this._currentRemoteOwnerMutationFences.delete(admission);
 		if (!this.isAdmissionCurrent(admission)) {
 			this.release(admission);
 			return false;
@@ -1341,6 +2142,8 @@ export class ReplicationInfoV2ReceiveCoordinator {
 		) {
 			return false;
 		}
+		this.invalidateCurrentRemoteOwner(state.peerHash, state);
+		state.remoteOwnerGrant = undefined;
 
 		const ready: LocalCapabilityReady = {
 			peerHash: state.peerHash,

--- a/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
+++ b/packages/programs/data/shared-log/test/replication-info-v2-receiver.spec.ts
@@ -1,4 +1,4 @@
-import { Ed25519PublicKey } from "@peerbit/crypto";
+import { Ed25519PublicKey, toHexString } from "@peerbit/crypto";
 import { TestSession } from "@peerbit/test-utils";
 import { waitForResolved } from "@peerbit/time";
 import { expect } from "chai";
@@ -11,11 +11,14 @@ import {
 } from "../src/exchange-heads.js";
 import {
 	ReplicationIntent,
-	ReplicationRangeMessageU32,
 	ReplicationRangeMessageU64,
 } from "../src/ranges.js";
 import { deriveReplicationInfoV2ReceiverBinding } from "../src/replication-info-v2-binding.js";
-import { ReplicationInfoV2ReceiveCoordinator } from "../src/replication-info-v2-receive.js";
+import {
+	MAX_REPLICATION_INFO_V2_CURRENT_OWNER_BATCH,
+	MAX_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS,
+	ReplicationInfoV2ReceiveCoordinator,
+} from "../src/replication-info-v2-receive.js";
 import { ReplicationInfoV2SendCoordinator } from "../src/replication-info-v2-send.js";
 import {
 	AddedReplicationInfoV2Message,
@@ -53,11 +56,16 @@ describe("receive admission replication-info V2 receiver state", () => {
 		requestRetryMs?: number;
 		maxRequestRetryMs?: number;
 		requestMaxAttempts?: number;
+		monotonicNow?: () => number;
+		wallNow?: () => number;
+		currentRemoteOwnerTtlMs?: number;
+		isOwnershipActive?: () => boolean;
 	}) =>
 		new ReplicationInfoV2ReceiveCoordinator({
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => receiverTransportSession,
 			isClosed: () => closed,
+			isOwnershipActive: options?.isOwnershipActive ?? (() => true),
 			isPeerSessionCurrent: (_peerHash, peerSession) =>
 				peerSession === currentSession,
 			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
@@ -70,6 +78,9 @@ describe("receive admission replication-info V2 receiver state", () => {
 				transportSession === currentSenderTransportSession,
 			sendRequest,
 			refreshLocalCapability,
+			monotonicNow: options?.monotonicNow,
+			wallNow: options?.wallNow,
+			currentRemoteOwnerTtlMs: options?.currentRemoteOwnerTtlMs,
 			requestRetryMs: options?.requestRetryMs ?? 5,
 			maxRequestRetryMs: options?.maxRequestRetryMs ?? 20,
 			requestMaxAttempts: options?.requestMaxAttempts ?? 7,
@@ -112,6 +123,21 @@ describe("receive admission replication-info V2 receiver state", () => {
 			senderTransportSession,
 			transportTimestamp,
 		});
+
+	const finalizeCurrentRemoteOwner = (
+		message:
+			| FullReplicationInfoV2Message
+			| AddedReplicationInfoV2Message
+			| StoppedReplicationInfoV2Message,
+	) => {
+		const admission = prepare(message);
+		expect(admission).to.exist;
+		expect(coordinator.beginRemoteOwnerProvenanceMutation(admission!)).to.be
+			.true;
+		expect(coordinator.commit(admission!)).to.be.true;
+		expect(coordinator.publishRemoteOwnerProvenance(admission!)).to.be.true;
+		return admission!;
+	};
 
 	beforeEach(() => {
 		closed = false;
@@ -321,6 +347,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => receiverTransportSession,
 			isClosed: () => false,
+			isOwnershipActive: () => true,
 			isPeerSessionCurrent: (hash, peerSession) =>
 				sessionByPeer.get(hash) === peerSession,
 			isReceiveEpochCurrent: (hash, receiveEpoch) =>
@@ -582,6 +609,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => localTransportSession,
 			isClosed: () => closed,
+			isOwnershipActive: () => true,
 			isPeerSessionCurrent: (_peerHash, peerSession) =>
 				peerSession === currentSession,
 			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
@@ -628,6 +656,7 @@ describe("receive admission replication-info V2 receiver state", () => {
 			getSelfKey: () => self,
 			getReceiverTransportSession: () => localTransportSession,
 			isClosed: () => closed,
+			isOwnershipActive: () => true,
 			isPeerSessionCurrent: (_peerHash, peerSession) =>
 				peerSession === currentSession,
 			isReceiveEpochCurrent: (_peerHash, receiveEpoch) =>
@@ -878,6 +907,514 @@ describe("receive admission replication-info V2 receiver state", () => {
 		expect(state.lastSequence).to.equal(5n);
 	});
 
+	it("publishes immutable Full and delta provenance without renewing the grant", () => {
+		let monotonicNow = 100;
+		coordinator = createCoordinator({
+			monotonicNow: () => monotonicNow,
+			wallNow: () => 1_000 + monotonicNow,
+			currentRemoteOwnerTtlMs: 50,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(31);
+
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+		const first = coordinator.currentRemoteOwnerProvenance(peerHash)!;
+		expect(first).to.exist;
+		expect(first.freshUntilMs).to.equal(1_150n);
+		expect(first.token.peerHash).to.equal(peerHash);
+		expect(first.token.publicKeyHex).to.equal(toHexString(sender.bytes));
+		expect(first.token.sequence).to.equal(1n);
+		expect(Object.isFrozen(first)).to.be.true;
+		expect(Object.isFrozen(first.token)).to.be.true;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(first.token)).to.be.true;
+
+		monotonicNow = 110;
+		// Neither a readiness/capability replay nor a recovery Full under this
+		// exact binding may move the deadline.
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender(2n)).to.be.true;
+		expect(
+			coordinator.currentRemoteOwnerProvenance(peerHash)?.freshUntilMs,
+		).to.equal(1_150n);
+
+		monotonicNow = 120;
+		finalizeCurrentRemoteOwner(
+			new AddedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 2n,
+				segments: [],
+			}),
+		);
+		expect(coordinator.isCurrentRemoteOwnerProvenance(first.token)).to.be.false;
+		const added = coordinator.currentRemoteOwnerProvenance(peerHash)!;
+		expect(added.token.sequence).to.equal(2n);
+		expect(added.freshUntilMs).to.equal(1_150n);
+
+		finalizeCurrentRemoteOwner(
+			new StoppedReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 3n,
+				segmentIds: [],
+			}),
+		);
+		const stopped = coordinator.currentRemoteOwnerProvenance(peerHash)!;
+		expect(stopped.token.sequence).to.equal(3n);
+		expect(stopped.freshUntilMs).to.equal(1_150n);
+
+		monotonicNow = 150;
+		expect(coordinator.currentRemoteOwnerProvenance(peerHash)).to.be.undefined;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(stopped.token)).to.be
+			.false;
+		expect(state.phase).to.equal("resync");
+		expect(state.capabilityRefreshRequired).to.be.true;
+		expect(state.remoteOwnerGrant).to.be.undefined;
+	});
+
+	it("fences publication at begin and brands empty and nonempty captures", () => {
+		let monotonicNow = 10;
+		coordinator = createCoordinator({
+			monotonicNow: () => monotonicNow,
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		const senderEpoch = bytes(32);
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+
+		const current = coordinator.currentRemoteOwnerProvenance(peerHash)!;
+		const capture = coordinator.captureCurrentRemoteOwnerProvenance([
+			peerHash,
+		])!;
+		const empty = coordinator.captureCurrentRemoteOwnerProvenance([])!;
+		expect(capture.tokens).to.deep.equal([current.token]);
+		expect(Object.isFrozen(capture)).to.be.true;
+		expect(Object.isFrozen(capture.tokens)).to.be.true;
+		expect(empty.tokens).to.deep.equal([]);
+		expect(empty.freshUntilMs).to.be.undefined;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(capture)).to.be
+			.true;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(empty)).to.be.true;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture({ ...empty })).to
+			.be.false;
+
+		const added = new AddedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 2n,
+			segments: [],
+		});
+		const admission = prepare(added)!;
+		// Decode/reservation alone does not revoke the last durable fact.
+		expect(coordinator.isCurrentRemoteOwnerProvenance(current.token)).to.be
+			.true;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(empty)).to.be.true;
+		expect(coordinator.beginRemoteOwnerProvenanceMutation(admission)).to.be
+			.true;
+		const revisionAfterBegin = coordinator.captureCurrentRemoteOwnerProvenance(
+			[],
+		)!.revision;
+		expect(coordinator.beginRemoteOwnerProvenanceMutation(admission)).to.be
+			.true;
+		expect(
+			coordinator.captureCurrentRemoteOwnerProvenance([])!.revision,
+		).to.equal(revisionAfterBegin);
+		expect(coordinator.isCurrentRemoteOwnerProvenance(current.token)).to.be
+			.false;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(capture)).to.be
+			.false;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(empty)).to.be
+			.false;
+		expect(coordinator.commit(admission)).to.be.true;
+		expect(coordinator.publishRemoteOwnerProvenance(admission)).to.be.true;
+
+		const stopped = new StoppedReplicationInfoV2Message({
+			receiverChallenge: state.receiverBinding!.slice(),
+			senderEpoch,
+			sequence: 3n,
+			segmentIds: [],
+		});
+		const bypassed = prepare(stopped)!;
+		const beforeDirectCommit = coordinator.captureCurrentRemoteOwnerProvenance(
+			[],
+		)!;
+		expect(coordinator.commit(bypassed)).to.be.true;
+		expect(
+			coordinator.isCurrentRemoteOwnerProvenanceCapture(beforeDirectCommit),
+		).to.be.false;
+		expect(coordinator.publishRemoteOwnerProvenance(bypassed)).to.be.false;
+		expect(coordinator.currentRemoteOwnerProvenance(peerHash)).to.be.undefined;
+		expect(coordinator.requireFullAfterFailure(bypassed)).to.be.true;
+		expect(state.phase).to.equal("resync");
+
+		const staleEmpty = coordinator.captureCurrentRemoteOwnerProvenance([])!;
+		coordinator.clearForClose();
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(staleEmpty)).to.be
+			.false;
+		coordinator.resetForOpen();
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(staleEmpty)).to.be
+			.false;
+		monotonicNow++;
+	});
+
+	it("fails owner tokens closed across state, transport and host lifecycle resets", () => {
+		let ownershipActive = true;
+		const mint = () => {
+			coordinator.clearForClose();
+			closed = false;
+			currentSession = {};
+			currentReceiveEpoch = {};
+			currentSenderTransportSession = senderTransportSession;
+			coordinator = createCoordinator({
+				monotonicNow: () => 10,
+				wallNow: () => 1_000,
+				currentRemoteOwnerTtlMs: 100,
+				isOwnershipActive: () => ownershipActive,
+			});
+			expect(markLocalReady()).to.be.true;
+			expect(observeSender()).to.be.true;
+			const state = coordinator._receiveStates.get(peerHash)!;
+			finalizeCurrentRemoteOwner(
+				new FullReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch: bytes(33),
+					sequence: 1n,
+					segments: [],
+				}),
+			);
+			return coordinator.currentRemoteOwnerProvenance(peerHash)!.token;
+		};
+
+		let token = mint();
+		coordinator.clearPeer(peerHash, currentSession);
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+
+		token = mint();
+		coordinator.revokePeerCapability(peerHash);
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+
+		token = mint();
+		currentReceiveEpoch = {};
+		expect(
+			coordinator.advanceRecovery({
+				peerHash,
+				peerSession: currentSession,
+				receiveEpoch: currentReceiveEpoch,
+			}),
+		).to.be.true;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+
+		token = mint();
+		currentSession = {};
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+
+		token = mint();
+		currentSenderTransportSession++;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+
+		token = mint();
+		const lifecycleCapture = coordinator.captureCurrentRemoteOwnerProvenance(
+			[],
+		)!;
+		coordinator.invalidateCurrentRemoteOwnerProvenance();
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(lifecycleCapture))
+			.to.be.false;
+
+		token = mint();
+		const capture = coordinator.captureCurrentRemoteOwnerProvenance([
+			peerHash,
+		])!;
+		const lifecycleState = coordinator._receiveStates.get(peerHash)!;
+		ownershipActive = false;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(capture)).to.be
+			.false;
+		ownershipActive = true;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+		expect(coordinator.isCurrentRemoteOwnerProvenanceCapture(capture)).to.be
+			.false;
+		expect(
+			prepare(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: lifecycleState.receiverBinding!.slice(),
+					senderEpoch: bytes(33),
+					sequence: 2n,
+					segments: [],
+				}),
+			),
+		).to.be.undefined;
+		expect(lifecycleState.capabilityRefreshRequired).to.be.true;
+
+		token = mint();
+		closed = true;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+	});
+
+	it("bounds batch inputs before lookup and returns no partial capture", () => {
+		coordinator = createCoordinator({
+			monotonicNow: () => 10,
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		const state = coordinator._receiveStates.get(peerHash)!;
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch: bytes(34),
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+
+		expect(
+			coordinator.captureCurrentRemoteOwnerProvenance([peerHash, "missing"]),
+		).to.be.undefined;
+		expect(() =>
+			coordinator.captureCurrentRemoteOwnerProvenance([peerHash, peerHash]),
+		).to.throw("Invalid replication-info V2 current-owner batch");
+		const sparse = new Array<string>(1);
+		expect(() =>
+			coordinator.captureCurrentRemoteOwnerProvenance(sparse),
+		).to.throw("Invalid replication-info V2 current-owner batch");
+		expect(() =>
+			coordinator.captureCurrentRemoteOwnerProvenance(
+				new Array(MAX_REPLICATION_INFO_V2_CURRENT_OWNER_BATCH + 1).fill(
+					peerHash,
+				),
+			),
+		).to.throw("Invalid replication-info V2 current-owner batch");
+		expect(() =>
+			coordinator.captureCurrentRemoteOwnerProvenance(["x".repeat(513)]),
+		).to.throw("Invalid replication-info V2 current-owner batch");
+
+		let lengthReads = 0;
+		let indexReads = 0;
+		const proxied = new Proxy([peerHash], {
+			get(target, property, receiver) {
+				if (property === "length") {
+					lengthReads++;
+					return lengthReads === 1 ? 1 : 100_000;
+				}
+				if (property === "0") {
+					indexReads++;
+				}
+				return Reflect.get(target, property, receiver);
+			},
+		});
+		const capture = coordinator.captureCurrentRemoteOwnerProvenance(proxied)!;
+		expect(capture.tokens).to.have.length(1);
+		expect(lengthReads).to.equal(1);
+		expect(indexReads).to.equal(1);
+	});
+
+	it("fails closed on invalid clocks, deadline overflow and TTL overrides", () => {
+		expect(() =>
+			createCoordinator({
+				currentRemoteOwnerTtlMs:
+					MAX_REPLICATION_INFO_V2_CURRENT_OWNER_TTL_MS + 1,
+			}),
+		).to.throw("Invalid replication-info V2 current-owner TTL");
+
+		let monotonicNow = 10;
+		coordinator = createCoordinator({
+			monotonicNow: () => monotonicNow,
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		let state = coordinator._receiveStates.get(peerHash)!;
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch: bytes(35),
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+		const token = coordinator.currentRemoteOwnerProvenance(peerHash)!.token;
+		monotonicNow = Number.NaN;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+		monotonicNow = 11;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(token)).to.be.false;
+		expect(
+			prepare(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch: bytes(35),
+					sequence: 2n,
+					segments: [],
+				}),
+			),
+		).to.be.undefined;
+		expect(state.capabilityRefreshRequired).to.be.true;
+		coordinator.clearForClose();
+
+		monotonicNow = 30;
+		coordinator = createCoordinator({
+			monotonicNow: () => monotonicNow,
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		state = coordinator._receiveStates.get(peerHash)!;
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch: bytes(37),
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+		const regressingClockToken =
+			coordinator.currentRemoteOwnerProvenance(peerHash)!.token;
+		monotonicNow = 29;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(regressingClockToken)).to
+			.be.false;
+		monotonicNow = 30;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(regressingClockToken)).to
+			.be.false;
+		expect(
+			prepare(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch: bytes(37),
+					sequence: 2n,
+					segments: [],
+				}),
+			),
+		).to.be.undefined;
+		expect(state.capabilityRefreshRequired).to.be.true;
+		coordinator.clearForClose();
+
+		let clockThrows = false;
+		coordinator = createCoordinator({
+			monotonicNow: () => {
+				if (clockThrows) {
+					throw new Error("clock unavailable");
+				}
+				return 20;
+			},
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		state = coordinator._receiveStates.get(peerHash)!;
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch: bytes(36),
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+		const throwingClockToken =
+			coordinator.currentRemoteOwnerProvenance(peerHash)!.token;
+		clockThrows = true;
+		expect(() =>
+			coordinator.isCurrentRemoteOwnerProvenance(throwingClockToken),
+		).not.to.throw();
+		clockThrows = false;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(throwingClockToken)).to.be
+			.false;
+		expect(
+			prepare(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch: bytes(36),
+					sequence: 2n,
+					segments: [],
+				}),
+			),
+		).to.be.undefined;
+		coordinator.clearForClose();
+
+		let wallClockThrows = false;
+		coordinator = createCoordinator({
+			monotonicNow: () => 40,
+			wallNow: () => {
+				if (wallClockThrows) {
+					throw new Error("wall clock unavailable");
+				}
+				return 1_000;
+			},
+			currentRemoteOwnerTtlMs: 100,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		state = coordinator._receiveStates.get(peerHash)!;
+		finalizeCurrentRemoteOwner(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch: bytes(38),
+				sequence: 1n,
+				segments: [],
+			}),
+		);
+		const wallClockToken =
+			coordinator.currentRemoteOwnerProvenance(peerHash)!.token;
+		wallClockThrows = true;
+		expect(() =>
+			coordinator.currentRemoteOwnerProvenance(peerHash),
+		).not.to.throw();
+		expect(coordinator.currentRemoteOwnerProvenance(peerHash)).to.be.undefined;
+		expect(coordinator.captureCurrentRemoteOwnerProvenance([peerHash])).to.be
+			.undefined;
+		expect(coordinator.isCurrentRemoteOwnerProvenance(wallClockToken)).to.be
+			.true;
+		wallClockThrows = false;
+		expect(coordinator.currentRemoteOwnerProvenance(peerHash)?.token).to.equal(
+			wallClockToken,
+		);
+		coordinator.clearForClose();
+
+		coordinator = createCoordinator({
+			monotonicNow: () => Number.MAX_VALUE,
+			wallNow: () => 1_000,
+			currentRemoteOwnerTtlMs: 10,
+		});
+		expect(markLocalReady()).to.be.true;
+		expect(observeSender()).to.be.true;
+		state = coordinator._receiveStates.get(peerHash)!;
+		expect(state.remoteOwnerGrant).to.be.undefined;
+		expect(
+			prepare(
+				new FullReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch: bytes(35),
+					sequence: 1n,
+					segments: [],
+				}),
+			),
+		).to.be.undefined;
+		expect(state.phase).to.equal("resync");
+		expect(state.capabilityRefreshRequired).to.be.true;
+	});
+
 	it("fences a parked delta across same-session recovery", () => {
 		expect(markLocalReady()).to.be.true;
 		expect(observeSender()).to.be.true;
@@ -938,8 +1475,11 @@ describe("receive admission replication-info V2 receiver state", () => {
 			senderTransportSession,
 			transportTimestamp: 1n,
 		});
-		expect(admission).to.exist;
-		expect(coordinator.commit(admission!)).to.be.true;
+		// Recovery cleared the old provenance grant. Even a Full using the old
+		// binding must wait for the capability worker to rotate the challenge.
+		expect(admission).to.be.undefined;
+		expect(state.phase).to.equal("resync");
+		expect(state.remoteOwnerGrant).to.be.undefined;
 	});
 
 	it("makes exact capability replays side-effect free", async () => {
@@ -2130,6 +2670,8 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		).to.equal(1);
 		expect(state.lastSequence).to.equal(1n);
 		expect(state.phase).to.equal("resync");
+		expect(log._v2Receive.currentRemoteOwnerProvenance(remoteHash)).to.be
+			.undefined;
 		expect(log._v2Receive._cutoverPeerSessions.has(peerSession)).to.be.true;
 		await waitForResolved(() => expect(send.called).to.be.true);
 
@@ -2144,6 +2686,58 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		);
 		expect(state.lastSequence).to.equal(2n);
 		expect(state.phase).to.equal("active");
+		const recovered = log._v2Receive.currentRemoteOwnerProvenance(remoteHash);
+		expect(recovered?.token.sequence).to.equal(2n);
+		const recoveredCapture = log._v2Receive.captureCurrentRemoteOwnerProvenance(
+			[remoteHash],
+		);
+		expect(
+			log._v2Receive.isCurrentRemoteOwnerProvenanceCapture(recoveredCapture),
+		).to.be.true;
+
+		const originalTrust = log._isTrustedReplicator;
+		log._isTrustedReplicator = async () => false;
+		try {
+			await log.onMessage(
+				new AddedReplicationInfoV2Message({
+					receiverChallenge: state.receiverBinding!.slice(),
+					senderEpoch,
+					sequence: 3n,
+					segments: [range],
+				}),
+				context,
+			);
+		} finally {
+			log._isTrustedReplicator = originalTrust;
+		}
+		expect(state.lastSequence).to.equal(2n);
+		expect(state.phase).to.equal("resync");
+		expect(log._v2Receive.isCurrentRemoteOwnerProvenance(recovered!.token)).to
+			.be.false;
+		expect(
+			log._v2Receive.isCurrentRemoteOwnerProvenanceCapture(recoveredCapture),
+		).to.be.false;
+
+		await log.onMessage(
+			new FullReplicationInfoV2Message({
+				receiverChallenge: state.receiverBinding!.slice(),
+				senderEpoch,
+				sequence: 4n,
+				segments: [range],
+			}),
+			context,
+		);
+		const lifecycleToken =
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)!.token;
+		const lifecycleCapture = log._v2Receive.captureCurrentRemoteOwnerProvenance(
+			[remoteHash],
+		);
+		log.startRepairLifecycle();
+		expect(log._v2Receive.isCurrentRemoteOwnerProvenance(lifecycleToken)).to.be
+			.false;
+		expect(
+			log._v2Receive.isCurrentRemoteOwnerProvenanceCapture(lifecycleCapture),
+		).to.be.false;
 	});
 
 	it("rolls back stale Full and Stopped deletions after transport revocation", async () => {
@@ -2367,6 +2961,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		expect(state.phase).to.equal("active");
 		expect(state.lastSequence).to.equal(1n);
 		expect(
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)?.token.sequence,
+		).to.equal(1n);
+		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(1);
 		expect(activity.calledOnceWith(remoteHash)).to.be.true;
@@ -2384,6 +2981,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(2);
+		expect(
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)?.token.sequence,
+		).to.equal(2n);
 		expect(activity.calledOnceWith(remoteHash)).to.be.true;
 
 		activity.resetHistory();
@@ -2398,6 +2998,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		);
 		expect(state.phase).to.equal("active");
 		expect(state.lastSequence).to.equal(3n);
+		expect(
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)?.token.sequence,
+		).to.equal(3n);
 		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(2);
@@ -2414,6 +3017,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		expect(state.phase).to.equal("active");
 		expect(state.lastSequence).to.equal(4n);
 		expect(
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)?.token.sequence,
+		).to.equal(4n);
+		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(3);
 
@@ -2428,6 +3034,8 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			context(0n),
 		);
 		expect(state.phase).to.equal("resync");
+		expect(log._v2Receive.currentRemoteOwnerProvenance(remoteHash)).to.be
+			.undefined;
 		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(3);
@@ -2449,6 +3057,9 @@ describe("receive admission replication-info V2 receiver integration", () => {
 		);
 		expect(state.phase).to.equal("active");
 		expect(state.lastSequence).to.equal(7n);
+		expect(
+			log._v2Receive.currentRemoteOwnerProvenance(remoteHash)?.token.sequence,
+		).to.equal(7n);
 		expect(
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(1);
@@ -2501,6 +3112,12 @@ describe("receive admission replication-info V2 receiver integration", () => {
 			await log.replicationIndex.count({ query: { hash: remoteHash } }),
 		).to.equal(1);
 		expect(activity.notCalled).to.be.true;
+		await waitForResolved(() => {
+			expect(state.remoteOwnerGrant).to.exist;
+			expect([...state.receiverRequestChallenge]).to.not.deep.equal([
+				...challengeBeforeRecovery,
+			]);
+		});
 
 		await log.onMessage(
 			new FullReplicationInfoV2Message({


### PR DESCRIPTION
## Stack

Stacked on #1301. Review the top commit f3cc58741 for this slice.

## Summary

- track one bounded volatile current-owner token per authenticated replication-info V2 peer, bound to the exact open generation, peer/receive sessions, transport sessions, challenge/binding, sender epoch, sequence, and receiver-local monotonic grant
- publish provenance only after Full, Added, or Stopped ownership work durably commits and all fallible bookkeeping finishes inside the global ownership mutation lane
- invalidate tokens and branded all-or-nothing captures across mutation start, failure, expiry, clock regression, lifecycle rotation, session/transport change, recovery, close, and reopen
- move unknown and refreshed-empty Stopped completion into the same ownership lane, and fail closed when current authorization rejects or publication cannot complete

## Safety boundary

This slice has no placement snapshot consumer, executor wiring, transfer handler, custody receipt, or prune path. The token is volatile current-session evidence only; it is explicitly not consensus, custody, transfer, or prune authority, and future capture must re-evaluate custom replicator authorization.

## Verification

- complete shared-log Node suite: 2,604 passing, 10 pending
- final focused receiver state and integration suite: 45 passing
- shared-log TypeScript build and no-emit typecheck
- targeted ESLint and Prettier
- shard coverage guard
- changeset guard tests: 52 passing
- git diff check
- three independent read-only safety reviews: no blockers